### PR TITLE
fix(wework): keep environment panel fixed while scrolling

### DIFF
--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -40,6 +40,7 @@ core_segments=(
   renderer-storage
   tray-lifecycle
   conversation-state
+  environment-panel-scroll
   temporary-chat
   workspace-attachments
   rendering-extensions
@@ -128,7 +129,7 @@ core_shards=(
   task-status-sync,task-board-association,core-task-flow,change-request-status,context-compaction
   window-lifecycle,runtime-terminal-convergence,browser-toolbar-actions,browser-annotation-anchors
   project-automation
-  resilience
+  resilience,environment-panel-scroll
   workspace-attachments,automation-lifecycle
   project-assignment-notification,split-workbench,priority-filter
   rendering-extensions
@@ -502,17 +503,25 @@ classify_wework_path() {
       return
       ;;
 
-    # Right-workspace temporary chats have an independently bootstrapped
-    # ephemeral-thread scenario.
+    # The main workbench owns the independent message scroller and fixed
+    # environment panel, plus temporary-chat and project-context integration.
     wework/src/components/layout/DesktopWorkbenchMain.tsx | \
-      wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx | \
-      wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx | \
-      wework/e2e/desktop/scenarios/temporary-chat.scenario.mjs)
-      select_target "core:temporary-chat"
+      wework/src/components/layout/DesktopWorkbenchLayout.test.tsx)
+      select_target "core:environment-panel-scroll"
       if [[ "$path" == wework/src/components/layout/DesktopWorkbenchMain.tsx ]]; then
+        select_target "core:temporary-chat"
         select_target "core:cloud-context-resilience"
         select_target "core:task-board-association"
       fi
+      return
+      ;;
+
+    # Right-workspace temporary chats have an independently bootstrapped
+    # ephemeral-thread scenario.
+    wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx | \
+      wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx | \
+      wework/e2e/desktop/scenarios/temporary-chat.scenario.mjs)
+      select_target "core:temporary-chat"
       return
       ;;
 

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -400,6 +400,22 @@ wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx"
 
+assert_desktop_case "main workbench changes select fixed environment panel coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-3","name":"Core / shard 3","segments":"temporary-chat"},{"id":"core-5","name":"Core / shard 5","segments":"cloud-context-resilience"},{"id":"core-7","name":"Core / shard 7","segments":"task-board-association"},{"id":"core-10","name":"Core / shard 10","segments":"environment-panel-scroll"}]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
+  "wework/src/components/layout/DesktopWorkbenchMain.tsx"
+
+assert_desktop_case "main workbench layout test selects fixed environment panel coverage" \
+  'wework_desktop_e2e=true
+wework_desktop_core_e2e=true
+wework_desktop_core_e2e_matrix={"include":[{"id":"core-10","name":"Core / shard 10","segments":"environment-panel-scroll"}]}
+wework_desktop_other_e2e=false
+wework_desktop_other_e2e_matrix={"include":[]}' \
+  "wework/src/components/layout/DesktopWorkbenchLayout.test.tsx"
+
 assert_desktop_case "startup splash selects native startup coverage" \
   'wework_desktop_e2e=true
 wework_desktop_core_e2e=true
@@ -425,6 +441,7 @@ wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-1","name":"Cloud / shar
 wework_desktop_other_e2e=true
 wework_desktop_other_e2e_matrix={"include":[{"id":"plugins","name":"Plugins","command":"e2e:desktop:plugins","segment":""}]}
 wework_desktop_macos_inspector_e2e=true'
+full_desktop_expected="${full_desktop_expected/\"segments\":\"resilience\"/\"segments\":\"resilience,environment-panel-scroll\"}"
 
 assert_desktop_case "runner-only changes retain full coverage" \
   "$full_desktop_expected" \

