### PR TITLE
fix(wework): restore archived conversations from sidebar

### DIFF
--- a/executor/src/runtime_work/handler/helpers/transcript.rs
+++ b/executor/src/runtime_work/handler/helpers/transcript.rs
@@ -534,6 +534,7 @@ fn attach_user_message_presentations(
         messages,
         presentations,
         &page_messages,
+        &[],
         false,
         false,
     );
@@ -543,6 +544,7 @@ fn attach_user_message_presentations_for_page(
     messages: &mut Vec<Value>,
     presentations: Vec<Value>,
     page_messages: &[Value],
+    page_turn_ids: &[String],
     has_more_before: bool,
     has_more_after: bool,
 ) {
@@ -565,6 +567,7 @@ fn attach_user_message_presentations_for_page(
                     && presentation_belongs_to_transcript_page(
                         &presentation,
                         page_messages,
+                        page_turn_ids,
                         has_more_before,
                         has_more_after,
                     ) =>
@@ -663,6 +666,7 @@ fn attach_user_message_presentations_for_page(
 fn presentation_belongs_to_transcript_page(
     presentation: &Value,
     page_messages: &[Value],
+    page_turn_ids: &[String],
     has_more_before: bool,
     has_more_after: bool,
 ) -> bool {
@@ -673,14 +677,15 @@ fn presentation_belongs_to_transcript_page(
     let presentation_turn_id = string_field(presentation, "turnId")
         .or_else(|| string_field(presentation, "turn_id"));
     if let Some(presentation_turn_id) = presentation_turn_id {
-        return page_messages.iter().any(|message| {
-            string_field(message, "turnId")
-                .or_else(|| string_field(message, "turn_id"))
-                .or_else(|| string_field(message, "subtaskId"))
-                .or_else(|| string_field(message, "subtask_id"))
-                .as_deref()
-                == Some(presentation_turn_id.as_str())
-        });
+        return page_turn_ids.contains(&presentation_turn_id)
+            || page_messages.iter().any(|message| {
+                string_field(message, "turnId")
+                    .or_else(|| string_field(message, "turn_id"))
+                    .or_else(|| string_field(message, "subtaskId"))
+                    .or_else(|| string_field(message, "subtask_id"))
+                    .as_deref()
+                    == Some(presentation_turn_id.as_str())
+            });
     }
 
     let Some(created_at) = timestamp_ms_field(presentation, "createdAt") else {

--- a/executor/src/runtime_work/handler/queries.rs
+++ b/executor/src/runtime_work/handler/queries.rs
@@ -253,6 +253,7 @@ impl RuntimeWorkRpcHandler {
                         &mut messages,
                         user_message_presentations(link),
                         &presentation_page_messages,
+                        &[],
                         false,
                         false,
                     );
@@ -380,6 +381,13 @@ impl RuntimeWorkRpcHandler {
         )
         .await
         .map_err(|error| AppIpcError::new("codex_error", error))?;
+        let presentation_page_turn_ids = thread
+            .get("turns")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|turn| string_field(turn, "id"))
+            .collect::<Vec<_>>();
         let presentation_page_messages = local_link.as_ref().map(|_| {
             if include_full_content {
                 full_transcript_messages(&thread, &self.device_id)
@@ -410,6 +418,7 @@ impl RuntimeWorkRpcHandler {
                 &mut messages,
                 user_message_presentations(link),
                 presentation_page_messages.as_deref().unwrap_or_default(),
+                &presentation_page_turn_ids,
                 page_before_cursor.is_some(),
                 page_after_cursor.is_some(),
             );

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -3314,6 +3314,7 @@ fn paginated_transcript_does_not_restore_a_presentation_from_a_newer_page() {
         &mut provider_messages,
         presentations,
         &page_messages,
+        &[],
         false,
         true,
     );
@@ -3352,6 +3353,7 @@ fn paginated_transcript_restores_a_missing_presentation_inside_the_current_page(
         &mut provider_messages,
         presentations,
         &page_messages,
+        &[],
         true,
         true,
     );
@@ -3359,6 +3361,36 @@ fn paginated_transcript_restores_a_missing_presentation_inside_the_current_page(
     assert_eq!(provider_messages.len(), 3);
     assert_eq!(provider_messages[1]["content"], "Middle instruction");
     assert_eq!(provider_messages[1]["turnId"], "turn-last");
+}
+
+#[test]
+fn paginated_transcript_restores_a_presentation_for_an_empty_turn_on_the_current_page() {
+    let mut provider_messages = Vec::new();
+    let presentations = vec![json!({
+        "clientUserMessageId": "client-user-interrupted",
+        "content": "Instruction archived before the provider stored its user item",
+        "createdAt": 200,
+        "ensureVisible": true,
+        "references": [],
+        "turnId": "turn-interrupted"
+    })];
+
+    attach_user_message_presentations_for_page(
+        &mut provider_messages,
+        presentations,
+        &[],
+        &["turn-interrupted".to_owned()],
+        false,
+        true,
+    );
+
+    assert_eq!(provider_messages.len(), 1);
+    assert_eq!(provider_messages[0]["role"], "user");
+    assert_eq!(provider_messages[0]["turnId"], "turn-interrupted");
+    assert_eq!(
+        provider_messages[0]["content"],
+        "Instruction archived before the provider stored its user item"
+    );
 }
 
 #[test]

--- a/wework/e2e/desktop/modules/cloud-worktree-flows.mjs
+++ b/wework/e2e/desktop/modules/cloud-worktree-flows.mjs
@@ -39,6 +39,7 @@ const WORKTREE_QUEUE_SCENARIO = 'worktree_queue_hold'
 const WORKTREE_RESTART_SCENARIO = 'worktree_restart_hold'
 const WORKTREE_QUEUE_PROMPT = 'WEWORK_DESKTOP_E2E_WORKTREE_QUEUE_HOLD'
 const WORKTREE_RESTART_PROMPT = 'WEWORK_DESKTOP_E2E_WORKTREE_RESTART_HOLD'
+const WORKTREE_ARCHIVE_RESTORE_PROMPT = 'WEWORK_DESKTOP_E2E_WORKTREE_ARCHIVE_RESTORE_HOLD'
 
 function scenarioRequestCount(control, scenario) {
   return control.scenarioRequests.get(scenario)?.length ?? 0
@@ -689,14 +690,58 @@ async function verifyTools(context) {
 }
 
 async function verifyArchiveRestore(context) {
-  const task = await launchTask(context, {
-    prompt: `${CHECKPOINT_TASK_PROMPT} archive-restore`,
-  })
-  await assertWorktreeCreated(task, context.workspacePath)
+  context.control.holdScenarioResponse(WORKTREE_RESTART_SCENARIO)
+  let task
   const markerName = 'worktree-archive-marker.txt'
-  const markerText = `restore ${task.taskId}\n`
-  await writeFile(join(task.workspacePath, markerName), markerText)
-  await archiveTask(context.control, task)
+  let markerText
+  let rowSelector
+  try {
+    task = await launchTask(context, {
+      prompt: WORKTREE_ARCHIVE_RESTORE_PROMPT,
+      scenario: WORKTREE_RESTART_SCENARIO,
+      waitForCompletion: false,
+    })
+    await assertWorktreeCreated(task, context.workspacePath)
+    await context.control.command(
+      'waitFor',
+      `[data-testid="runtime-local-task-running-${task.taskId}"]`,
+      { timeoutMs: DEFAULT_STEP_TIMEOUT_MS }
+    )
+    markerText = `restore ${task.taskId}\n`
+    await writeFile(join(task.workspacePath, markerName), markerText)
+
+    rowSelector = `[data-testid="${task.rowTestId}"]`
+    await context.control.command('hover', rowSelector)
+    await context.control.command(
+      'click',
+      `[data-testid="runtime-local-task-archive-${task.taskId}"]`
+    )
+    const archiveToastSelector = `[data-testid="runtime-local-task-archive-toast-${task.taskId}"]`
+    await context.control.command('waitFor', archiveToastSelector, {
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    assert.match(
+      await context.control.command('getAttribute', archiveToastSelector, { value: 'class' }),
+      /electron-titlebar-interactive-region/,
+      'The archive undo notice remained inside the native titlebar drag region'
+    )
+    await context.control.command(
+      'clickWhenEnabled',
+      `[data-testid="runtime-local-task-archive-undo-${task.taskId}"]`
+    )
+    await context.control.command('waitFor', rowSelector, {
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    assert.equal(
+      await pathExists(task.workspacePath),
+      true,
+      'Undoing the pending archive still removed the managed Worktree'
+    )
+
+    await archiveTask(context.control, task)
+  } finally {
+    context.control.releaseScenarioResponse(WORKTREE_RESTART_SCENARIO)
+  }
 
   const archivedRecord = await waitForCondition(
     async () => {
@@ -749,6 +794,15 @@ async function verifyArchiveRestore(context) {
     'active',
     'Restoring did not return the Worktree record to active state'
   )
+  await context.control.command('click', '[data-testid="settings-back-button"]')
+  await context.control.command('waitFor', rowSelector, {
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await context.control.command('click', rowSelector)
+  await context.control.command('waitFor', '[data-testid="user-message-content"]', {
+    text: WORKTREE_ARCHIVE_RESTORE_PROMPT,
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
   await deleteWorktreeFromSettings(context.control, task)
 }
 

--- a/wework/electron/src/host/electron-capabilities.test.ts
+++ b/wework/electron/src/host/electron-capabilities.test.ts
@@ -129,13 +129,13 @@ describe('captureWebContentsDataUrl', () => {
     expect(debuggerSession.sendCommand).not.toHaveBeenCalled()
   })
 
-  test('can use debugger-only view capture without blocking on Electron capturePage', async () => {
+  test('can prefer debugger view capture without blocking on Electron capturePage', async () => {
     const { capturePage, contents, debuggerSession } = createWebContents({
       captureDataUrl: 'data:image/png;base64,native-capture',
       debuggerData: 'debugger-capture',
     })
 
-    await expect(captureWebContentsDataUrl(contents, { debuggerOnly: true })).resolves.toBe(
+    await expect(captureWebContentsDataUrl(contents, { preferDebugger: true })).resolves.toBe(
       'data:image/png;base64,debugger-capture'
     )
     expect(debuggerSession.attach).toHaveBeenCalledOnce()
@@ -148,21 +148,20 @@ describe('captureWebContentsDataUrl', () => {
     expect(capturePage).not.toHaveBeenCalled()
   })
 
-  test('times out debugger-only capture and detaches the session', async () => {
+  test('falls back to native capture when preferred debugger capture times out', async () => {
     vi.useFakeTimers()
     try {
-      const { contents, debuggerSession } = createWebContents({
+      const { capturePage, contents, debuggerSession } = createWebContents({
+        captureDataUrl: 'data:image/png;base64,native-after-debugger-timeout',
         debuggerPending: true,
       })
 
-      const capture = expect(
-        captureWebContentsDataUrl(contents, { debuggerOnly: true })
-      ).rejects.toThrow(
-        'CDP Page.captureScreenshot failed: CDP Page.captureScreenshot timed out after 10000ms'
-      )
+      const capture = captureWebContentsDataUrl(contents, { preferDebugger: true })
       await vi.advanceTimersByTimeAsync(10_000)
-      await capture
+
+      await expect(capture).resolves.toBe('data:image/png;base64,native-after-debugger-timeout')
       expect(debuggerSession.detach).toHaveBeenCalledOnce()
+      expect(capturePage).toHaveBeenCalledOnce()
     } finally {
       vi.useRealTimers()
     }

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -376,7 +376,7 @@ export function createElectronCapabilityRouter(
     if (!contents || contents.isDestroyed()) {
       throw new HostCapabilityError('e2e_view_unavailable', 'Primary DSH view is unavailable')
     }
-    return captureWebContentsDataUrl(contents, { debuggerOnly: true })
+    return captureWebContentsDataUrl(contents, { preferDebugger: true })
   })
   router.register('e2e.captureWorkspaceWindow', async params => {
     const requestedLabel = optionalStringParam(params, 'windowLabel')
@@ -394,7 +394,7 @@ export function createElectronCapabilityRouter(
         `Workspace DSH view is unavailable: ${label}`
       )
     }
-    return captureWebContentsDataUrl(contents, { debuggerOnly: true })
+    return captureWebContentsDataUrl(contents, { preferDebugger: true })
   })
   router.register('e2e.closeMainWindow', () => requiredWindow(window).close())
   router.register('e2e.activateRuntimeTaskNotification', params => {

--- a/wework/electron/src/host/web-contents-capture.ts
+++ b/wework/electron/src/host/web-contents-capture.ts
@@ -4,19 +4,20 @@ import { HostCapabilityError } from './capability-router.js'
 const CAPTURE_ATTEMPT_TIMEOUT_MS = 10_000
 
 export interface WebContentsCaptureOptions {
-  debuggerOnly?: boolean
+  preferDebugger?: boolean
 }
 
 export async function captureWebContentsDataUrl(
   contents: WebContents,
   options: WebContentsCaptureOptions = {}
 ): Promise<string> {
-  const attempts = options.debuggerOnly
+  const attempts = options.preferDebugger
     ? [
         {
           label: 'CDP Page.captureScreenshot',
           capture: () => captureDebugger(contents, false),
         },
+        { label: 'Electron capturePage', capture: () => captureNative(contents) },
       ]
     : [
         { label: 'Electron capturePage', capture: () => captureNative(contents) },

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -107,6 +107,19 @@ const mocks = vi.hoisted(() => {
     recoverRuntimeConnections: localRecoverRuntimeConnections,
   }
 
+  const cloudDeviceApi = {
+    listDevices: cloudListDevices,
+    getHomeDirectory: vi.fn(),
+    getProjectWorkspaceRoot: vi.fn(),
+    listDirectories: vi.fn(),
+    createDirectory: vi.fn(),
+    executeCommand: vi.fn(),
+    upgradeDevice: vi.fn(),
+    listSkills: vi.fn(),
+    listWorkspaceEntries: vi.fn(),
+    readWorkspaceTextFile: vi.fn(),
+    createDockerRemoteDeviceCommand: cloudCreateDockerRemoteDeviceCommand,
+  }
   const cloudServices = {
     teamApi: {
       listTeams: cloudListTeams,
@@ -115,19 +128,7 @@ const mocks = vi.hoisted(() => {
     skillApi: {},
     projectApi: { listProjects: vi.fn() },
     taskApi: { getTurnFileChangesDiff: vi.fn() },
-    deviceApi: {
-      listDevices: cloudListDevices,
-      getHomeDirectory: vi.fn(),
-      getProjectWorkspaceRoot: vi.fn(),
-      listDirectories: vi.fn(),
-      createDirectory: vi.fn(),
-      executeCommand: vi.fn(),
-      upgradeDevice: vi.fn(),
-      listSkills: vi.fn(),
-      listWorkspaceEntries: vi.fn(),
-      readWorkspaceTextFile: vi.fn(),
-      createDockerRemoteDeviceCommand: cloudCreateDockerRemoteDeviceCommand,
-    },
+    deviceApi: cloudDeviceApi,
     runtimeWorkApi: {
       prepareRuntimeModel: vi.fn().mockResolvedValue(true),
       listRuntimeWork: cloudListRuntimeWork,
@@ -145,6 +146,14 @@ const mocks = vi.hoisted(() => {
       deleteAttachment: vi.fn(),
     },
     userApi: { updateCurrentUser: cloudUpdateCurrentUser },
+    projectSpaceDetailServices: {
+      cloud: {
+        deliveryApi: {},
+        deviceApi: cloudDeviceApi,
+        modelApi: { listModels: cloudListModels },
+        teamApi: { listTeams: cloudListTeams },
+      },
+    },
     chatStream: { subscribe: vi.fn(() => vi.fn()) },
     socketClient: { ensureConnected: vi.fn(), dispose: vi.fn() },
     recoverRuntimeConnections: cloudRecoverRuntimeConnections,
@@ -777,6 +786,15 @@ describe('createHybridWorkbenchServices', () => {
     const devices = await services.deviceApi.listDevices()
 
     expect(devices.map(device => device.device_id)).toEqual(['local-device', 'cloud-device'])
+  })
+
+  it('loads current cloud devices for cloud project execution configuration', async () => {
+    const services = createServices()
+
+    const devices = await services.projectSpaceDetailServices?.cloud?.deviceApi.listDevices()
+
+    expect(devices?.map(device => device.device_id)).toEqual(['local-device', 'cloud-device'])
+    expect(mocks.cloudListDevices).toHaveBeenCalledTimes(1)
   })
 
   it('keeps remote Docker devices in the workbench device list after background sync', async () => {

--- a/wework/src/api/hybrid/hybridServices.test.ts
+++ b/wework/src/api/hybrid/hybridServices.test.ts
@@ -797,6 +797,20 @@ describe('createHybridWorkbenchServices', () => {
     expect(mocks.cloudListDevices).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps local project execution available when cloud device discovery fails', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    mocks.cloudListDevices.mockRejectedValue(new Error('cloud devices unavailable'))
+    const services = createServices()
+
+    const devices = await services.projectSpaceDetailServices?.cloud?.deviceApi.listDevices()
+
+    expect(devices?.map(device => device.device_id)).toEqual(['local-device'])
+    expect(warning).toHaveBeenCalledWith(
+      '[Wework] Failed to load cloud devices for project execution configuration',
+      expect.objectContaining({ message: 'cloud devices unavailable' })
+    )
+  })
+
   it('keeps remote Docker devices in the workbench device list after background sync', async () => {
     mocks.cloudListDevices.mockResolvedValue([
       {

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -775,6 +775,18 @@ export function createHybridWorkbenchServices(
       return cloudServices.deviceApi.createDockerRemoteDeviceCommand(data)
     },
   }
+  const projectSpaceDeviceApi: WorkbenchServices['deviceApi'] = {
+    ...hybridDeviceApi,
+    async listDevices(requestOptions) {
+      const [localDevices, cloudDevices] = await Promise.all([
+        listLocalDevices(requestOptions?.signal),
+        listCloudDevices(requestOptions?.signal),
+      ])
+      return mergeDeviceLists(localDevices, cloudDevices) as Awaited<
+        ReturnType<WorkbenchServices['deviceApi']['listDevices']>
+      >
+    },
+  }
 
   const hybridRuntimeWorkApi: NonNullable<WorkbenchServices['runtimeWorkApi']> = {
     prepareRuntimeModel(data) {
@@ -1307,6 +1319,7 @@ export function createHybridWorkbenchServices(
       cloud: cloudServices.projectSpaceDetailServices?.cloud
         ? {
             ...cloudServices.projectSpaceDetailServices.cloud,
+            deviceApi: projectSpaceDeviceApi,
             pluginApi: projectPluginApi,
           }
         : undefined,

--- a/wework/src/api/hybrid/hybridServices.ts
+++ b/wework/src/api/hybrid/hybridServices.ts
@@ -778,10 +778,16 @@ export function createHybridWorkbenchServices(
   const projectSpaceDeviceApi: WorkbenchServices['deviceApi'] = {
     ...hybridDeviceApi,
     async listDevices(requestOptions) {
-      const [localDevices, cloudDevices] = await Promise.all([
-        listLocalDevices(requestOptions?.signal),
-        listCloudDevices(requestOptions?.signal),
-      ])
+      const localDevices = await listLocalDevices(requestOptions?.signal)
+      let cloudDevices: DeviceInfo[] = []
+      try {
+        cloudDevices = await listCloudDevices(requestOptions?.signal)
+      } catch (error) {
+        console.warn(
+          '[Wework] Failed to load cloud devices for project execution configuration',
+          error
+        )
+      }
       return mergeDeviceLists(localDevices, cloudDevices) as Awaited<
         ReturnType<WorkbenchServices['deviceApi']['listDevices']>
       >

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -3796,6 +3796,10 @@ describe('DesktopSidebar', () => {
       expect(screen.getByTestId('runtime-local-task-archive-toast-codex-1')).toHaveTextContent(
         '撤销'
       )
+      expect(screen.getByTestId('runtime-local-task-archive-toast-codex-1')).toHaveClass(
+        'electron-titlebar-interactive-region',
+        'pointer-events-auto'
+      )
 
       await user.click(screen.getByTestId('runtime-local-task-archive-undo-codex-1'))
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -2170,7 +2170,7 @@ function RuntimeTaskRow({
             data-testid={`runtime-local-task-archive-toast-${task.taskId}`}
             role="status"
             aria-live="polite"
-            className="fixed left-1/2 top-5 z-[200] flex max-w-[calc(100vw-32px)] -translate-x-1/2 items-center gap-1 rounded-2xl border border-border bg-surface px-4 py-2 text-sm text-text-primary shadow-lg"
+            className="electron-titlebar-interactive-region pointer-events-auto fixed left-1/2 top-5 z-[200] flex max-w-[calc(100vw-32px)] -translate-x-1/2 items-center gap-1 rounded-2xl border border-border bg-surface px-4 py-2 text-sm text-text-primary shadow-lg"
           >
             <button
               type="button"

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -42,6 +42,7 @@ import type {
   RuntimeWorkListResponse,
   User,
 } from '@/types/api'
+import type { RefreshWorkLists } from '@/features/workbench/workbenchContextTypes'
 import {
   getRuntimeChatSidebarTaskItems,
   getNextRuntimeSidebarTaskVisibleLimit,
@@ -94,7 +95,7 @@ interface MobileDrawerProps {
   onRemoveProject?: (projectId: number) => Promise<void>
   onSelectProject: (projectId: number) => void
   onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void> | void
-  onRefreshWorkLists?: () => Promise<void>
+  onRefreshWorkLists?: RefreshWorkLists
 }
 
 export function MobileDrawer({

--- a/wework/src/components/settings/ArchivedConversationsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ArchivedConversationsSettingsPage.test.tsx
@@ -245,7 +245,15 @@ describe('ArchivedConversationsSettingsPage', () => {
 
     await userEvent.click(screen.getByTestId('archived-view-now-button'))
     await waitFor(() => expect(onOpenRuntimeTask).toHaveBeenCalled())
-    expect(onRefreshWorkLists).toHaveBeenCalled()
+    expect(onRefreshWorkLists).toHaveBeenCalledWith({
+      unarchivedTasks: [
+        {
+          deviceId: 'device-1',
+          workspacePath: '/Users/crystal/dev/git/weekly-report',
+          taskId: 'codex-1',
+        },
+      ],
+    })
     expect(onLeaveSettings).toHaveBeenCalled()
   })
 

--- a/wework/src/components/settings/ArchivedConversationsSettingsPage.tsx
+++ b/wework/src/components/settings/ArchivedConversationsSettingsPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { createLocalAppServices } from '@/api/local/localServices'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
+import type { RefreshWorkLists } from '@/features/workbench/workbenchContextTypes'
 import { WORKBENCH_CLOUD_ARCHIVES_CHANGED_EVENT } from '@/features/workbench/workbenchCloudDataEvents'
 import { useTranslation } from '@/hooks/useTranslation'
 import {
@@ -42,7 +43,7 @@ type RuntimeWorkApi = NonNullable<WorkbenchServices['runtimeWorkApi']>
 interface ArchivedConversationsSettingsPageProps {
   api?: RuntimeWorkApi
   onOpenRuntimeTask?: (address: ReturnType<typeof archivedConversationAddress>) => Promise<void>
-  onRefreshWorkLists?: () => Promise<void>
+  onRefreshWorkLists?: RefreshWorkLists
   onLeaveSettings?: () => void
 }
 
@@ -445,9 +446,13 @@ export function ArchivedConversationsSettingsPage({
         await unarchiveLocalHarnessSession(harnessSessionId)
         notifyLocalHarnessSessionsChanged()
       } else {
-        await api.unarchiveConversation(archivedConversationAddress(item))
+        const address = archivedConversationAddress(item)
+        await api.unarchiveConversation(address)
+        await onRefreshWorkLists?.({ unarchivedTasks: [address] })
       }
-      await onRefreshWorkLists?.()
+      if (harnessSessionId) {
+        await onRefreshWorkLists?.()
+      }
       setLastUnarchived(item)
       await loadArchivedConversations()
       track('feature_action_completed', {

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -65,6 +65,7 @@ import {
   resolveDshSettingsPath,
   type WeworkDshSettingsPage,
 } from '@/features/dsh-runtime/dshSettings'
+import type { RefreshWorkLists } from '@/features/workbench/workbenchContextTypes'
 import { resolveDshSettingsIcon } from '@/features/dsh-runtime/dshSettingsIcons'
 import { DshSettingsSurface } from '@/features/dsh-runtime/DshSettingsSurface'
 import { DshSlotSurface } from '@/features/dsh-runtime/DshSlotSurface'
@@ -80,7 +81,7 @@ interface ConnectionsSettingsPageProps {
   services?: WorkbenchServices
   devices?: RuntimeDeviceInfo[]
   onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void>
-  onRefreshWorkLists?: () => Promise<void>
+  onRefreshWorkLists?: RefreshWorkLists
 }
 
 function getSettingsNavFromPath(

--- a/wework/src/components/settings/MobileSettingsPage.tsx
+++ b/wework/src/components/settings/MobileSettingsPage.tsx
@@ -34,6 +34,7 @@ import { HarnessSettingsPage } from './HarnessSettingsPage'
 import { GitHostingSettingsPage } from './GitHostingSettingsPage'
 import { ConnectionsDeviceSettingsPage } from './ConnectionsSettingsPage'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
+import type { RefreshWorkLists } from '@/features/workbench/workbenchContextTypes'
 import type { DeviceInfo, RuntimeTaskAddress } from '@/types/api'
 
 interface MobileSettingsPageProps {
@@ -42,7 +43,7 @@ interface MobileSettingsPageProps {
   services?: WorkbenchServices
   devices?: DeviceInfo[]
   onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void>
-  onRefreshWorkLists?: () => Promise<void>
+  onRefreshWorkLists?: RefreshWorkLists
 }
 
 export function MobileSettingsPage({

--- a/wework/src/components/settings/WorktreesSettingsPage.tsx
+++ b/wework/src/components/settings/WorktreesSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { CircleCheck, Loader2, RefreshCw, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
+import type { RefreshWorkLists } from '@/features/workbench/workbenchContextTypes'
 import { useTranslation } from '@/hooks/useTranslation'
 import type {
   DeviceInfo,
@@ -26,7 +27,7 @@ interface WorktreesSettingsPageProps {
     Pick<DeviceInfo, 'device_id' | 'name' | 'status' | 'device_type' | 'runtime_features'>
   >
   onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void>
-  onRefreshWorkLists?: () => Promise<void>
+  onRefreshWorkLists?: RefreshWorkLists
   onLeaveSettings?: () => void
 }
 

--- a/wework/src/features/dsh-runtime/dshSettings.ts
+++ b/wework/src/features/dsh-runtime/dshSettings.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
+import type { RefreshWorkLists } from '@/features/workbench/workbenchContextTypes'
 import type { DeviceInfo, RuntimeTaskAddress } from '@/types/api'
 import { getDshSlotEntries, WEWORK_DSH_SLOTS, type WeworkDshSlotEntry } from './dshUiSlots'
 
@@ -9,7 +10,7 @@ export interface WeworkDshSettingsContext {
   onBack: () => void
   onOpenCloudSettings: () => void
   onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void>
-  onRefreshWorkLists?: () => Promise<void>
+  onRefreshWorkLists?: RefreshWorkLists
 }
 
 export interface WeworkDshSettingsPage extends WeworkDshSlotEntry {

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -4042,6 +4042,54 @@ describe('CloudTodoWorkspace', () => {
     expect(workbenchServices.deliveryApi.updateLoopItem).not.toHaveBeenCalled()
   })
 
+  it('does not bypass execution configuration when project services are unavailable', async () => {
+    const user = userEvent.setup()
+    const workbenchServices = services()
+    workbenchServices.deliveryApi!.createLoopItem = vi.fn(async (_projectId, values) => ({
+      ...item,
+      id: 'WEG-AI-UNAVAILABLE',
+      sequence_number: 2,
+      title: values.title,
+      description: values.description ?? '',
+      status: 'pending' as const,
+      workflow: {
+        version: 1,
+        definition_version: 1,
+        stage_mode: 'none' as const,
+        advancement_policy: 'ai' as const,
+        ai_automation_rule_id: 'ai-manager',
+        execution_config: {
+          agent_id: null,
+          runtime_profile_id: 'runtime-incomplete',
+          execution_device_id: 'local-device',
+          model: null,
+          model_type: null,
+          model_options: {},
+          workspace_binding: { type: 'standalone' as const },
+        },
+        nodes: [],
+      },
+    }))
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[]}
+        services={workbenchServices}
+      />
+    )
+
+    await user.click((await screen.findAllByText('Wegent V4'))[0])
+    await user.click(screen.getByTestId('cloud-todo-column-add-pending'))
+    delete workbenchServices.projectSpaceDetailServices?.cloud
+    await user.type(screen.getByTestId('workspace-issue-input'), 'Unavailable AI Issue')
+    await user.click(screen.getByTestId('workspace-issue-submit'))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('运行服务当前不可用')
+    expect(screen.queryByTestId('issue-execution-config-dialog')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mock-start-background-task')).not.toBeInTheDocument()
+  })
+
   it('opens the full issue composer popup with the quick title and lane', async () => {
     const workbenchServices = services()
     render(

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -240,6 +240,7 @@ type PendingExecutionConfiguration = {
         type: 'save'
       }
 }
+type ExecutionConfigurationRequestResult = 'not-needed' | 'opened' | 'unavailable'
 
 const nativeBoardGroupFields: AITableField[] = [
   { id: 'status', name: '状态', type: 'status', config: null, raw: {} },
@@ -1801,14 +1802,16 @@ export function CloudTodoWorkspace({
   const pendingExecutionServices = pendingExecutionProject
     ? services.projectSpaceDetailServices?.[pendingExecutionProject.location]
     : undefined
-  function openExecutionConfiguration(pending: PendingExecutionConfiguration): boolean {
+  function openExecutionConfiguration(
+    pending: PendingExecutionConfiguration
+  ): Exclude<ExecutionConfigurationRequestResult, 'not-needed'> {
     const project = projectForItem(pending.item)
     if (!project || !services.projectSpaceDetailServices?.[project.location]) {
-      setBoardError('项目空间运行服务当前不可用')
-      return false
+      setBoardError(t('todo.run_unavailable', '运行服务当前不可用'))
+      return 'unavailable'
     }
     setPendingExecutionConfiguration(pending)
-    return true
+    return 'opened'
   }
   const selectedProjectApi =
     selectedProject?.task_provider === 'dingtalk_aitable'
@@ -2481,9 +2484,11 @@ export function CloudTodoWorkspace({
     return locatedItem
   }
 
-  function requestCreatedItemExecutionConfiguration(item: LocatedLoopItem): boolean {
+  function requestCreatedItemExecutionConfiguration(
+    item: LocatedLoopItem
+  ): ExecutionConfigurationRequestResult {
     if (!isProcessingStatus(item.status) || !itemNeedsExecutionConfiguration(item)) {
-      return false
+      return 'not-needed'
     }
     return openExecutionConfiguration({
       item,
@@ -3435,8 +3440,8 @@ export function CloudTodoWorkspace({
         setIssueComposerOpen(false)
         setSelectedItem(locatedItem)
       }
-      const needsExecutionConfiguration = requestCreatedItemExecutionConfiguration(locatedItem)
-      if (input.createTask && !needsExecutionConfiguration) {
+      const executionConfigurationResult = requestCreatedItemExecutionConfiguration(locatedItem)
+      if (input.createTask && executionConfigurationResult === 'not-needed') {
         setBackgroundTaskItemId(locatedItem.id)
         openTaskComposer({
           workItemId: locatedItem.id,

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -4306,7 +4306,7 @@ export function CloudTodoWorkspace({
                   projectAutomationApi={selectedProjectServices?.projectAutomationApi}
                   runtimeProfileApi={selectedProjectServices?.runtimeProfileApi}
                   executionApi={automationExecutionApi}
-                  deviceApi={services.deviceApi}
+                  deviceApi={selectedProjectServices?.deviceApi ?? services.deviceApi}
                   modelApi={services.modelApi}
                   teamApi={selectedProjectServices?.teamApi}
                   pluginApi={selectedProjectServices?.pluginApi}
@@ -4926,7 +4926,7 @@ export function CloudTodoWorkspace({
               pendingExecutionServices?.runtimeProfileApi ?? services.runtimeProfileApi
             }
             modelApi={services.modelApi}
-            deviceApi={services.deviceApi}
+            deviceApi={pendingExecutionServices?.deviceApi ?? services.deviceApi}
             localProjects={localProjects}
             onClose={() => setPendingExecutionConfiguration(null)}
             onConfirm={async result => {

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -1801,6 +1801,15 @@ export function CloudTodoWorkspace({
   const pendingExecutionServices = pendingExecutionProject
     ? services.projectSpaceDetailServices?.[pendingExecutionProject.location]
     : undefined
+  function openExecutionConfiguration(pending: PendingExecutionConfiguration): boolean {
+    const project = projectForItem(pending.item)
+    if (!project || !services.projectSpaceDetailServices?.[project.location]) {
+      setBoardError('项目空间运行服务当前不可用')
+      return false
+    }
+    setPendingExecutionConfiguration(pending)
+    return true
+  }
   const selectedProjectApi =
     selectedProject?.task_provider === 'dingtalk_aitable'
       ? apiForProject(selectedProject)
@@ -2476,11 +2485,10 @@ export function CloudTodoWorkspace({
     if (!isProcessingStatus(item.status) || !itemNeedsExecutionConfiguration(item)) {
       return false
     }
-    setPendingExecutionConfiguration({
+    return openExecutionConfiguration({
       item,
       continuation: { type: 'save' },
     })
-    return true
   }
 
   async function createTodoInBoardColumn(
@@ -3048,7 +3056,7 @@ export function CloudTodoWorkspace({
     }
     const needsExecutionConfig = enteringExecution && itemNeedsExecutionConfiguration(executionItem)
     if (needsExecutionConfig && !executionResult) {
-      setPendingExecutionConfiguration({
+      openExecutionConfiguration({
         item: executionItem,
         continuation: { type: 'move', columnKey, beforeItemId },
       })
@@ -3154,7 +3162,7 @@ export function CloudTodoWorkspace({
           itemId: locatedUpdated.id,
           route: 'workflow_configuration',
         })
-        setPendingExecutionConfiguration({
+        openExecutionConfiguration({
           item: locatedUpdated,
           continuation: { type: 'save' },
         })
@@ -4298,7 +4306,8 @@ export function CloudTodoWorkspace({
                 <AITableView api={aitableApi} project={selectedProject} />
               ) : projectView === 'automation' &&
                 selectedProjectAutomationSupported &&
-                selectedProjectApi ? (
+                selectedProjectApi &&
+                selectedProjectServices ? (
                 <ProjectAutomationView
                   key={selectedProject.id}
                   api={selectedProjectApi}
@@ -4306,7 +4315,7 @@ export function CloudTodoWorkspace({
                   projectAutomationApi={selectedProjectServices?.projectAutomationApi}
                   runtimeProfileApi={selectedProjectServices?.runtimeProfileApi}
                   executionApi={automationExecutionApi}
-                  deviceApi={selectedProjectServices?.deviceApi ?? services.deviceApi}
+                  deviceApi={selectedProjectServices.deviceApi}
                   modelApi={services.modelApi}
                   teamApi={selectedProjectServices?.teamApi}
                   pluginApi={selectedProjectServices?.pluginApi}
@@ -4785,7 +4794,7 @@ export function CloudTodoWorkspace({
                                         }
                                       }}
                                       onConfigureExecution={() =>
-                                        setPendingExecutionConfiguration({
+                                        openExecutionConfiguration({
                                           item,
                                           continuation: { type: 'save' },
                                         })
@@ -4916,7 +4925,7 @@ export function CloudTodoWorkspace({
             onConfirm={pendingAutomationSelection.onConfirm}
           />
         ) : null}
-        {pendingExecutionConfiguration ? (
+        {pendingExecutionConfiguration && pendingExecutionServices ? (
           <IssueExecutionConfigDialog
             item={pendingExecutionConfiguration.item}
             projectChatAgentApi={
@@ -4926,7 +4935,7 @@ export function CloudTodoWorkspace({
               pendingExecutionServices?.runtimeProfileApi ?? services.runtimeProfileApi
             }
             modelApi={services.modelApi}
-            deviceApi={pendingExecutionServices?.deviceApi ?? services.deviceApi}
+            deviceApi={pendingExecutionServices.deviceApi}
             localProjects={localProjects}
             onClose={() => setPendingExecutionConfiguration(null)}
             onConfirm={async result => {

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -670,6 +670,12 @@ export function useWorkbenchDataRefresh({
 
   const refreshWorkLists: RefreshWorkLists = useCallback(
     async options => {
+      if (options?.unarchivedTasks?.length) {
+        const unarchivedTaskKeys = new Set(options.unarchivedTasks.map(getRuntimeTaskRouteKey))
+        archivedRuntimeTaskAddressesRef.current = archivedRuntimeTaskAddressesRef.current.filter(
+          address => !unarchivedTaskKeys.has(getRuntimeTaskRouteKey(address))
+        )
+      }
       const refreshRevision = ++workListRefreshRevisionRef.current
       const [devicesResult, runtimeWorkResult] = await Promise.all([
         executorClient.commands.listDevices().catch(error => {

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -84,7 +84,10 @@ export type ArchiveRuntimeTaskResult = {
   status: 'archived' | 'dirty_worktree' | 'failed'
 }
 
-export type RefreshWorkLists = (options?: { syncCloud?: boolean }) => Promise<void>
+export type RefreshWorkLists = (options?: {
+  syncCloud?: boolean
+  unarchivedTasks?: RuntimeTaskAddress[]
+}) => Promise<void>
 
 export type ArchiveRuntimeConversationsResult = ArchiveRuntimeTaskResult
 


### PR DESCRIPTION
## Summary

- restore local user-message presentations for paginated Codex turns whose provider item list is empty after an interrupted archive
- clear the optimistic archive suppression when a conversation is explicitly unarchived so it returns to the sidebar immediately
- make the three-second archive undo notice clickable inside the Electron titlebar area
- extend the desktop cloud Worktree checkpoint to cover clickable undo, unarchive, sidebar reopening, and transcript restoration

## Root cause

Production logs showed that unarchive succeeded and the task list contained the restored task, but transcript pagination returned zero messages for an interrupted turn. The runtime index still contained the canonical user-message presentation. Page membership was inferred only from converted messages, so an empty turn disappeared before presentation attachment. A second race left the restored task hidden by the optimistic archive address when archive and unarchive happened before a list refresh observed the archived state.

## Verification

- `pnpm --filter wework exec tsc --noEmit`
- focused Vitest coverage for archived settings and archive undo notice
- `cargo test runtime_work::handler::tests::paginated_transcript --lib`
- `pnpm --filter wework e2e:desktop --cloud-only --segment cloud-worktree-archive-restore`
- pre-push Wework checks, Executor `cargo test --all-features --lib`, and `cargo clippy`

Desktop E2E evidence: `wework/test-results/desktop-e2e/2026-08-31T15-18-12-007Z-24237`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project execution settings now include local and cloud devices when available.
  - Project-specific device selections are used for automation and issue execution configuration.

- **Bug Fixes**
  - Improved transcript pagination so interrupted-turn user messages and content are restored correctly.
  - Archive undo notifications remain interactive and clickable in the desktop title bar.
  - Unarchived conversations and worktrees now refresh immediately and leave archived results.
  - Missing execution services now display an error instead of opening an unusable task composer.
  - Screenshot capture now falls back gracefully when the preferred capture method times out.

- **Tests**
  - Expanded coverage for transcript restoration, archive undo interaction, unarchive refresh behavior, and archive restoration after restarting a task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->