### PR TITLE
fix(wework): keep composer focused after task switch

### DIFF
--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -828,6 +828,25 @@ async function verifyTurnNavigationTracksVisibleTurnMessages(
   await captureVerificationScreenshot(control, 'turn-navigation-02-assistant-only-active.png')
 }
 
+export async function waitForComposerFocus(control, timeoutMs, failureMessage) {
+  const focusStartedAt = Date.now()
+  let activeElementTestId = ''
+  while (Date.now() - focusStartedAt < timeoutMs) {
+    activeElementTestId = await control.command('getActiveElementTestId', 'body')
+    if (activeElementTestId === 'chat-message-input') return
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  const [focusSnapshot, workbenchSnapshot, composerDiagnostics] = await Promise.all([
+    control.command('getComposerFocusSnapshot', 'body'),
+    control.command('getWorkbenchDebugSnapshot', 'body'),
+    control.command('getComposerDiagnosticsSnapshot', 'body'),
+  ])
+  throw new Error(
+    `${failureMessage}; activeElementTestId=${activeElementTestId}; focus=${focusSnapshot}; ` +
+      `workbench=${workbenchSnapshot}; composerDiagnostics=${composerDiagnostics}`
+  )
+}
+
 async function reopenCurrentTurnNavigationTask(
   control,
   composerSelector,
@@ -856,26 +875,11 @@ async function reopenCurrentTurnNavigationTask(
       timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
     }
   )
-  const focusStartedAt = Date.now()
-  let activeElementTestId = ''
-  while (Date.now() - focusStartedAt < DEFAULT_STEP_TIMEOUT_MS) {
-    activeElementTestId = await control.command('getActiveElementTestId', 'body')
-    if (activeElementTestId === 'chat-message-input') break
-    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
-  }
-  if (activeElementTestId !== 'chat-message-input') {
-    const [focusSnapshot, workbenchSnapshot, composerDiagnostics] = await Promise.all([
-      control.command('getComposerFocusSnapshot', 'body'),
-      control.command('getWorkbenchDebugSnapshot', 'body'),
-      control.command('getComposerDiagnosticsSnapshot', 'body'),
-    ])
-    throw new Error(
-      `Opening a conversation from the sidebar did not transfer keyboard focus to the composer; ` +
-        `activeElementTestId=${activeElementTestId}; focus=${focusSnapshot}; ` +
-        `workbench=${workbenchSnapshot}; ` +
-        `composerDiagnostics=${composerDiagnostics}`
-    )
-  }
+  await waitForComposerFocus(
+    control,
+    DEFAULT_STEP_TIMEOUT_MS,
+    'Opening a conversation from the sidebar did not transfer keyboard focus to the composer'
+  )
   if (expectedTurnCount > E2E_TRANSCRIPT_PAGE_SIZE) {
     const expectedMessageCount = expectedConversationTurnCount * 2
     let paginatedSnapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -37,6 +37,7 @@ import {
   verifyTurnNavigationTracksVisibleTurnMessages,
   verifyUserMessageNavigation,
   verifyVisionSidecar,
+  waitForComposerFocus,
 } from './conversation-navigation.mjs'
 
 import {
@@ -3517,6 +3518,11 @@ last_updated = "2026-07-30T00:00:00Z"`
           activeTaskWorkbenchSelector
         )
       }
+      await waitForComposerFocus(
+        control,
+        DEFAULT_STEP_TIMEOUT_MS,
+        'Restoring a task with an open terminal did not leave keyboard focus in the composer'
+      )
       await control.command(
         'waitFor',
         `${activeTaskWorkbenchSelector} [data-testid="file-changes-review-file-tree"]`,

--- a/wework/src/components/chat/ChatInput.tsx
+++ b/wework/src/components/chat/ChatInput.tsx
@@ -640,6 +640,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
   useImperativeHandle(
     ref,
     () => ({
+      get element() {
+        return composerRef.current?.element ?? null
+      },
       focus: () => composerRef.current?.focus(),
       getValue: () => composerRef.current?.getValue() ?? value,
       setValue: (nextValue, selectionOffset) =>

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -173,6 +173,12 @@ export const CompactChatComposer = forwardRef<ComposerTextareaHandle, CompactCha
     useImperativeHandle(
       ref,
       () => ({
+        get element() {
+          const activeHandle = fullscreenInputOpen
+            ? fullscreenComposerRef.current
+            : composerRef.current
+          return activeHandle?.element ?? null
+        },
         focus: () => {
           const activeHandle = fullscreenInputOpen
             ? fullscreenComposerRef.current

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -102,6 +102,7 @@ interface ActiveComposerMenu {
 }
 
 export interface ComposerTextareaHandle {
+  readonly element: HTMLElement | null
   focus: () => void
   getValue: () => string
   setValue: (value: string, selectionOffset?: number) => void
@@ -175,6 +176,9 @@ export const ComposerTextarea = forwardRef<ComposerTextareaHandle, ComposerTexta
     useImperativeHandle(
       ref,
       () => ({
+        get element() {
+          return editorRef.current?.element ?? null
+        },
         focus: () => {
           focusRequestExpiresAtRef.current = Date.now() + 2_000
           editorRef.current?.focus()

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -219,6 +219,9 @@ export const ProjectChatComposer = forwardRef<ComposerTextareaHandle, ProjectCha
     useImperativeHandle(
       ref,
       () => ({
+        get element() {
+          return composerRef.current?.element ?? null
+        },
         focus: () => composerRef.current?.focus(),
         getValue: () => composerRef.current?.getValue() ?? value,
         setValue: (nextValue, selectionOffset) =>

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -2,7 +2,10 @@ import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { requestWorkbenchComposerFocus } from '@/lib/workbenchComposerFocus'
+import {
+  dispatchPendingWorkbenchComposerFocusRequest,
+  requestWorkbenchComposerFocus,
+} from '@/lib/workbenchComposerFocus'
 import { BufferedChatInput } from './BufferedChatInput'
 
 vi.mock('@/api/dsh/desktopHost', () => ({
@@ -473,13 +476,15 @@ describe('BufferedChatInput', () => {
     render(
       <>
         <button type="button">Conversation</button>
-        <BufferedChatInput
-          value=""
-          onChange={vi.fn()}
-          onSubmit={vi.fn()}
-          disabled={false}
-          projectChat={createProjectChat('runtime:device-1:task-1')}
-        />
+        <div data-active-workbench-pane="true">
+          <BufferedChatInput
+            value=""
+            onChange={vi.fn()}
+            onSubmit={vi.fn()}
+            disabled={false}
+            projectChat={createProjectChat('runtime:device-1:task-1')}
+          />
+        </div>
       </>
     )
     const conversation = screen.getByRole('button', { name: 'Conversation' })
@@ -493,29 +498,76 @@ describe('BufferedChatInput', () => {
   test('focuses a selected conversation after its composer mounts', async () => {
     requestWorkbenchComposerFocus('runtime:device-1:task-1')
 
-    const { rerender } = render(
-      <BufferedChatInput
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        disabled={false}
-        projectChat={createProjectChat('runtime:device-1:task-1')}
-      />
+    const composer = (
+      <div data-active-workbench-pane="true">
+        <BufferedChatInput
+          value=""
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+          disabled={false}
+          projectChat={createProjectChat('runtime:device-1:task-1')}
+        />
+      </div>
     )
+    const { rerender } = render(composer)
 
     await waitFor(() => expect(screen.getByTestId('chat-message-input')).toHaveFocus())
 
     rerender(<div />)
     rerender(
-      <BufferedChatInput
-        key="remounted"
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        disabled={false}
-        projectChat={createProjectChat('runtime:device-1:task-1')}
-      />
+      <div data-active-workbench-pane="true">
+        <BufferedChatInput
+          key="remounted"
+          value=""
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+          disabled={false}
+          projectChat={createProjectChat('runtime:device-1:task-1')}
+        />
+      </div>
     )
+    dispatchPendingWorkbenchComposerFocusRequest()
+
+    await waitFor(() => expect(screen.getByTestId('chat-message-input')).toHaveFocus())
+  })
+
+  test('does not let a cached hidden composer consume the focus request', async () => {
+    const { rerender } = render(
+      <>
+        <button type="button">Conversation</button>
+        <div data-active-workbench-pane="false">
+          <BufferedChatInput
+            value=""
+            onChange={vi.fn()}
+            onSubmit={vi.fn()}
+            disabled={false}
+            projectChat={createProjectChat('runtime:device-1:task-1')}
+          />
+        </div>
+      </>
+    )
+    const conversation = screen.getByRole('button', { name: 'Conversation' })
+    conversation.focus()
+
+    requestWorkbenchComposerFocus('runtime:device-1:task-1')
+    await new Promise(resolve => window.requestAnimationFrame(resolve))
+    expect(conversation).toHaveFocus()
+
+    rerender(
+      <>
+        <button type="button">Conversation</button>
+        <div data-active-workbench-pane="true">
+          <BufferedChatInput
+            value=""
+            onChange={vi.fn()}
+            onSubmit={vi.fn()}
+            disabled={false}
+            projectChat={createProjectChat('runtime:device-1:task-1')}
+          />
+        </div>
+      </>
+    )
+    dispatchPendingWorkbenchComposerFocusRequest()
 
     await waitFor(() => expect(screen.getByTestId('chat-message-input')).toHaveFocus())
   })

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -8,6 +8,7 @@ import {
 import { recordComposerDiagnostic } from '@/components/chat/composer/composerDiagnostics'
 import {
   consumeWorkbenchComposerFocusRequest,
+  hasWorkbenchComposerFocusRequest,
   WORKBENCH_COMPOSER_FOCUS_EVENT,
   type WorkbenchComposerFocusDetail,
 } from '@/lib/workbenchComposerFocus'
@@ -58,21 +59,30 @@ export const BufferedChatInput = memo(function BufferedChatInput({
 
   useLayoutEffect(() => {
     const focusComposer = () => {
-      composerRef.current?.focus()
+      const composer = composerRef.current
+      if (!composer) return false
+      const element = composer.element
+      const pane = element?.closest<HTMLElement>('[data-active-workbench-pane]')
+      if (pane?.dataset.activeWorkbenchPane !== 'true') return false
+      if (element?.closest('[hidden], [aria-hidden="true"]')) return false
+      composer.focus()
+      return true
     }
     const focusRequestedComposer = (event: Event) => {
       const detail = (event as CustomEvent<WorkbenchComposerFocusDetail>).detail
       if (props.disabled || !scopeKey || detail?.scopeKey !== scopeKey) return
-      if (!consumeWorkbenchComposerFocusRequest(scopeKey, focusConsumerIdRef.current)) return
-      focusComposer()
+      if (!hasWorkbenchComposerFocusRequest(scopeKey, focusConsumerIdRef.current)) return
+      if (!focusComposer()) return
+      consumeWorkbenchComposerFocusRequest(scopeKey, focusConsumerIdRef.current)
     }
     window.addEventListener(WORKBENCH_COMPOSER_FOCUS_EVENT, focusRequestedComposer)
     if (
       !props.disabled &&
       scopeKey &&
-      consumeWorkbenchComposerFocusRequest(scopeKey, focusConsumerIdRef.current)
-    ) {
+      hasWorkbenchComposerFocusRequest(scopeKey, focusConsumerIdRef.current) &&
       focusComposer()
+    ) {
+      consumeWorkbenchComposerFocusRequest(scopeKey, focusConsumerIdRef.current)
     }
     return () => {
       window.removeEventListener(WORKBENCH_COMPOSER_FOCUS_EVENT, focusRequestedComposer)

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -404,7 +404,6 @@ export function DesktopWorkbenchLayout({
   const openRuntimeTaskOutsideHarness = useCallback(
     async (address: RuntimeTaskAddress) => {
       setActiveLocalHarnessSessionId(null)
-      requestWorkbenchComposerFocus(getRuntimeTaskChatScopeKey(address))
       activateSplitPane(
         getWorkbenchPaneKey({
           currentRuntimeTask: address,
@@ -414,6 +413,7 @@ export function DesktopWorkbenchLayout({
       if (!(currentPath === '/' && isSameRuntimeTask(state.currentRuntimeTask, address))) {
         await onOpenRuntimeTask(address)
       }
+      requestWorkbenchComposerFocus(getRuntimeTaskChatScopeKey(address))
     },
     [activateSplitPane, currentPath, onOpenRuntimeTask, state.currentRuntimeTask]
   )

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -10,6 +10,7 @@ import {
   observeTerminalTheme,
 } from '@/lib/xterm-theme'
 import { appendRuntimeTerminalContext } from '@/lib/runtime-terminal-context'
+import { focusTerminalUnlessComposerFocusRequested } from '@/lib/workbenchComposerFocus'
 import { defaultAppearance, useOptionalAppearance } from '@/features/appearance'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
 import { createXtermWebLinksAddon } from './xtermLinks'
@@ -322,7 +323,7 @@ export function EmbeddedLocalTerminal({
           terminal,
           terminalKind: 'local',
         })
-        terminal.textarea?.focus({ preventScroll: true })
+        focusTerminalUnlessComposerFocusRequested(terminal.textarea)
         if (terminal.rows > 0 && terminal.cols > 0) {
           const lastSize = lastSizeRef.current
           if (lastSize?.rows !== terminal.rows || lastSize.cols !== terminal.cols) {

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { StrictMode } from 'react'
 import { openExternalUrl } from '@/lib/external-links'
 import { createRemoteTerminalClient } from '@/lib/remote-terminal-socket'
+import {
+  consumeWorkbenchComposerFocusRequest,
+  requestWorkbenchComposerFocus,
+} from '@/lib/workbenchComposerFocus'
 import { RemoteTerminal } from './RemoteTerminal'
 
 const testState = vi.hoisted(() => ({
@@ -28,6 +32,8 @@ const testState = vi.hoisted(() => ({
     dispose: ReturnType<typeof vi.fn>
     focus: ReturnType<typeof vi.fn>
     refresh: ReturnType<typeof vi.fn>
+    textarea: HTMLTextAreaElement
+    textareaFocus: ReturnType<typeof vi.spyOn>
     options: { theme?: unknown }
   }>,
   webLinksAddonInstances: [] as Array<{
@@ -68,6 +74,8 @@ vi.mock('@xterm/xterm', () => ({
   Terminal: vi.fn().mockImplementation(function TerminalMock(options: Record<string, unknown>) {
     testState.terminalConstructorOptions.push(options)
     const dataHandlers: Array<(data: string) => void> = []
+    const textarea = document.createElement('textarea')
+    const textareaFocus = vi.spyOn(textarea, 'focus')
     const terminal = {
       rows: 24,
       cols: 80,
@@ -92,6 +100,8 @@ vi.mock('@xterm/xterm', () => ({
       dispose: vi.fn(),
       focus: vi.fn(),
       refresh: vi.fn(),
+      textarea,
+      textareaFocus,
       options: {},
     }
     testState.terminalInstances.push(terminal)
@@ -288,6 +298,68 @@ describe('RemoteTerminal', () => {
     )
 
     expect(client.resize).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not take focus from the composer when reactivated', () => {
+    const client = createClient({
+      attach: vi.fn(() => new Promise(() => undefined)),
+    })
+    createRemoteTerminalClientMock.mockReturnValue(client)
+
+    const { rerender } = render(
+      <RemoteTerminal
+        sessionId="terminal-1"
+        clientFactory={createRemoteTerminalClient}
+        active={false}
+      />
+    )
+    const composer = document.createElement('textarea')
+    composer.dataset.testid = 'chat-message-input'
+    document.body.append(composer)
+    composer.focus()
+
+    rerender(
+      <RemoteTerminal sessionId="terminal-1" clientFactory={createRemoteTerminalClient} active />
+    )
+
+    expect(composer).toHaveFocus()
+    expect(testState.terminalInstances[0].textareaFocus).not.toHaveBeenCalled()
+    composer.remove()
+  })
+
+  test('does not focus the terminal while a composer focus request is pending', () => {
+    const now = Date.now()
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+    const client = createClient({
+      attach: vi.fn(() => new Promise(() => undefined)),
+    })
+    createRemoteTerminalClientMock.mockReturnValue(client)
+    requestWorkbenchComposerFocus('runtime:device-1:task-1')
+
+    render(
+      <RemoteTerminal sessionId="terminal-1" clientFactory={createRemoteTerminalClient} active />
+    )
+
+    expect(testState.terminalInstances[0].textareaFocus).not.toHaveBeenCalled()
+    dateNowSpy.mockReturnValue(now + 2_001)
+    consumeWorkbenchComposerFocusRequest('runtime:device-1:task-1', Symbol('cleanup-1'))
+    consumeWorkbenchComposerFocusRequest('runtime:device-1:task-1', Symbol('cleanup-2'))
+    dateNowSpy.mockRestore()
+  })
+
+  test('focuses the terminal when activated without a focused composer', () => {
+    const client = createClient({
+      attach: vi.fn(() => new Promise(() => undefined)),
+    })
+    createRemoteTerminalClientMock.mockReturnValue(client)
+
+    render(
+      <RemoteTerminal sessionId="terminal-1" clientFactory={createRemoteTerminalClient} active />
+    )
+
+    expect(testState.terminalInstances[0].textareaFocus).toHaveBeenCalledWith({
+      preventScroll: true,
+    })
   })
 
   test('refreshes buffered rows when activated and when the window regains focus', () => {

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -13,6 +13,7 @@ import {
   observeTerminalTheme,
 } from '@/lib/xterm-theme'
 import { appendRuntimeTerminalContext } from '@/lib/runtime-terminal-context'
+import { focusTerminalUnlessComposerFocusRequested } from '@/lib/workbenchComposerFocus'
 import { defaultAppearance, useOptionalAppearance } from '@/features/appearance'
 import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
@@ -343,7 +344,7 @@ export function RemoteTerminal({
           terminal,
           terminalKind: 'remote',
         })
-        terminal.textarea?.focus({ preventScroll: true })
+        focusTerminalUnlessComposerFocusRequested(terminal.textarea)
       } catch (error) {
         console.error('Failed to activate remote terminal:', error)
         return

--- a/wework/src/lib/workbenchComposerFocus.ts
+++ b/wework/src/lib/workbenchComposerFocus.ts
@@ -8,11 +8,10 @@ export interface WorkbenchComposerFocusDetail {
 interface PendingWorkbenchComposerFocus {
   scopeKey: string
   consumers: Set<symbol>
-  expiresAt: number
+  expiresAt: number | null
 }
 
 const WORKBENCH_COMPOSER_FOCUS_TTL_MS = 2_000
-const WORKBENCH_COMPOSER_FOCUS_CONSUMES = 2
 let pendingWorkbenchComposerFocus: PendingWorkbenchComposerFocus | null = null
 
 export function focusComposerAtEnd(element: HTMLElement | null | undefined) {
@@ -32,6 +31,20 @@ export function focusComposerAtEnd(element: HTMLElement | null | undefined) {
   selection.addRange(range)
 }
 
+export function focusTerminalUnlessComposerFocusRequested(
+  terminalInput: Pick<HTMLElement, 'focus'> | null | undefined
+) {
+  if (getPendingWorkbenchComposerFocus()) return
+  const activeElement = document.activeElement
+  if (
+    activeElement instanceof HTMLElement &&
+    activeElement.closest('[data-testid="chat-message-input"]')
+  ) {
+    return
+  }
+  terminalInput?.focus({ preventScroll: true })
+}
+
 export function requestNewChatComposerFocus() {
   window.requestAnimationFrame(() => {
     window.dispatchEvent(new Event(WORKBENCH_NEW_CHAT_FOCUS_EVENT))
@@ -42,28 +55,48 @@ export function requestWorkbenchComposerFocus(scopeKey: string) {
   pendingWorkbenchComposerFocus = {
     scopeKey,
     consumers: new Set(),
-    expiresAt: Date.now() + WORKBENCH_COMPOSER_FOCUS_TTL_MS,
+    expiresAt: null,
   }
   window.requestAnimationFrame(() => {
-    window.dispatchEvent(
-      new CustomEvent<WorkbenchComposerFocusDetail>(WORKBENCH_COMPOSER_FOCUS_EVENT, {
-        detail: { scopeKey },
-      })
-    )
+    dispatchPendingWorkbenchComposerFocusRequest()
   })
 }
 
+export function dispatchPendingWorkbenchComposerFocusRequest() {
+  const pending = getPendingWorkbenchComposerFocus()
+  if (!pending) return
+  window.dispatchEvent(
+    new CustomEvent<WorkbenchComposerFocusDetail>(WORKBENCH_COMPOSER_FOCUS_EVENT, {
+      detail: { scopeKey: pending.scopeKey },
+    })
+  )
+}
+
 export function consumeWorkbenchComposerFocusRequest(scopeKey: string, consumerId: symbol) {
-  const pending = pendingWorkbenchComposerFocus
+  const pending = getPendingWorkbenchComposerFocus()
   if (!pending || pending.scopeKey !== scopeKey) return false
-  if (pending.expiresAt < Date.now()) {
-    pendingWorkbenchComposerFocus = null
-    return false
-  }
   if (pending.consumers.has(consumerId)) return false
   pending.consumers.add(consumerId)
-  if (pending.consumers.size === WORKBENCH_COMPOSER_FOCUS_CONSUMES) {
+  if (pending.consumers.size === 1) {
+    pending.expiresAt = Date.now() + WORKBENCH_COMPOSER_FOCUS_TTL_MS
+  } else {
     pendingWorkbenchComposerFocus = null
   }
   return true
+}
+
+export function hasWorkbenchComposerFocusRequest(scopeKey: string, consumerId: symbol) {
+  const pending = getPendingWorkbenchComposerFocus()
+  if (!pending || pending.scopeKey !== scopeKey) return false
+  return !pending.consumers.has(consumerId)
+}
+
+function getPendingWorkbenchComposerFocus() {
+  const pending = pendingWorkbenchComposerFocus
+  if (!pending) return null
+  if (pending.expiresAt !== null && pending.expiresAt < Date.now()) {
+    pendingWorkbenchComposerFocus = null
+    return null
+  }
+  return pending
 }


### PR DESCRIPTION
## Summary

- request composer focus after the selected task finishes opening
- prevent cached composers from consuming another pane's focus request and prevent restored terminals from stealing composer focus
- add the regression assertion to the existing `core-task-flow` task-switch scenario without introducing a standalone checkpoint

## Verification

- `pnpm --filter wework test src/components/layout/BufferedChatInput.test.tsx src/components/layout/workbenchPaneStack.test.tsx src/components/layout/workspace-panels/RemoteTerminal.test.tsx src/components/chat/ChatInput.test.tsx src/components/chat/composer/ComposerProseMirrorEditor.test.tsx` (209 passed)
- focused ESLint and Prettier checks passed
- real packaged Electron focused scenario passed: `wework/test-results/desktop-e2e/2026-08-31T15-18-15-649Z-24764`
- the earlier full `core-task-flow` attempt reached an unrelated existing system-drag failure before this task-switch segment; the committed regression remains in the CI-covered `core-task-flow` suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composer focus restoration when reopening conversations, switching workspaces, and restoring tasks.
  * Prevented hidden or inactive composers from consuming focus requests.
  * Prevented terminal panels from stealing focus while the composer is focused or awaiting focus.
  * Improved focus behavior when activating runtime tasks and terminals.

* **Tests**
  * Added coverage for composer and terminal focus behavior across remounts, pane switches, and pending focus requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->