--- a/wework/e2e/desktop/checkpoints.mjs
+++ b/wework/e2e/desktop/checkpoints.mjs
@@ -47,6 +47,7 @@ export const DESKTOP_CHECKPOINTS = [
   'goal-lifecycle',
   'supervisor-lifecycle',
   'resilience',
+  'environment-panel-scroll',
   'conversation-state',
   'temporary-chat',
   'workspace-attachments',

--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -846,6 +846,7 @@ async function verifyTurnNavigationTracksVisibleTurnMessages(
 }
 
 async function verifyEnvironmentPanelScrollStability(control) {
+  const scrollFrameSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-scroll-frame"]`
   const scrollerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`
   const environmentPanelSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="environment-info-panel-container"]`
   await control.command(
@@ -862,6 +863,11 @@ async function verifyEnvironmentPanelScrollStability(control) {
     scrollerSelector,
     'The conversation before verifying the fixed environment panel'
   )
+  const scrollFrameBeforeScroll = await getSingleElementMetrics(
+    control,
+    scrollFrameSelector,
+    'The full-width workbench scroll frame'
+  )
   assert.ok(
     scrollerBeforeScroll.scrollHeight > scrollerBeforeScroll.clientHeight,
     `The environment-panel fixture did not overflow: ${JSON.stringify(scrollerBeforeScroll)}`
@@ -870,6 +876,21 @@ async function verifyEnvironmentPanelScrollStability(control) {
     control,
     environmentPanelSelector,
     'The environment panel before scrolling the conversation'
+  )
+  assert.ok(
+    Math.abs(scrollerBeforeScroll.right - scrollFrameBeforeScroll.right) <= 1 &&
+      Math.abs(scrollerBeforeScroll.width - scrollFrameBeforeScroll.width) <= 1,
+    `The conversation scrollbar was not aligned to the workbench right edge: ${JSON.stringify({
+      scrollFrame: scrollFrameBeforeScroll,
+      scroller: scrollerBeforeScroll,
+    })}`
+  )
+  assert.ok(
+    Math.abs(environmentPanelBeforeScroll.right - scrollFrameBeforeScroll.right) <= 1,
+    `The fixed environment panel was not aligned to the workbench right edge: ${JSON.stringify({
+      environmentPanel: environmentPanelBeforeScroll,
+      scrollFrame: scrollFrameBeforeScroll,
+    })}`
   )
   const assertEnvironmentPanelDidNotMove = (metrics, description) => {
     for (const property of ['top', 'right', 'bottom', 'left', 'width', 'height']) {
@@ -919,6 +940,13 @@ async function verifyEnvironmentPanelScrollStability(control) {
     environmentPanelSelector,
     'The environment panel after scrolling downward'
   )
+  assert.ok(
+    Number.isFinite(upwardScrollTop) && Number.isFinite(downwardScrollTop),
+    `The conversation scroller did not report numeric offsets: ${JSON.stringify({
+      downwardScrollTop,
+      upwardScrollTop,
+    })}`
+  )
   assert.notEqual(
     downwardScrollTop,
     upwardScrollTop,
@@ -935,6 +963,8 @@ async function verifyEnvironmentPanelScrollStability(control) {
       afterUpwardScroll: environmentPanelAfterUpwardScroll,
       beforeScroll: environmentPanelBeforeScroll,
       downwardScrollTop,
+      scrollFrame: scrollFrameBeforeScroll,
+      scroller: scrollerBeforeScroll,
       upwardScrollTop,
     })
   )

--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -845,6 +845,102 @@ async function verifyTurnNavigationTracksVisibleTurnMessages(
   await captureVerificationScreenshot(control, 'turn-navigation-02-assistant-only-active.png')
 }
 
+async function verifyEnvironmentPanelScrollStability(control) {
+  const scrollerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`
+  const environmentPanelSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="environment-info-panel-container"]`
+  await control.command(
+    'waitFor',
+    `${environmentPanelSelector} [data-testid="environment-info-popover"]`,
+    {
+      visible: true,
+      stableMs: COMPOSER_READY_STABILITY_MS,
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    }
+  )
+  const scrollerBeforeScroll = await getSingleElementMetrics(
+    control,
+    scrollerSelector,
+    'The conversation before verifying the fixed environment panel'
+  )
+  assert.ok(
+    scrollerBeforeScroll.scrollHeight > scrollerBeforeScroll.clientHeight,
+    `The environment-panel fixture did not overflow: ${JSON.stringify(scrollerBeforeScroll)}`
+  )
+  const environmentPanelBeforeScroll = await getSingleElementMetrics(
+    control,
+    environmentPanelSelector,
+    'The environment panel before scrolling the conversation'
+  )
+  const assertEnvironmentPanelDidNotMove = (metrics, description) => {
+    for (const property of ['top', 'right', 'bottom', 'left', 'width', 'height']) {
+      assert.ok(
+        Math.abs(metrics[property] - environmentPanelBeforeScroll[property]) <= 1,
+        `${description}: ${property} changed from ${environmentPanelBeforeScroll[property]} to ${metrics[property]}`
+      )
+    }
+  }
+  await captureVerificationScreenshot(control, 'environment-panel-scroll-01-before.png')
+
+  const upwardScrollTop = Number(
+    await control.command('scrollToRatioAsUser', scrollerSelector, { value: '0.15' })
+  )
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
+  await assertDesktopComposerDocked(
+    control,
+    await getSingleElementMetrics(control, scrollerSelector, 'The conversation after scrolling up'),
+    'The composer after scrolling upward while the environment panel is visible'
+  )
+  const environmentPanelAfterUpwardScroll = await getSingleElementMetrics(
+    control,
+    environmentPanelSelector,
+    'The environment panel after scrolling upward'
+  )
+  assertEnvironmentPanelDidNotMove(
+    environmentPanelAfterUpwardScroll,
+    'The environment panel moved with the upward conversation scroll'
+  )
+  await captureVerificationScreenshot(control, 'environment-panel-scroll-02-upward.png')
+
+  const downwardScrollTop = Number(
+    await control.command('scrollToRatioAsUser', scrollerSelector, { value: '0.75' })
+  )
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
+  await assertDesktopComposerDocked(
+    control,
+    await getSingleElementMetrics(
+      control,
+      scrollerSelector,
+      'The conversation after scrolling down'
+    ),
+    'The composer after scrolling downward while the environment panel is visible'
+  )
+  const environmentPanelAfterDownwardScroll = await getSingleElementMetrics(
+    control,
+    environmentPanelSelector,
+    'The environment panel after scrolling downward'
+  )
+  assert.notEqual(
+    downwardScrollTop,
+    upwardScrollTop,
+    'The conversation did not move between the environment-panel assertions'
+  )
+  assertEnvironmentPanelDidNotMove(
+    environmentPanelAfterDownwardScroll,
+    'The environment panel moved with the downward conversation scroll'
+  )
+  console.log(
+    'Environment panel scroll metrics:',
+    JSON.stringify({
+      afterDownwardScroll: environmentPanelAfterDownwardScroll,
+      afterUpwardScroll: environmentPanelAfterUpwardScroll,
+      beforeScroll: environmentPanelBeforeScroll,
+      downwardScrollTop,
+      upwardScrollTop,
+    })
+  )
+  await captureVerificationScreenshot(control, 'environment-panel-scroll-03-downward.png')
+}
+
 export async function waitForComposerFocus(control, timeoutMs, failureMessage) {
   const focusStartedAt = Date.now()
   let activeElementTestId = ''
@@ -933,30 +1029,7 @@ async function reopenCurrentTurnNavigationTask(
       'Loading the older transcript page changed the assistant-message count'
     )
 
-    const scrollerSelector = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="desktop-workbench-content"]`
-    await control.command('scrollToRatioAsUser', scrollerSelector, { value: '0.15' })
-    await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
-    await assertDesktopComposerDocked(
-      control,
-      await getSingleElementMetrics(
-        control,
-        scrollerSelector,
-        'The paginated conversation after scrolling upward'
-      ),
-      'The composer after scrolling upward in a paginated conversation'
-    )
-    await control.command('scrollToRatioAsUser', scrollerSelector, { value: '0.75' })
-    await new Promise(resolvePromise => setTimeout(resolvePromise, 500))
-    await assertDesktopComposerDocked(
-      control,
-      await getSingleElementMetrics(
-        control,
-        scrollerSelector,
-        'The paginated conversation after scrolling downward'
-      ),
-      'The composer after scrolling downward in a paginated conversation'
-    )
-    await captureVerificationScreenshot(control, 'turn-navigation-00-paginated-scroll-stable.png')
+    await verifyEnvironmentPanelScrollStability(control)
   }
   await control.command('waitFor', '[data-testid="message-turn-navigation-preview"]', {
     text: `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${TURN_NAVIGATION_VIRTUALIZED_BOUNDARY_TURN}`,
@@ -1418,6 +1491,7 @@ export {
   verifyBackgroundGuidanceNavigation,
   verifyForegroundGuidanceScroll,
   verifyTurnNavigationTracksVisibleTurnMessages,
+  verifyEnvironmentPanelScrollStability,
   reopenCurrentTurnNavigationTask,
   verifyStandaloneViewImageTask,
   verifyVisionSidecar,

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1579,36 +1579,6 @@ last_updated = "2026-07-30T00:00:00Z"`
       return
     }
 
-    if (shouldRunDesktopCheckpoint('environment-panel-scroll')) {
-      phase = 'environment-panel-scroll'
-      await control.command('click', '[data-testid="new-chat-button"]')
-      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
-        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
-      })
-      await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
-      control.setScenario('turn_navigation')
-      const environmentPanelTurnCount = E2E_TRANSCRIPT_PAGE_SIZE + 4
-      for (let index = 0; index < environmentPanelTurnCount; index += 1) {
-        const turnNumber = index + 1
-        await sendPrompt(
-          control,
-          ACTIVE_COMPOSER_SELECTOR,
-          `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
-        )
-        await control.command(
-          'waitFor',
-          `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
-          {
-            text: `${TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX}_${turnNumber}`,
-            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-          }
-        )
-      }
-      await verifyEnvironmentPanelScrollStability(control)
-      console.log(`Wework desktop environment-panel-scroll E2E passed. Evidence: ${resultDir}`)
-      return
-    }
-
     if (ATTACHMENT_ONLY) {
       phase = 'attachment-only-sidebar'
       await control.command('click', '[data-testid="new-chat-button"]')
@@ -3128,6 +3098,38 @@ last_updated = "2026-07-30T00:00:00Z"`
       await verifyReconnectRecovery({ composerSelector, control })
       if (shouldStopAfterDesktopCheckpoint('resilience')) {
         console.log(`Wework desktop resilience checkpoint passed. Evidence: ${resultDir}`)
+        return
+      }
+    }
+
+    if (shouldRunDesktopCheckpoint('environment-panel-scroll')) {
+      phase = 'environment-panel-scroll'
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
+        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+      })
+      await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
+      control.setScenario('turn_navigation')
+      const environmentPanelTurnCount = E2E_TRANSCRIPT_PAGE_SIZE + 4
+      for (let index = 0; index < environmentPanelTurnCount; index += 1) {
+        const turnNumber = index + 1
+        await sendPrompt(
+          control,
+          ACTIVE_COMPOSER_SELECTOR,
+          `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
+        )
+        await control.command(
+          'waitFor',
+          `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+          {
+            text: `${TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX}_${turnNumber}`,
+            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+          }
+        )
+      }
+      await verifyEnvironmentPanelScrollStability(control)
+      if (shouldStopAfterDesktopCheckpoint('environment-panel-scroll')) {
+        console.log(`Wework desktop environment-panel-scroll E2E passed. Evidence: ${resultDir}`)
         return
       }
     }

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -30,6 +30,7 @@ import {
   verifyBackgroundTaskPlanRestoration,
   verifyFollowUpMessageRestoration,
   verifyForegroundGuidanceScroll,
+  verifyEnvironmentPanelScrollStability,
   verifyLastUserMessageEdit,
   verifyPausedQueueLifecycle,
   verifyQueuedFollowUpNavigation,
@@ -1575,6 +1576,36 @@ last_updated = "2026-07-30T00:00:00Z"`
       )
       await verifyTurnNavigationTracksVisibleTurnMessages(control, 2)
       console.log(`Wework desktop turn-navigation E2E passed. Evidence: ${resultDir}`)
+      return
+    }
+
+    if (shouldRunDesktopCheckpoint('environment-panel-scroll')) {
+      phase = 'environment-panel-scroll'
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
+        timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+      })
+      await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
+      control.setScenario('turn_navigation')
+      const environmentPanelTurnCount = E2E_TRANSCRIPT_PAGE_SIZE + 4
+      for (let index = 0; index < environmentPanelTurnCount; index += 1) {
+        const turnNumber = index + 1
+        await sendPrompt(
+          control,
+          ACTIVE_COMPOSER_SELECTOR,
+          `${TURN_NAVIGATION_REGRESSION_PROMPT_PREFIX}_${turnNumber}`
+        )
+        await control.command(
+          'waitFor',
+          `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
+          {
+            text: `${TURN_NAVIGATION_REGRESSION_COMPLETION_PREFIX}_${turnNumber}`,
+            timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+          }
+        )
+      }
+      await verifyEnvironmentPanelScrollStability(control)
+      console.log(`Wework desktop environment-panel-scroll E2E passed. Evidence: ${resultDir}`)
       return
     }
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -5930,10 +5930,12 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     const content = screen.getByTestId('desktop-workbench-content')
+    const contentFrame = content.parentElement
+    expect(contentFrame).not.toBeNull()
     const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
     expect(rightPanelShell).toHaveClass('h-full', 'min-h-0', 'overflow-hidden')
     await waitFor(() => {
-      expect(content).toHaveStyle({ width: '420px' })
+      expect(contentFrame).toHaveStyle({ width: '420px' })
       expect(rightPanelShell).toHaveStyle({
         minWidth: '260px',
         width: 'calc(100% - 420px)',
@@ -5941,7 +5943,7 @@ describe('DesktopWorkbenchLayout', () => {
     })
     expect(panel).toHaveClass('min-w-0', 'flex-1', 'basis-0')
     expect(panel).toHaveClass('transition-[opacity,transform]', 'duration-300', 'ease-out')
-    expect(content).toHaveClass(
+    expect(contentFrame).toHaveClass(
       'transition-[width]',
       'duration-[240ms]',
       'ease-[cubic-bezier(0.2,0,0,1)]'
@@ -5953,7 +5955,7 @@ describe('DesktopWorkbenchLayout', () => {
     fireEvent.pointerUp(document)
     expect(document.body).not.toHaveAttribute('data-wework-panel-resizing')
 
-    expect(content).toHaveStyle({ width: '580px' })
+    expect(contentFrame).toHaveStyle({ width: '580px' })
     expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 580px)' })
     expect(screen.getByTestId('workspace-file-tree')).toHaveClass('w-[240px]')
   })
@@ -5974,13 +5976,15 @@ describe('DesktopWorkbenchLayout', () => {
 
     fireEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
     const content = screen.getByTestId('desktop-workbench-content')
+    const contentFrame = content.parentElement
+    expect(contentFrame).not.toBeNull()
     const panelShell = screen.getByTestId('right-workspace-panel-shell')
     const expandButton = screen.getByTestId('toggle-right-workspace-panel-expanded-button')
 
     expect(expandButton).toHaveAttribute('aria-pressed', 'false')
     fireEvent.click(expandButton)
 
-    expect(content).toHaveStyle({ width: '100%' })
+    expect(contentFrame).toHaveStyle({ width: '100%' })
     expect(panelShell).toHaveStyle({ width: '100%' })
     expect(panelShell).toHaveClass('absolute', 'inset-y-0', 'right-0')
     expect(screen.queryByTestId('right-workspace-resize-handle')).not.toBeInTheDocument()
@@ -6005,7 +6009,7 @@ describe('DesktopWorkbenchLayout', () => {
     fireEvent.click(screen.getByTestId('restore-conversation-from-expanded-workspace-button'))
 
     await waitFor(() => {
-      expect(content).toHaveStyle({ width: '420px' })
+      expect(contentFrame).toHaveStyle({ width: '420px' })
       expect(panelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
     })
     expect(screen.getByTestId('right-workspace-resize-handle')).toBeInTheDocument()
@@ -6202,19 +6206,21 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     const content = screen.getByTestId('desktop-workbench-content')
+    const contentFrame = content.parentElement
+    expect(contentFrame).not.toBeNull()
     const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
 
     await waitFor(() => {
-      expect(content).toHaveStyle({ width: '420px' })
+      expect(contentFrame).toHaveStyle({ width: '420px' })
       expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
     })
 
     fireEvent.pointerDown(screen.getByTestId('right-workspace-resize-handle'), { clientX: 422 })
     fireEvent.pointerMove(document, { clientX: 702 })
 
-    expect(content).toHaveClass('transition-none')
+    expect(contentFrame).toHaveClass('transition-none')
     expect(rightPanelShell).toHaveClass('transition-none')
-    expect(content).toHaveStyle({ width: '700px' })
+    expect(contentFrame).toHaveStyle({ width: '700px' })
     expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 700px)' })
 
     fireEvent.pointerMove(document, { clientX: 902 })
@@ -6230,7 +6236,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
 
-    expect(content).toHaveStyle({ width: '420px' })
+    expect(contentFrame).toHaveStyle({ width: '420px' })
     expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
     expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('http://example.com/')
   })
@@ -6521,16 +6527,18 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     const content = screen.getByTestId('desktop-workbench-content')
+    const contentFrame = content.parentElement
+    expect(contentFrame).not.toBeNull()
     const topBar = screen.getByTestId('workbench-topbar')
     const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
     expect(topBar).toHaveStyle({ width: '100%' })
-    expect(content).toHaveClass(
+    expect(contentFrame).toHaveClass(
       'flex-none',
       'transition-[width]',
       'duration-[240ms]',
       'ease-[cubic-bezier(0.2,0,0,1)]'
     )
-    expect(content).toHaveStyle({ width: '100%' })
+    expect(contentFrame).toHaveStyle({ width: '100%' })
     expect(rightPanelShell).toHaveClass(
       'overflow-hidden',
       'opacity-0',
@@ -6549,15 +6557,15 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
 
-    expect(content).toHaveClass(
+    expect(contentFrame).toHaveClass(
       'flex-none',
       'transition-[width]',
       'duration-[240ms]',
       'ease-[cubic-bezier(0.2,0,0,1)]'
     )
-    expect(content).not.toHaveClass('border-r')
+    expect(contentFrame).not.toHaveClass('border-r')
     await waitFor(() => {
-      expect(content).toHaveStyle({ width: '420px' })
+      expect(contentFrame).toHaveStyle({ width: '420px' })
       expect(topBar).toHaveStyle({ width: '420px' })
       expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
     })
@@ -6708,7 +6716,9 @@ describe('DesktopWorkbenchLayout', () => {
     )
     expect(within(tabbar).getAllByText('临时聊天')).toHaveLength(1)
     await waitFor(() => {
-      expect(screen.getByTestId('desktop-workbench-content')).toHaveStyle({ width: '580px' })
+      expect(screen.getByTestId('desktop-workbench-content').parentElement).toHaveStyle({
+        width: '580px',
+      })
       expect(screen.getByTestId('right-workspace-panel-shell')).toHaveStyle({
         width: 'calc(100% - 580px)',
       })
@@ -9003,7 +9013,10 @@ describe('DesktopWorkbenchLayout', () => {
     expect(environmentInfoPanel).toContainElement(environmentInfoPopover)
     expect(environmentInfoPopover).toHaveAttribute('data-environment-info-popover')
     expect(environmentInfoPanel.matches(':has([data-environment-info-popover])')).toBe(true)
-    expect(screen.getByTestId('desktop-workbench-content')).toContainElement(environmentInfoPanel)
+    const conversationScroller = screen.getByTestId('desktop-workbench-content')
+    expect(conversationScroller.firstElementChild).toHaveClass('grid', 'min-h-full', 'grid-cols-1')
+    expect(conversationScroller).not.toContainElement(environmentInfoPanel)
+    expect(conversationScroller.parentElement).toContainElement(environmentInfoPanel)
     expect(environmentInfoPanel).toHaveClass(
       'overflow-hidden',
       'has-[[data-environment-info-popover]]:overflow-visible'

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -9014,13 +9014,18 @@ describe('DesktopWorkbenchLayout', () => {
     expect(environmentInfoPopover).toHaveAttribute('data-environment-info-popover')
     expect(environmentInfoPanel.matches(':has([data-environment-info-popover])')).toBe(true)
     const conversationScroller = screen.getByTestId('desktop-workbench-content')
-    expect(conversationScroller.firstElementChild).toHaveClass('grid', 'min-h-full', 'grid-cols-1')
+    expect(conversationScroller.firstElementChild).toHaveClass(
+      'grid',
+      'min-h-full',
+      'grid-cols-[minmax(0,1fr)_auto]'
+    )
+    expect(screen.getByTestId('environment-info-panel-spacer')).toHaveClass('w-[320px]')
     expect(conversationScroller).not.toContainElement(environmentInfoPanel)
     expect(conversationScroller.parentElement).toContainElement(environmentInfoPanel)
-    expect(environmentInfoPanel).toHaveClass(
-      'overflow-hidden',
-      'has-[[data-environment-info-popover]]:overflow-visible'
+    expect(conversationScroller.parentElement).toBe(
+      screen.getByTestId('desktop-workbench-scroll-frame')
     )
+    expect(environmentInfoPanel).toHaveClass('absolute', 'right-0', 'w-[320px]', 'overflow-visible')
     expect(screen.getByTestId('environment-info-popover')).toHaveClass(
       'w-[300px]',
       'bg-background',
@@ -9091,7 +9096,8 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(screen.queryByTestId('environment-info-popover')).not.toBeInTheDocument()
     expect(environmentInfoPanel.matches(':has([data-environment-info-popover])')).toBe(false)
-    expect(environmentInfoPanel).toHaveClass('overflow-hidden')
+    expect(environmentInfoPanel).toHaveClass('w-0', 'overflow-hidden')
+    expect(screen.getByTestId('environment-info-panel-spacer')).toHaveClass('w-0')
   })
 
   test('shares the pinned summary state across tasks and resets it on app-shell remount', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -4397,570 +4397,590 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           style={{ maxWidth: chatColumnMaxWidth, width: chatColumnWidth }}
         />
         <div
-          ref={workbenchScrollRef}
-          data-testid="desktop-workbench-content"
-          data-scroll-origin={hasConversation ? 'bottom' : 'top'}
-          data-embedded-browser-label={defaultEmbeddedBrowserLabel}
           className={cn(
             'relative flex h-full min-w-0 flex-none',
-            hasConversation
-              ? 'flex-col-reverse overflow-x-hidden overflow-y-auto [overflow-anchor:none]'
-              : 'overflow-hidden',
-            rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS,
-            showPageTopBar && 'pt-11'
+            rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
           )}
           style={{ maxWidth: chatColumnMaxWidth, width: chatColumnWidth }}
         >
-          <div className="grid min-h-full w-full shrink-0 grid-cols-[minmax(0,1fr)_auto]">
-            {isBootstrapping ? (
-              <div className="flex min-w-0 flex-1" data-testid="desktop-workbench-loading" />
-            ) : activeLocalHarnessSession ? (
-              <div className="relative flex min-h-0 min-w-0">
-                {activeLocalHarnessSession.active ? (
-                  <CentralHarnessTerminal
-                    sessionId={activeLocalHarnessSession.sessionId}
-                    title={activeLocalHarnessSession.title}
-                    cwd={activeLocalHarnessSession.cwd}
-                    active={paneActive && workbenchVisible}
-                    showHeader={false}
-                    onClose={
-                      activeLocalHarnessSession.isPrimary
-                        ? undefined
-                        : () => {
-                            void onLocalHarnessSessionClose(activeLocalHarnessSession.sessionId)
-                          }
+          <div
+            ref={workbenchScrollRef}
+            data-testid="desktop-workbench-content"
+            data-scroll-origin={hasConversation ? 'bottom' : 'top'}
+            data-embedded-browser-label={defaultEmbeddedBrowserLabel}
+            className={cn(
+              'relative flex h-full min-w-0 flex-1',
+              hasConversation
+                ? 'flex-col-reverse overflow-x-hidden overflow-y-auto [overflow-anchor:none]'
+                : 'overflow-hidden',
+              showPageTopBar && 'pt-11'
+            )}
+          >
+            <div className="grid min-h-full w-full shrink-0 grid-cols-1">
+              {isBootstrapping ? (
+                <div className="flex min-w-0 flex-1" data-testid="desktop-workbench-loading" />
+              ) : activeLocalHarnessSession ? (
+                <div className="relative flex min-h-0 min-w-0">
+                  {activeLocalHarnessSession.active ? (
+                    <CentralHarnessTerminal
+                      sessionId={activeLocalHarnessSession.sessionId}
+                      title={activeLocalHarnessSession.title}
+                      cwd={activeLocalHarnessSession.cwd}
+                      active={paneActive && workbenchVisible}
+                      showHeader={false}
+                      onClose={
+                        activeLocalHarnessSession.isPrimary
+                          ? undefined
+                          : () => {
+                              void onLocalHarnessSessionClose(activeLocalHarnessSession.sessionId)
+                            }
+                      }
+                      onExit={() => onLocalHarnessSessionExit(activeLocalHarnessSession.sessionId)}
+                    />
+                  ) : (
+                    <div
+                      data-testid="local-harness-session-resuming"
+                      className={cn(
+                        'flex min-h-0 min-w-0 flex-1 items-center justify-center text-sm',
+                        activeHarnessDisplayError ? 'text-destructive' : 'text-text-secondary'
+                      )}
+                    >
+                      {activeHarnessDisplayError ? (
+                        activeHarnessDisplayError
+                      ) : (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                          {t('workbench.harness_resuming', {
+                            name: localHarnessLabel(activeLocalHarnessSession.harnessId),
+                            defaultValue: `正在恢复 ${localHarnessLabel(activeLocalHarnessSession.harnessId)} 会话…`,
+                          })}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ) : hasConversation ? (
+                <div className="relative flex min-h-full min-w-0 shrink-0 flex-col">
+                  <ScrollableMessageArea
+                    messages={paneMessages}
+                    loading={paneSession.transcriptLoading}
+                    isWaitingForAssistant={
+                      !isCreatingWorktree && paneSession.status.isWaitingForAssistantIndicator
                     }
-                    onExit={() => onLocalHarnessSessionExit(activeLocalHarnessSession.sessionId)}
-                  />
-                ) : (
-                  <div
-                    data-testid="local-harness-session-resuming"
-                    className={cn(
-                      'flex min-h-0 min-w-0 flex-1 items-center justify-center text-sm',
-                      activeHarnessDisplayError ? 'text-destructive' : 'text-text-secondary'
-                    )}
-                  >
-                    {activeHarnessDisplayError ? (
-                      activeHarnessDisplayError
-                    ) : (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-                        {t('workbench.harness_resuming', {
-                          name: localHarnessLabel(activeLocalHarnessSession.harnessId),
-                          defaultValue: `正在恢复 ${localHarnessLabel(activeLocalHarnessSession.harnessId)} 会话…`,
-                        })}
-                      </>
-                    )}
-                  </div>
-                )}
-              </div>
-            ) : hasConversation ? (
-              <div className="relative flex min-h-full min-w-0 shrink-0 flex-col">
-                <ScrollableMessageArea
-                  messages={paneMessages}
-                  loading={paneSession.transcriptLoading}
-                  isWaitingForAssistant={
-                    !isCreatingWorktree && paneSession.status.isWaitingForAssistantIndicator
-                  }
-                  hasMoreBefore={paneSession.transcriptHasMoreBefore}
-                  loadingMoreBefore={paneSession.transcriptLoadingMoreBefore}
-                  turnNavigation={paneSession.turnNavigation}
-                  loadedTranscriptRanges={paneSession.loadedTranscriptRanges}
-                  autoScrollSuspended={!paneVisible || !workbenchVisible}
-                  onLoadMoreBefore={paneSession.loadMoreTranscriptBefore}
-                  onLoadFullTranscript={paneSession.loadFullTranscript}
-                  loadingFullTranscript={paneSession.transcriptLoadingFullContent}
-                  onLoadTurnNavigationItem={paneSession.loadTranscriptTurnNavigationItem}
-                  onLoadTranscriptGap={paneSession.loadTranscriptGap}
-                  conversationKey={
-                    currentRuntimeTask
-                      ? `${currentRuntimeTask.deviceId}:${currentRuntimeTask.taskId}`
-                      : null
-                  }
-                  className="min-h-full"
-                  scrollTestId="desktop-chat-scroll"
-                  externalScrollRef={workbenchScrollRef}
-                  turnNavigationPortalTarget={turnNavigationPortalTarget}
-                  scrollerClassName="min-h-full overflow-visible"
-                  contentClassName={rightPanelExpanded ? 'invisible' : undefined}
-                  messageListClassName={cn(
-                    DESKTOP_MESSAGE_LIST_CLASS,
-                    chatContentResizing && 'transition-none'
-                  )}
-                  contentFooter={
-                    isCreatingWorktree ? (
-                      <WorktreeCreationStatus className="py-8" />
-                    ) : (
-                      <PluginWorkspaceConversationResult
-                        taskId={currentRuntimeTask?.taskId}
-                        workspacePath={
-                          currentRuntimeTask?.workspacePath || runtimeTaskWorkspacePath
-                        }
-                        messages={paneMessages}
-                        waiting={paneSession.status.isWaitingForAssistantIndicator}
-                        onOpenFile={path => void openWorkspaceFileFromMessage(path)}
-                        onSendAction={(message, additionalContext) =>
-                          paneSession.send(message, { additionalContext })
-                        }
-                      />
-                    )
-                  }
-                  contentFooterClassName={DESKTOP_MESSAGE_LIST_WIDTH_CLASS}
-                  stickyFooterClassName={cn(
-                    DESKTOP_STICKY_COMPOSER_FOOTER_CLASS,
-                    hasMainBackground
-                      ? 'from-transparent via-transparent'
-                      : 'from-background via-background',
-                    chatContentResizing && 'transition-none',
-                    rightPanelExpanded && 'z-critical'
-                  )}
-                  stickyFooter={
-                    temporaryChatExpanded || isCreatingWorktree ? null : (
-                      <>
-                        <div
-                          className={cn(
-                            DESKTOP_STICKY_COMPOSER_BACKDROP_CLASS,
-                            hasMainBackground
-                              ? 'from-transparent via-transparent'
-                              : 'from-background via-background'
-                          )}
-                          data-testid="desktop-floating-composer-backdrop"
-                        />
-                        <div
-                          className={cn(
-                            DESKTOP_STICKY_COMPOSER_LAYER_CLASS,
-                            chatContentResizing && 'transition-none',
-                            rightPanelExpanded && 'z-critical'
-                          )}
-                          data-testid="desktop-floating-composer-layer"
-                        >
-                          <div
-                            className="pointer-events-auto"
-                            data-testid="desktop-floating-composer-card"
-                          >
-                            {rightPanelExpanded && (
-                              <button
-                                type="button"
-                                data-testid="restore-conversation-from-expanded-workspace-button"
-                                className="mb-1 flex h-8 w-full items-center justify-between rounded-xl border border-border/45 bg-background/95 px-4 text-xs text-text-secondary shadow-sm hover:bg-muted hover:text-text-primary"
-                                onClick={() => setRightPanelExpanded(false)}
-                              >
-                                <span>{t('workbench.latest_conversation_turn')}</span>
-                                <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                              </button>
-                            )}
-                            {connectorAuthGate.pending ? (
-                              <ConnectorAuthCard
-                                target={connectorAuthGate.pending.target}
-                                title={connectorAuthGate.pending.title}
-                                onSuccess={() => {
-                                  void connectorAuthGate.completePending()
-                                }}
-                                onCancel={connectorAuthGate.clearPending}
-                              />
-                            ) : !rightPanelExpanded ? (
-                              <>
-                                {showConversationDeviceBanner ? (
-                                  <ConversationDeviceOfflineBanner
-                                    device={activeDevice}
-                                    deviceId={activeDeviceId}
-                                    className="mb-2"
-                                  />
-                                ) : (
-                                  <DeviceStatusPrompt
-                                    devices={devices}
-                                    upgradingDevices={upgradingDevices}
-                                    onUpgradeDevice={upgradeDevice}
-                                    onOpenCloudDeviceSettings={requestOpenCloudDeviceSettings}
-                                    activeDeviceId={activeDeviceId}
-                                    requiresOnlineCompatibleDevice={noStandaloneCompatibleDevice}
-                                    hideAvailableUpdates
-                                    className="mb-2"
-                                  />
-                                )}
-                                {pendingRequestUserInput ? (
-                                  <RequestUserInputCard
-                                    key={
-                                      requestUserInputPayloadKey(pendingRequestUserInput) ??
-                                      'implementation-plan'
-                                    }
-                                    payload={pendingRequestUserInput}
-                                    onSubmit={response => {
-                                      const isImplementationPlanRequest =
-                                        isImplementationPlanRequestUserInput(
-                                          pendingRequestUserInput
-                                        )
-                                      const shouldImplementPlan =
-                                        isImplementationPlanRequest &&
-                                        isImplementationPlanConfirmationResponse(response)
-                                      return paneSession.sendRequestUserInputResponse(response, {
-                                        appendUserMessage: isImplementationPlanRequest,
-                                        forceDefaultCollaborationMode: shouldImplementPlan,
-                                      })
-                                    }}
-                                    onIgnore={() =>
-                                      paneSession.ignoreRequestUserInput(pendingRequestUserInput)
-                                    }
-                                  />
-                                ) : (
-                                  <>
-                                    {supervisor && (
-                                      <SupervisorSuggestionCards
-                                        suggestions={supervisor.suggestions}
-                                        onAccept={suggestion =>
-                                          resolveTaskSupervisorSuggestion(suggestion, 'accepted')
-                                        }
-                                        onDismiss={suggestion =>
-                                          resolveTaskSupervisorSuggestion(suggestion, 'dismissed')
-                                        }
-                                      />
-                                    )}
-                                    <BufferedChatInput
-                                      insertion={conversationSelectionInsertion}
-                                      value={paneSession.input}
-                                      onChange={paneSession.setInput}
-                                      onDraftEdit={paneSession.clearError}
-                                      onSubmit={submitPaneInput}
-                                      disabled={
-                                        composerDisabled || !paneVisible || !workbenchVisible
-                                      }
-                                      pluginPickerIconOnly={hasConversation}
-                                      submitDisabled={paneSession.status.isSubmitting}
-                                      error={paneSession.error}
-                                      disabledReason={inlineComposerDisabledReason}
-                                      placeholder={t(
-                                        'workbench.follow_up_placeholder',
-                                        '要求后续变更'
-                                      )}
-                                      variant="desktop"
-                                      projectChat={projectChatWithModelSelectorSignal}
-                                      projectWork={branchNameProjectWork}
-                                      showProjectWorkBar={false}
-                                      queuedMessages={paneQueuedMessages}
-                                      guidanceMessages={paneGuidanceMessages}
-                                      codeComments={paneSession.codeCommentContexts}
-                                      cloudMentionCandidates={visibleCloudMentionCandidates}
-                                      cloudProjectCandidates={cloudProjectMentionCandidates}
-                                      cloudSpaceEnabled={
-                                        experimentalFeaturesEnabled &&
-                                        Boolean(services?.deliveryApi)
-                                      }
-                                      onSelectCloudProject={handleSelectCloudProject}
-                                      contextHeader={projectSpaceContext}
-                                      isStreaming={paneIsBusy}
-                                      onPause={pauseCurrentResponse}
-                                      onCompactContext={
-                                        currentRuntimeUsesCodex ||
-                                        currentRuntimeTask?.runtime === 'claude_code'
-                                          ? compactCurrentContext
-                                          : undefined
-                                      }
-                                      goal={paneSession.goal}
-                                      goalContinuing={paneSession.goalContinuing}
-                                      taskPlan={paneSession.taskPlan}
-                                      goalDraftActive={paneSession.goalDraftActive}
-                                      onSetGoal={composerSupportsGoal ? setCurrentGoal : undefined}
-                                      onConfigureSupervisor={
-                                        supervisorFeatureAvailable
-                                          ? openSupervisorDialog
-                                          : undefined
-                                      }
-                                      supervisorEnabled={Boolean(
-                                        supervisor || pendingSupervisorConfig
-                                      )}
-                                      supervisorPending={Boolean(
-                                        !currentRuntimeTask && pendingSupervisorConfig
-                                      )}
-                                      onCancelGoalDraft={paneSession.cancelGoalDraft}
-                                      onEditGoal={paneSession.editCurrentGoal}
-                                      onPauseGoal={pauseCurrentGoal}
-                                      onResumeGoal={resumeCurrentGoal}
-                                      onClearGoal={clearCurrentGoal}
-                                      onCancelQueuedMessage={paneSession.cancelQueuedMessage}
-                                      onReorderQueuedMessages={paneSession.reorderQueuedMessages}
-                                      queuePaused={paneSession.queuedMessagesPaused}
-                                      onResumeQueue={paneSession.resumeQueuedMessages}
-                                      onResumeQueueWithInput={
-                                        paneSession.resumeQueuedMessagesWithInput
-                                      }
-                                      onClearQueue={paneSession.clearQueuedMessages}
-                                      onSendQueuedAsGuidance={
-                                        currentRuntimeUsesCodex
-                                          ? paneSession.sendQueuedAsGuidance
-                                          : undefined
-                                      }
-                                      onInterruptAndSendQueuedMessage={
-                                        paneSession.interruptAndSendQueued
-                                      }
-                                      onEditQueuedMessage={paneSession.editQueuedMessage}
-                                      onCancelGuidanceMessage={paneSession.cancelGuidanceMessage}
-                                      onClearCodeComments={paneSession.clearCodeComments}
-                                      onOpenSkillFile={openLocalSkillFile}
-                                      workspaceTarget={composerWorkspaceTarget}
-                                      workspaceFileApi={workspaceFileApi}
-                                    />
-                                  </>
-                                )}
-                              </>
-                            ) : null}
-                          </div>
-                        </div>
-                      </>
-                    )
-                  }
-                  scrollButtonClassName={DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS}
-                  devices={devices}
-                  onRetryFailedMessage={message => {
-                    void paneSession.retryFailedMessage(message)
-                  }}
-                  onSwitchModelForFailedMessage={message => {
-                    pendingModelRetryRef.current = message
-                    setModelSelectorOpenSignal(signal => signal + 1)
-                  }}
-                  onLoadFileChangesDiff={(subtaskId, fileChanges) =>
-                    loadTurnFileChangesDiff(
-                      subtaskId,
-                      paneMessages,
-                      fileChanges,
+                    hasMoreBefore={paneSession.transcriptHasMoreBefore}
+                    loadingMoreBefore={paneSession.transcriptLoadingMoreBefore}
+                    turnNavigation={paneSession.turnNavigation}
+                    loadedTranscriptRanges={paneSession.loadedTranscriptRanges}
+                    autoScrollSuspended={!paneVisible || !workbenchVisible}
+                    onLoadMoreBefore={paneSession.loadMoreTranscriptBefore}
+                    onLoadFullTranscript={paneSession.loadFullTranscript}
+                    loadingFullTranscript={paneSession.transcriptLoadingFullContent}
+                    onLoadTurnNavigationItem={paneSession.loadTranscriptTurnNavigationItem}
+                    onLoadTranscriptGap={paneSession.loadTranscriptGap}
+                    conversationKey={
                       currentRuntimeTask
-                    )
-                  }
-                  onRevertFileChanges={(subtaskId, fileChanges) =>
-                    revertTurnFileChanges(subtaskId, paneMessages, fileChanges, currentRuntimeTask)
-                  }
-                  onOpenFileChangesReview={({
-                    subtaskId,
-                    loadDiff,
-                    reviewTitle,
-                    defaultFileTreeVisible,
-                    focusFilePath,
-                  }) => {
-                    previousTurnReviewRef.current = {
-                      loadDiff,
-                      defaultFileTreeVisible,
-                      sourceSubtaskId: subtaskId,
+                        ? `${currentRuntimeTask.deviceId}:${currentRuntimeTask.taskId}`
+                        : null
                     }
-                    setHasPreviousTurnReview(true)
-                    void openReviewFromDiffLoader(loadDiff, {
+                    className="min-h-full"
+                    scrollTestId="desktop-chat-scroll"
+                    externalScrollRef={workbenchScrollRef}
+                    turnNavigationPortalTarget={turnNavigationPortalTarget}
+                    scrollerClassName="min-h-full overflow-visible"
+                    contentClassName={rightPanelExpanded ? 'invisible' : undefined}
+                    messageListClassName={cn(
+                      DESKTOP_MESSAGE_LIST_CLASS,
+                      chatContentResizing && 'transition-none'
+                    )}
+                    contentFooter={
+                      isCreatingWorktree ? (
+                        <WorktreeCreationStatus className="py-8" />
+                      ) : (
+                        <PluginWorkspaceConversationResult
+                          taskId={currentRuntimeTask?.taskId}
+                          workspacePath={
+                            currentRuntimeTask?.workspacePath || runtimeTaskWorkspacePath
+                          }
+                          messages={paneMessages}
+                          waiting={paneSession.status.isWaitingForAssistantIndicator}
+                          onOpenFile={path => void openWorkspaceFileFromMessage(path)}
+                          onSendAction={(message, additionalContext) =>
+                            paneSession.send(message, { additionalContext })
+                          }
+                        />
+                      )
+                    }
+                    contentFooterClassName={DESKTOP_MESSAGE_LIST_WIDTH_CLASS}
+                    stickyFooterClassName={cn(
+                      DESKTOP_STICKY_COMPOSER_FOOTER_CLASS,
+                      hasMainBackground
+                        ? 'from-transparent via-transparent'
+                        : 'from-background via-background',
+                      chatContentResizing && 'transition-none',
+                      rightPanelExpanded && 'z-critical'
+                    )}
+                    stickyFooter={
+                      temporaryChatExpanded || isCreatingWorktree ? null : (
+                        <>
+                          <div
+                            className={cn(
+                              DESKTOP_STICKY_COMPOSER_BACKDROP_CLASS,
+                              hasMainBackground
+                                ? 'from-transparent via-transparent'
+                                : 'from-background via-background'
+                            )}
+                            data-testid="desktop-floating-composer-backdrop"
+                          />
+                          <div
+                            className={cn(
+                              DESKTOP_STICKY_COMPOSER_LAYER_CLASS,
+                              chatContentResizing && 'transition-none',
+                              rightPanelExpanded && 'z-critical'
+                            )}
+                            data-testid="desktop-floating-composer-layer"
+                          >
+                            <div
+                              className="pointer-events-auto"
+                              data-testid="desktop-floating-composer-card"
+                            >
+                              {rightPanelExpanded && (
+                                <button
+                                  type="button"
+                                  data-testid="restore-conversation-from-expanded-workspace-button"
+                                  className="mb-1 flex h-8 w-full items-center justify-between rounded-xl border border-border/45 bg-background/95 px-4 text-xs text-text-secondary shadow-sm hover:bg-muted hover:text-text-primary"
+                                  onClick={() => setRightPanelExpanded(false)}
+                                >
+                                  <span>{t('workbench.latest_conversation_turn')}</span>
+                                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                                </button>
+                              )}
+                              {connectorAuthGate.pending ? (
+                                <ConnectorAuthCard
+                                  target={connectorAuthGate.pending.target}
+                                  title={connectorAuthGate.pending.title}
+                                  onSuccess={() => {
+                                    void connectorAuthGate.completePending()
+                                  }}
+                                  onCancel={connectorAuthGate.clearPending}
+                                />
+                              ) : !rightPanelExpanded ? (
+                                <>
+                                  {showConversationDeviceBanner ? (
+                                    <ConversationDeviceOfflineBanner
+                                      device={activeDevice}
+                                      deviceId={activeDeviceId}
+                                      className="mb-2"
+                                    />
+                                  ) : (
+                                    <DeviceStatusPrompt
+                                      devices={devices}
+                                      upgradingDevices={upgradingDevices}
+                                      onUpgradeDevice={upgradeDevice}
+                                      onOpenCloudDeviceSettings={requestOpenCloudDeviceSettings}
+                                      activeDeviceId={activeDeviceId}
+                                      requiresOnlineCompatibleDevice={noStandaloneCompatibleDevice}
+                                      hideAvailableUpdates
+                                      className="mb-2"
+                                    />
+                                  )}
+                                  {pendingRequestUserInput ? (
+                                    <RequestUserInputCard
+                                      key={
+                                        requestUserInputPayloadKey(pendingRequestUserInput) ??
+                                        'implementation-plan'
+                                      }
+                                      payload={pendingRequestUserInput}
+                                      onSubmit={response => {
+                                        const isImplementationPlanRequest =
+                                          isImplementationPlanRequestUserInput(
+                                            pendingRequestUserInput
+                                          )
+                                        const shouldImplementPlan =
+                                          isImplementationPlanRequest &&
+                                          isImplementationPlanConfirmationResponse(response)
+                                        return paneSession.sendRequestUserInputResponse(response, {
+                                          appendUserMessage: isImplementationPlanRequest,
+                                          forceDefaultCollaborationMode: shouldImplementPlan,
+                                        })
+                                      }}
+                                      onIgnore={() =>
+                                        paneSession.ignoreRequestUserInput(pendingRequestUserInput)
+                                      }
+                                    />
+                                  ) : (
+                                    <>
+                                      {supervisor && (
+                                        <SupervisorSuggestionCards
+                                          suggestions={supervisor.suggestions}
+                                          onAccept={suggestion =>
+                                            resolveTaskSupervisorSuggestion(suggestion, 'accepted')
+                                          }
+                                          onDismiss={suggestion =>
+                                            resolveTaskSupervisorSuggestion(suggestion, 'dismissed')
+                                          }
+                                        />
+                                      )}
+                                      <BufferedChatInput
+                                        insertion={conversationSelectionInsertion}
+                                        value={paneSession.input}
+                                        onChange={paneSession.setInput}
+                                        onDraftEdit={paneSession.clearError}
+                                        onSubmit={submitPaneInput}
+                                        disabled={
+                                          composerDisabled || !paneVisible || !workbenchVisible
+                                        }
+                                        pluginPickerIconOnly={hasConversation}
+                                        submitDisabled={paneSession.status.isSubmitting}
+                                        error={paneSession.error}
+                                        disabledReason={inlineComposerDisabledReason}
+                                        placeholder={t(
+                                          'workbench.follow_up_placeholder',
+                                          '要求后续变更'
+                                        )}
+                                        variant="desktop"
+                                        projectChat={projectChatWithModelSelectorSignal}
+                                        projectWork={branchNameProjectWork}
+                                        showProjectWorkBar={false}
+                                        queuedMessages={paneQueuedMessages}
+                                        guidanceMessages={paneGuidanceMessages}
+                                        codeComments={paneSession.codeCommentContexts}
+                                        cloudMentionCandidates={visibleCloudMentionCandidates}
+                                        cloudProjectCandidates={cloudProjectMentionCandidates}
+                                        cloudSpaceEnabled={
+                                          experimentalFeaturesEnabled &&
+                                          Boolean(services?.deliveryApi)
+                                        }
+                                        onSelectCloudProject={handleSelectCloudProject}
+                                        contextHeader={projectSpaceContext}
+                                        isStreaming={paneIsBusy}
+                                        onPause={pauseCurrentResponse}
+                                        onCompactContext={
+                                          currentRuntimeUsesCodex ||
+                                          currentRuntimeTask?.runtime === 'claude_code'
+                                            ? compactCurrentContext
+                                            : undefined
+                                        }
+                                        goal={paneSession.goal}
+                                        goalContinuing={paneSession.goalContinuing}
+                                        taskPlan={paneSession.taskPlan}
+                                        goalDraftActive={paneSession.goalDraftActive}
+                                        onSetGoal={
+                                          composerSupportsGoal ? setCurrentGoal : undefined
+                                        }
+                                        onConfigureSupervisor={
+                                          supervisorFeatureAvailable
+                                            ? openSupervisorDialog
+                                            : undefined
+                                        }
+                                        supervisorEnabled={Boolean(
+                                          supervisor || pendingSupervisorConfig
+                                        )}
+                                        supervisorPending={Boolean(
+                                          !currentRuntimeTask && pendingSupervisorConfig
+                                        )}
+                                        onCancelGoalDraft={paneSession.cancelGoalDraft}
+                                        onEditGoal={paneSession.editCurrentGoal}
+                                        onPauseGoal={pauseCurrentGoal}
+                                        onResumeGoal={resumeCurrentGoal}
+                                        onClearGoal={clearCurrentGoal}
+                                        onCancelQueuedMessage={paneSession.cancelQueuedMessage}
+                                        onReorderQueuedMessages={paneSession.reorderQueuedMessages}
+                                        queuePaused={paneSession.queuedMessagesPaused}
+                                        onResumeQueue={paneSession.resumeQueuedMessages}
+                                        onResumeQueueWithInput={
+                                          paneSession.resumeQueuedMessagesWithInput
+                                        }
+                                        onClearQueue={paneSession.clearQueuedMessages}
+                                        onSendQueuedAsGuidance={
+                                          currentRuntimeUsesCodex
+                                            ? paneSession.sendQueuedAsGuidance
+                                            : undefined
+                                        }
+                                        onInterruptAndSendQueuedMessage={
+                                          paneSession.interruptAndSendQueued
+                                        }
+                                        onEditQueuedMessage={paneSession.editQueuedMessage}
+                                        onCancelGuidanceMessage={paneSession.cancelGuidanceMessage}
+                                        onClearCodeComments={paneSession.clearCodeComments}
+                                        onOpenSkillFile={openLocalSkillFile}
+                                        workspaceTarget={composerWorkspaceTarget}
+                                        workspaceFileApi={workspaceFileApi}
+                                      />
+                                    </>
+                                  )}
+                                </>
+                              ) : null}
+                            </div>
+                          </div>
+                        </>
+                      )
+                    }
+                    scrollButtonClassName={DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS}
+                    devices={devices}
+                    onRetryFailedMessage={message => {
+                      void paneSession.retryFailedMessage(message)
+                    }}
+                    onSwitchModelForFailedMessage={message => {
+                      pendingModelRetryRef.current = message
+                      setModelSelectorOpenSignal(signal => signal + 1)
+                    }}
+                    onLoadFileChangesDiff={(subtaskId, fileChanges) =>
+                      loadTurnFileChangesDiff(
+                        subtaskId,
+                        paneMessages,
+                        fileChanges,
+                        currentRuntimeTask
+                      )
+                    }
+                    onRevertFileChanges={(subtaskId, fileChanges) =>
+                      revertTurnFileChanges(
+                        subtaskId,
+                        paneMessages,
+                        fileChanges,
+                        currentRuntimeTask
+                      )
+                    }
+                    onOpenFileChangesReview={({
+                      subtaskId,
+                      loadDiff,
                       reviewTitle,
-                      reviewMode: 'previous-turn',
                       defaultFileTreeVisible,
                       focusFilePath,
-                      sourceSubtaskId: subtaskId,
-                    })
-                  }}
-                  fileChangesDiffPreviewDisabledSubtaskId={fileChangesDiffPreviewDisabledSubtaskId}
-                  onOpenWorkspaceFile={openWorkspaceFileFromMessage}
-                  onOpenLocalSkillFile={openLocalSkillFile}
-                  onRequestUserInputSubmit={paneSession.sendRequestUserInputResponse}
-                  onRequestUserInputIgnore={paneSession.ignoreRequestUserInput}
-                  onOpenAssistantPlan={openAssistantPlan}
-                  onEditLastUserMessage={paneSession.editLastUserMessage}
-                  canEditLastUserMessage={canEditLastUserMessage}
-                  onForkMessage={
-                    currentRuntimeUsesCodex
-                      ? message => {
-                          const workspacePath =
-                            currentRuntimeTask?.workspacePath || runtimeTaskWorkspacePath
-                          if (!currentRuntimeTask || !message.turnId || !workspacePath) return
-                          return forkCurrentRuntimeTask(
-                            {
-                              deviceId: currentRuntimeTask.deviceId,
-                              workspacePath,
-                            },
-                            { lastTurnId: message.turnId }
-                          )
-                        }
-                      : undefined
-                  }
-                  hideRequestUserInputBlocks={Boolean(pendingRequestUserInput)}
-                  hiddenRequestUserInputIds={paneSession.answeredRequestUserInputIds}
-                  onAddSelectionToConversation={addSelectionToConversation}
-                  onAskSelectionInSidebar={askSelectionInSidebar}
-                />
-              </div>
-            ) : rightPanelExpanded ? null : (
-              <DesktopEmptyTaskLauncher
-                projectName={currentProject?.name}
-                onOpenProjectSelector={anchorElement => {
-                  setProjectMenuAnchorElement(anchorElement)
-                  setProjectMenuOpenSignal(signal => signal + 1)
-                }}
-                onSelectSuggestion={selectTaskSuggestion}
-                composer={
-                  rightPanelExpanded ? null : (
-                    <>
-                      <DeviceStatusPrompt
-                        devices={devices}
-                        upgradingDevices={upgradingDevices}
-                        onUpgradeDevice={upgradeDevice}
-                        onOpenCloudDeviceSettings={requestOpenCloudDeviceSettings}
-                        activeDeviceId={activeDeviceId}
-                        requiresOnlineCompatibleDevice={noStandaloneCompatibleDevice}
-                        hideAvailableUpdates
-                        className="mb-3"
-                      />
-                      <BufferedChatInput
-                        value={paneSession.input}
-                        onChange={paneSession.setInput}
-                        onDraftEdit={() => {
-                          paneSession.clearError?.()
-                          setCentralHarnessError(null)
-                        }}
-                        onSubmit={submitWorkbenchInput}
-                        disabled={
-                          centralHarnessStarting ||
-                          ((activeNewChatRuntime === 'codex' ||
-                            activeNewChatRuntime === 'claude_code') &&
-                            composerDisabled) ||
-                          !paneVisible ||
-                          !workbenchVisible
-                        }
-                        submitDisabled={
-                          centralHarnessStarting ||
-                          ((activeNewChatRuntime === 'codex' ||
-                            activeNewChatRuntime === 'claude_code') &&
-                            paneSession.status.isSubmitting)
-                        }
-                        error={centralHarnessError ?? paneSession.error}
-                        disabledReason={
-                          activeNewChatRuntime === 'codex' || activeNewChatRuntime === 'claude_code'
-                            ? inlineComposerDisabledReason
-                            : undefined
-                        }
-                        placeholder={
-                          showComposerProjectMenuAction
-                            ? 'values' in popoutComposerPlaceholder
-                              ? t(popoutComposerPlaceholder.key, popoutComposerPlaceholder.values)
-                              : t(popoutComposerPlaceholder.key)
-                            : t('workbench.input_placeholder', '随心输入')
-                        }
-                        variant="desktop"
-                        projectChat={projectChatWithModelSelectorSignal}
-                        projectWork={emptyProjectWork}
-                        projectWorkBarMiddleContext={projectSpaceContext}
-                        projectWorkBarTrailingContext={
-                          experimentalFeaturesEnabled ? (
-                            <WorkbenchHarnessSelector
-                              runtime={activeNewChatRuntime}
-                              harnesses={localHarnesses}
-                              enabledHarnesses={enabledLocalHarnesses.map(
-                                preference => preference.id
-                              )}
-                              loading={localHarnessesLoading}
-                              detectionFailed={localHarnessDetectionFailed}
-                              onRuntimeChange={runtime => {
-                                setCentralHarnessError(null)
-                                setNewChatRuntime(runtime)
-                              }}
-                            />
-                          ) : undefined
-                        }
-                        modelSelectorOverride={
-                          selectedHarnessPreference ? (
-                            <WorkbenchHarnessModelSelector
-                              harnessId={selectedHarnessPreference.id}
-                              models={harnessModelOptions}
-                              selectedModel={selectedHarnessModel}
-                              onModelChange={model => {
-                                setLocalHarnessModelKeys(current => ({
-                                  ...current,
-                                  [selectedHarnessPreference.id]: model?.key ?? null,
-                                }))
-                                const localHarnesses = localHarnessPreferences.map(preference =>
-                                  preference.id === selectedHarnessPreference.id
-                                    ? { ...preference, modelKey: model?.key ?? null }
-                                    : preference
-                                )
-                                void updateAppPreferences({ localHarnesses }).catch(error => {
-                                  console.error('Failed to save harness model selection:', error)
-                                  setCentralHarnessError(
-                                    t(
-                                      'workbench.harness_model_save_failed',
-                                      '编码工具模型选择保存失败'
-                                    )
-                                  )
-                                })
-                              }}
-                            />
-                          ) : undefined
-                        }
-                        showWorkspaceMenu={showComposerProjectMenuAction}
-                        queuedMessages={paneQueuedMessages}
-                        guidanceMessages={paneGuidanceMessages}
-                        codeComments={paneSession.codeCommentContexts}
-                        cloudMentionCandidates={visibleCloudMentionCandidates}
-                        cloudProjectCandidates={cloudProjectMentionCandidates}
-                        cloudSpaceEnabled={
-                          experimentalFeaturesEnabled && Boolean(services?.deliveryApi)
-                        }
-                        onSelectCloudProject={handleSelectCloudProject}
-                        isStreaming={paneIsBusy}
-                        onPause={pauseCurrentResponse}
-                        onCompactContext={
-                          activeNewChatRuntime === 'codex' || activeNewChatRuntime === 'claude_code'
-                            ? compactCurrentContext
-                            : undefined
-                        }
-                        goal={paneSession.goal}
-                        goalContinuing={paneSession.goalContinuing}
-                        taskPlan={paneSession.taskPlan}
-                        goalDraftActive={paneSession.goalDraftActive}
-                        onSetGoal={composerSupportsGoal ? setCurrentGoal : undefined}
-                        onConfigureSupervisor={
-                          supervisorFeatureAvailable ? openSupervisorDialog : undefined
-                        }
-                        supervisorEnabled={Boolean(supervisor || pendingSupervisorConfig)}
-                        supervisorPending={Boolean(!currentRuntimeTask && pendingSupervisorConfig)}
-                        onCancelGoalDraft={paneSession.cancelGoalDraft}
-                        onEditGoal={paneSession.editCurrentGoal}
-                        onPauseGoal={pauseCurrentGoal}
-                        onResumeGoal={resumeCurrentGoal}
-                        onClearGoal={clearCurrentGoal}
-                        onCancelQueuedMessage={paneSession.cancelQueuedMessage}
-                        onReorderQueuedMessages={paneSession.reorderQueuedMessages}
-                        queuePaused={paneSession.queuedMessagesPaused}
-                        onResumeQueue={paneSession.resumeQueuedMessages}
-                        onResumeQueueWithInput={paneSession.resumeQueuedMessagesWithInput}
-                        onClearQueue={paneSession.clearQueuedMessages}
-                        onSendQueuedAsGuidance={
-                          activeNewChatRuntime === 'codex'
-                            ? paneSession.sendQueuedAsGuidance
-                            : undefined
-                        }
-                        onInterruptAndSendQueuedMessage={paneSession.interruptAndSendQueued}
-                        onEditQueuedMessage={paneSession.editQueuedMessage}
-                        onCancelGuidanceMessage={paneSession.cancelGuidanceMessage}
-                        onClearCodeComments={paneSession.clearCodeComments}
-                        onOpenSkillFile={openLocalSkillFile}
-                        workspaceTarget={composerWorkspaceTarget}
-                        workspaceFileApi={workspaceFileApi}
-                      />
-                    </>
-                  )
-                }
-              />
-            )}
-            <aside
-              data-testid="environment-info-panel-container"
-              className={cn(
-                'sticky top-0 z-popover flex h-full w-0 shrink-0 self-start flex-col overflow-hidden has-[[data-environment-info-popover]]:w-[320px] has-[[data-environment-info-popover]]:overflow-visible',
-                environmentInfoTransitionEnabled
-                  ? 'transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none'
-                  : 'transition-none'
-              )}
-            >
-              <div ref={setEnvironmentInfoPanelRef} className="shrink-0" />
-              {environmentInfoDocked && hasSubagentStatuses && (
-                <div
-                  data-testid="workbench-subagent-status-row"
-                  className="ml-2 mt-3 flex w-[300px] flex-wrap gap-2"
-                >
-                  <SubagentStatusIndicator statuses={paneSession.subagentStatuses} />
+                    }) => {
+                      previousTurnReviewRef.current = {
+                        loadDiff,
+                        defaultFileTreeVisible,
+                        sourceSubtaskId: subtaskId,
+                      }
+                      setHasPreviousTurnReview(true)
+                      void openReviewFromDiffLoader(loadDiff, {
+                        reviewTitle,
+                        reviewMode: 'previous-turn',
+                        defaultFileTreeVisible,
+                        focusFilePath,
+                        sourceSubtaskId: subtaskId,
+                      })
+                    }}
+                    fileChangesDiffPreviewDisabledSubtaskId={
+                      fileChangesDiffPreviewDisabledSubtaskId
+                    }
+                    onOpenWorkspaceFile={openWorkspaceFileFromMessage}
+                    onOpenLocalSkillFile={openLocalSkillFile}
+                    onRequestUserInputSubmit={paneSession.sendRequestUserInputResponse}
+                    onRequestUserInputIgnore={paneSession.ignoreRequestUserInput}
+                    onOpenAssistantPlan={openAssistantPlan}
+                    onEditLastUserMessage={paneSession.editLastUserMessage}
+                    canEditLastUserMessage={canEditLastUserMessage}
+                    onForkMessage={
+                      currentRuntimeUsesCodex
+                        ? message => {
+                            const workspacePath =
+                              currentRuntimeTask?.workspacePath || runtimeTaskWorkspacePath
+                            if (!currentRuntimeTask || !message.turnId || !workspacePath) return
+                            return forkCurrentRuntimeTask(
+                              {
+                                deviceId: currentRuntimeTask.deviceId,
+                                workspacePath,
+                              },
+                              { lastTurnId: message.turnId }
+                            )
+                          }
+                        : undefined
+                    }
+                    hideRequestUserInputBlocks={Boolean(pendingRequestUserInput)}
+                    hiddenRequestUserInputIds={paneSession.answeredRequestUserInputIds}
+                    onAddSelectionToConversation={addSelectionToConversation}
+                    onAskSelectionInSidebar={askSelectionInSidebar}
+                  />
                 </div>
+              ) : rightPanelExpanded ? null : (
+                <DesktopEmptyTaskLauncher
+                  projectName={currentProject?.name}
+                  onOpenProjectSelector={anchorElement => {
+                    setProjectMenuAnchorElement(anchorElement)
+                    setProjectMenuOpenSignal(signal => signal + 1)
+                  }}
+                  onSelectSuggestion={selectTaskSuggestion}
+                  composer={
+                    rightPanelExpanded ? null : (
+                      <>
+                        <DeviceStatusPrompt
+                          devices={devices}
+                          upgradingDevices={upgradingDevices}
+                          onUpgradeDevice={upgradeDevice}
+                          onOpenCloudDeviceSettings={requestOpenCloudDeviceSettings}
+                          activeDeviceId={activeDeviceId}
+                          requiresOnlineCompatibleDevice={noStandaloneCompatibleDevice}
+                          hideAvailableUpdates
+                          className="mb-3"
+                        />
+                        <BufferedChatInput
+                          value={paneSession.input}
+                          onChange={paneSession.setInput}
+                          onDraftEdit={() => {
+                            paneSession.clearError?.()
+                            setCentralHarnessError(null)
+                          }}
+                          onSubmit={submitWorkbenchInput}
+                          disabled={
+                            centralHarnessStarting ||
+                            ((activeNewChatRuntime === 'codex' ||
+                              activeNewChatRuntime === 'claude_code') &&
+                              composerDisabled) ||
+                            !paneVisible ||
+                            !workbenchVisible
+                          }
+                          submitDisabled={
+                            centralHarnessStarting ||
+                            ((activeNewChatRuntime === 'codex' ||
+                              activeNewChatRuntime === 'claude_code') &&
+                              paneSession.status.isSubmitting)
+                          }
+                          error={centralHarnessError ?? paneSession.error}
+                          disabledReason={
+                            activeNewChatRuntime === 'codex' ||
+                            activeNewChatRuntime === 'claude_code'
+                              ? inlineComposerDisabledReason
+                              : undefined
+                          }
+                          placeholder={
+                            showComposerProjectMenuAction
+                              ? 'values' in popoutComposerPlaceholder
+                                ? t(popoutComposerPlaceholder.key, popoutComposerPlaceholder.values)
+                                : t(popoutComposerPlaceholder.key)
+                              : t('workbench.input_placeholder', '随心输入')
+                          }
+                          variant="desktop"
+                          projectChat={projectChatWithModelSelectorSignal}
+                          projectWork={emptyProjectWork}
+                          projectWorkBarMiddleContext={projectSpaceContext}
+                          projectWorkBarTrailingContext={
+                            experimentalFeaturesEnabled ? (
+                              <WorkbenchHarnessSelector
+                                runtime={activeNewChatRuntime}
+                                harnesses={localHarnesses}
+                                enabledHarnesses={enabledLocalHarnesses.map(
+                                  preference => preference.id
+                                )}
+                                loading={localHarnessesLoading}
+                                detectionFailed={localHarnessDetectionFailed}
+                                onRuntimeChange={runtime => {
+                                  setCentralHarnessError(null)
+                                  setNewChatRuntime(runtime)
+                                }}
+                              />
+                            ) : undefined
+                          }
+                          modelSelectorOverride={
+                            selectedHarnessPreference ? (
+                              <WorkbenchHarnessModelSelector
+                                harnessId={selectedHarnessPreference.id}
+                                models={harnessModelOptions}
+                                selectedModel={selectedHarnessModel}
+                                onModelChange={model => {
+                                  setLocalHarnessModelKeys(current => ({
+                                    ...current,
+                                    [selectedHarnessPreference.id]: model?.key ?? null,
+                                  }))
+                                  const localHarnesses = localHarnessPreferences.map(preference =>
+                                    preference.id === selectedHarnessPreference.id
+                                      ? { ...preference, modelKey: model?.key ?? null }
+                                      : preference
+                                  )
+                                  void updateAppPreferences({ localHarnesses }).catch(error => {
+                                    console.error('Failed to save harness model selection:', error)
+                                    setCentralHarnessError(
+                                      t(
+                                        'workbench.harness_model_save_failed',
+                                        '编码工具模型选择保存失败'
+                                      )
+                                    )
+                                  })
+                                }}
+                              />
+                            ) : undefined
+                          }
+                          showWorkspaceMenu={showComposerProjectMenuAction}
+                          queuedMessages={paneQueuedMessages}
+                          guidanceMessages={paneGuidanceMessages}
+                          codeComments={paneSession.codeCommentContexts}
+                          cloudMentionCandidates={visibleCloudMentionCandidates}
+                          cloudProjectCandidates={cloudProjectMentionCandidates}
+                          cloudSpaceEnabled={
+                            experimentalFeaturesEnabled && Boolean(services?.deliveryApi)
+                          }
+                          onSelectCloudProject={handleSelectCloudProject}
+                          isStreaming={paneIsBusy}
+                          onPause={pauseCurrentResponse}
+                          onCompactContext={
+                            activeNewChatRuntime === 'codex' ||
+                            activeNewChatRuntime === 'claude_code'
+                              ? compactCurrentContext
+                              : undefined
+                          }
+                          goal={paneSession.goal}
+                          goalContinuing={paneSession.goalContinuing}
+                          taskPlan={paneSession.taskPlan}
+                          goalDraftActive={paneSession.goalDraftActive}
+                          onSetGoal={composerSupportsGoal ? setCurrentGoal : undefined}
+                          onConfigureSupervisor={
+                            supervisorFeatureAvailable ? openSupervisorDialog : undefined
+                          }
+                          supervisorEnabled={Boolean(supervisor || pendingSupervisorConfig)}
+                          supervisorPending={Boolean(
+                            !currentRuntimeTask && pendingSupervisorConfig
+                          )}
+                          onCancelGoalDraft={paneSession.cancelGoalDraft}
+                          onEditGoal={paneSession.editCurrentGoal}
+                          onPauseGoal={pauseCurrentGoal}
+                          onResumeGoal={resumeCurrentGoal}
+                          onClearGoal={clearCurrentGoal}
+                          onCancelQueuedMessage={paneSession.cancelQueuedMessage}
+                          onReorderQueuedMessages={paneSession.reorderQueuedMessages}
+                          queuePaused={paneSession.queuedMessagesPaused}
+                          onResumeQueue={paneSession.resumeQueuedMessages}
+                          onResumeQueueWithInput={paneSession.resumeQueuedMessagesWithInput}
+                          onClearQueue={paneSession.clearQueuedMessages}
+                          onSendQueuedAsGuidance={
+                            activeNewChatRuntime === 'codex'
+                              ? paneSession.sendQueuedAsGuidance
+                              : undefined
+                          }
+                          onInterruptAndSendQueuedMessage={paneSession.interruptAndSendQueued}
+                          onEditQueuedMessage={paneSession.editQueuedMessage}
+                          onCancelGuidanceMessage={paneSession.cancelGuidanceMessage}
+                          onClearCodeComments={paneSession.clearCodeComments}
+                          onOpenSkillFile={openLocalSkillFile}
+                          workspaceTarget={composerWorkspaceTarget}
+                          workspaceFileApi={workspaceFileApi}
+                        />
+                      </>
+                    )
+                  }
+                />
               )}
-            </aside>
+            </div>
           </div>
+          <aside
+            data-testid="environment-info-panel-container"
+            className={cn(
+              'relative z-popover flex h-full w-0 shrink-0 flex-col overflow-hidden has-[[data-environment-info-popover]]:w-[320px] has-[[data-environment-info-popover]]:overflow-visible',
+              showPageTopBar && 'pt-11',
+              environmentInfoTransitionEnabled
+                ? 'transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none'
+                : 'transition-none'
+            )}
+          >
+            <div ref={setEnvironmentInfoPanelRef} className="shrink-0" />
+            {environmentInfoDocked && hasSubagentStatuses && (
+              <div
+                data-testid="workbench-subagent-status-row"
+                className="ml-2 mt-3 flex w-[300px] flex-wrap gap-2"
+              >
+                <SubagentStatusIndicator statuses={paneSession.subagentStatuses} />
+              </div>
+            )}
+          </aside>
         </div>
         {rightPanelOpen && !rightPanelExpanded && (
           <div

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1651,6 +1651,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const environmentInfoOpen = environmentInfoDocked
     ? environmentInfoPinned
     : environmentInfoOverlayOpen
+  const environmentInfoPanelExpanded = environmentInfoDocked && environmentInfoOpen
   const setEnvironmentInfoOpen = useCallback(
     (open: boolean) => {
       if (environmentInfoDocked) {
@@ -4397,6 +4398,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           style={{ maxWidth: chatColumnMaxWidth, width: chatColumnWidth }}
         />
         <div
+          data-testid="desktop-workbench-scroll-frame"
           className={cn(
             'relative flex h-full min-w-0 flex-none',
             rightPanelTransitionDisabled ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
@@ -4416,7 +4418,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               showPageTopBar && 'pt-11'
             )}
           >
-            <div className="grid min-h-full w-full shrink-0 grid-cols-1">
+            <div className="grid min-h-full w-full shrink-0 grid-cols-[minmax(0,1fr)_auto]">
               {isBootstrapping ? (
                 <div className="flex min-w-0 flex-1" data-testid="desktop-workbench-loading" />
               ) : activeLocalHarnessSession ? (
@@ -4959,12 +4961,24 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                   }
                 />
               )}
+              <div
+                aria-hidden="true"
+                data-testid="environment-info-panel-spacer"
+                className={cn(
+                  'w-0 shrink-0',
+                  environmentInfoPanelExpanded && 'w-[320px]',
+                  environmentInfoTransitionEnabled
+                    ? 'transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none'
+                    : 'transition-none'
+                )}
+              />
             </div>
           </div>
           <aside
             data-testid="environment-info-panel-container"
             className={cn(
-              'relative z-popover flex h-full w-0 shrink-0 flex-col overflow-hidden has-[[data-environment-info-popover]]:w-[320px] has-[[data-environment-info-popover]]:overflow-visible',
+              'absolute inset-y-0 right-0 z-popover flex w-0 flex-col overflow-hidden',
+              environmentInfoPanelExpanded && 'w-[320px] overflow-visible',
               showPageTopBar && 'pt-11',
               environmentInfoTransitionEnabled
                 ? 'transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none'


### PR DESCRIPTION
## Summary

- move the environment panel outside the conversation scroll container, matching ChatGPT's sibling-panel layout
- preserve the original full-height single-column content grid so empty and project-selected layouts remain unchanged
- add a CI-covered Electron E2E checkpoint that scrolls a 24-turn conversation and verifies the environment panel rectangle remains fixed

## Verification

- `pnpm --filter wework test src/components/layout/DesktopWorkbenchLayout.test.tsx` (216 passed)
- ESLint and Prettier checks for all changed files
- `pnpm --filter wework e2e:desktop -- --segment environment-panel-scroll`
  - conversation scroll positions changed from `-13572` to `-3991.5`
  - environment panel remained exactly `top=76, left=1120, width=320, height=883`
- screenshot evidence reviewed locally under `wework/test-results/desktop-e2e/2026-09-01T03-06-03-367Z-82571/` and intentionally not committed

## Notes

- Full TypeScript checking currently reports pre-existing duplicate React/csstype type instances in unrelated files; no changed file appears in those diagnostics.

Closes WORK-302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop conversation scrolling so the environment information panel remains fixed while navigating longer conversations.
  * Updated the desktop workbench layout to keep environment details outside the scrollable conversation area.
  * Improved expanded and collapsed panel behavior, including consistent spacing and positioning.

* **Tests**
  * Added coverage to verify environment-panel scroll stability across desktop conversation navigation scenarios.
  * Expanded layout checks for panel placement, sizing, and scroll-frame behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->