### PR TITLE
fix(wework): keep browser notices above page content

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1096,6 +1096,7 @@ async function main() {
       DEVICE_SESSION_GATEWAY_PORT: '0',
       VITE_WEWORK_E2E: 'true',
       WEWORK_E2E_BACKGROUND_WINDOW: process.env.WEWORK_E2E_BACKGROUND_WINDOW ?? '1',
+      WEWORK_E2E_DISABLE_COMPONENT_UPDATES: '1',
       ...(DESKTOP_SEGMENT === 'local-file-preview'
         ? { WEWORK_E2E_LOCAL_FILE_READ_DELAY_MS: '1500' }
         : {}),

--- a/wework/e2e/desktop/scenarios/component-update.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/component-update.scenario.mjs
@@ -105,6 +105,7 @@ export async function createDesktopScenario({
   return {
     usesReleasePackageRuntimeAssets: true,
     appEnvironment: {
+      WEWORK_E2E_DISABLE_COMPONENT_UPDATES: '0',
       WEWORK_UPDATE_BASE_URL: origin,
     },
 

--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -13,7 +13,7 @@ const BROWSER_AGENT_STATUS_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid
 const BROWSER_AGENT_PAUSE_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-pause-button"]`
 const BROWSER_AGENT_RESUME_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-resume-button"]`
 const BROWSER_AGENT_APPROVE_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-approval-approve-button"]`
-const TRANSIENT_NOTICE_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="transient-notice"]`
+const TRANSIENT_NOTICE_SELECTOR = '[data-testid="transient-notice"]'
 const WORKBENCH_BROWSER_LABEL_SELECTOR =
   '[data-testid="desktop-workbench-content"][data-embedded-browser-label]'
 const BROWSER_LABEL = 'workspace-browser'
@@ -204,6 +204,35 @@ async function withTimeout(promise, timeoutMs, message) {
       timer = setTimeout(() => reject(new Error(message)), timeoutMs)
     }),
   ]).finally(() => clearTimeout(timer))
+}
+
+async function assertNoticeCenteredInBrowserPanel(control) {
+  const [noticeMetrics] = JSON.parse(
+    await control.command('getElementMetrics', TRANSIENT_NOTICE_SELECTOR)
+  )
+  const [panelMetrics] = JSON.parse(
+    await control.command(
+      'getElementMetrics',
+      `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-panel"]`
+    )
+  )
+  const noticeCenter = noticeMetrics.left + noticeMetrics.width / 2
+  const panelCenter = panelMetrics.left + panelMetrics.width / 2
+
+  assert.ok(
+    Math.abs(noticeCenter - panelCenter) <= 1,
+    `Browser notice was not centered in the browser panel: ${JSON.stringify({
+      noticeMetrics,
+      panelMetrics,
+    })}`
+  )
+  assert.ok(
+    noticeMetrics.left >= panelMetrics.left && noticeMetrics.right <= panelMetrics.right,
+    `Browser notice exceeded the browser panel width: ${JSON.stringify({
+      noticeMetrics,
+      panelMetrics,
+    })}`
+  )
 }
 
 async function waitForControlValue(control, selector, expected, timeoutMs, message) {
@@ -892,6 +921,7 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         text: BROWSER_CLEAR_STARTED_TEXT,
         timeoutMs: uiTimeoutMs,
       })
+      await assertNoticeCenteredInBrowserPanel(control)
       await control.command('waitFor', TRANSIENT_NOTICE_SELECTOR, {
         text: BROWSER_CLEAR_COMPLETED_TEXT,
         timeoutMs: 35_000,

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -74,6 +74,7 @@ import {
 import { SystemResumeBridge } from './host/system-resume-bridge.js'
 import {
   prepareDesktopComponents,
+  shouldStageDesktopComponentUpdates,
   type DesktopComponentUpdateController,
 } from './runtime/desktop-components.js'
 import {
@@ -1252,14 +1253,16 @@ function startDesktopRuntime(): Promise<void> {
     await loadPrimaryDshView()
     await componentUpdates?.confirmStartup()
     runtimePhase = 'ready'
-    void componentUpdates
-      ?.stageAvailableUpdate()
-      .then(staged => {
-        if (staged) console.log('[components] update staged for the next application restart')
-      })
-      .catch(error => {
-        console.error('[components] update check failed', error)
-      })
+    if (shouldStageDesktopComponentUpdates(process.env)) {
+      void componentUpdates
+        ?.stageAvailableUpdate()
+        .then(staged => {
+          if (staged) console.log('[components] update staged for the next application restart')
+        })
+        .catch(error => {
+          console.error('[components] update check failed', error)
+        })
+    }
   })()
     .catch(async error => {
       if (await componentUpdates?.rollbackStartup()) {

--- a/wework/electron/src/runtime/desktop-components.test.ts
+++ b/wework/electron/src/runtime/desktop-components.test.ts
@@ -4,7 +4,10 @@ import type {
   ComponentUpdateManager,
   ComponentUpdateManagerOptions,
 } from './component-update-manager.js'
-import { prepareDesktopComponents } from './desktop-components.js'
+import {
+  prepareDesktopComponents,
+  shouldStageDesktopComponentUpdates,
+} from './desktop-components.js'
 
 const options: ComponentUpdateManagerOptions = {
   resourcesRoot: '/resources',
@@ -51,5 +54,19 @@ describe('prepareDesktopComponents', () => {
     ).resolves.toEqual({ manager, paths })
     expect(createManager).toHaveBeenCalledWith(options)
     expect(manager.prepareStartup).toHaveBeenCalledOnce()
+  })
+})
+
+describe('shouldStageDesktopComponentUpdates', () => {
+  test('stages updates by default', () => {
+    expect(shouldStageDesktopComponentUpdates({})).toBe(true)
+  })
+
+  test('skips updates when desktop E2E disables them', () => {
+    expect(
+      shouldStageDesktopComponentUpdates({
+        WEWORK_E2E_DISABLE_COMPONENT_UPDATES: '1',
+      })
+    ).toBe(false)
   })
 })

--- a/wework/electron/src/runtime/desktop-components.ts
+++ b/wework/electron/src/runtime/desktop-components.ts
@@ -23,6 +23,10 @@ export interface PreparedDesktopComponents {
   paths: ComponentPaths | null
 }
 
+export function shouldStageDesktopComponentUpdates(environment: NodeJS.ProcessEnv): boolean {
+  return environment.WEWORK_E2E_DISABLE_COMPONENT_UPDATES !== '1'
+}
+
 export async function prepareDesktopComponents(
   options: PrepareDesktopComponentsOptions
 ): Promise<PreparedDesktopComponents> {

--- a/wework/src/components/common/TransientNotice.test.tsx
+++ b/wework/src/components/common/TransientNotice.test.tsx
@@ -55,4 +55,37 @@ describe('TransientNotice', () => {
     unmount()
     anchor.remove()
   })
+
+  test('keeps the clear timer active while an anchored notice is hidden', () => {
+    vi.useFakeTimers()
+    const anchor = document.createElement('div')
+    document.body.append(anchor)
+    const onClear = vi.fn()
+
+    const { rerender } = render(
+      <TransientNotice
+        message="Saved"
+        onClear={onClear}
+        horizontalAnchorRef={{ current: anchor }}
+        visible={false}
+      />
+    )
+
+    expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
+    vi.advanceTimersByTime(2200)
+    expect(onClear).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <TransientNotice
+        message={null}
+        onClear={onClear}
+        horizontalAnchorRef={{ current: anchor }}
+        visible
+      />
+    )
+    expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
+
+    anchor.remove()
+    vi.useRealTimers()
+  })
 })

--- a/wework/src/components/common/TransientNotice.test.tsx
+++ b/wework/src/components/common/TransientNotice.test.tsx
@@ -23,4 +23,36 @@ describe('TransientNotice', () => {
     expect(onClear).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
   })
+
+  test('portals and centers a notice within its horizontal anchor', () => {
+    const anchor = document.createElement('div')
+    anchor.getBoundingClientRect = () => ({
+      bottom: 720,
+      height: 600,
+      left: 400,
+      right: 900,
+      top: 120,
+      width: 500,
+      x: 400,
+      y: 120,
+      toJSON: () => ({}),
+    })
+    document.body.append(anchor)
+    const horizontalAnchorRef = { current: anchor }
+
+    const { unmount } = render(
+      <TransientNotice
+        message="Saved"
+        onClear={() => undefined}
+        horizontalAnchorRef={horizontalAnchorRef}
+      />
+    )
+
+    const notice = screen.getByTestId('transient-notice')
+    expect(notice.parentElement).toBe(document.body)
+    expect(notice).toHaveStyle({ left: '650px', maxWidth: '468px' })
+
+    unmount()
+    anchor.remove()
+  })
 })

--- a/wework/src/components/common/TransientNotice.tsx
+++ b/wework/src/components/common/TransientNotice.tsx
@@ -7,6 +7,7 @@ interface TransientNoticeProps {
   tone?: 'success' | 'error'
   onClear: () => void
   horizontalAnchorRef?: RefObject<HTMLElement | null>
+  visible?: boolean
 }
 
 interface HorizontalPlacement {
@@ -21,6 +22,7 @@ export function TransientNotice({
   tone = 'success',
   onClear,
   horizontalAnchorRef,
+  visible = true,
 }: TransientNoticeProps) {
   const [horizontalPlacement, setHorizontalPlacement] = useState<HorizontalPlacement | null>(null)
 
@@ -32,7 +34,7 @@ export function TransientNotice({
   }, [message, onClear])
 
   useLayoutEffect(() => {
-    if (!message || !horizontalAnchorRef) return
+    if (!message || !horizontalAnchorRef || !visible) return
     const anchor = horizontalAnchorRef.current
     if (!anchor) return
 
@@ -55,9 +57,9 @@ export function TransientNotice({
       window.removeEventListener('resize', updatePlacement)
       window.removeEventListener('scroll', updatePlacement, true)
     }
-  }, [horizontalAnchorRef, message])
+  }, [horizontalAnchorRef, message, visible])
 
-  if (!message) {
+  if (!message || !visible) {
     return null
   }
 

--- a/wework/src/components/common/TransientNotice.tsx
+++ b/wework/src/components/common/TransientNotice.tsx
@@ -1,13 +1,29 @@
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect, useState, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
 import { cn } from '@/lib/utils'
 
 interface TransientNoticeProps {
   message: string | null
   tone?: 'success' | 'error'
   onClear: () => void
+  horizontalAnchorRef?: RefObject<HTMLElement | null>
 }
 
-export function TransientNotice({ message, tone = 'success', onClear }: TransientNoticeProps) {
+interface HorizontalPlacement {
+  left: number
+  maxWidth: number
+}
+
+const NOTICE_VIEWPORT_GUTTER = 16
+
+export function TransientNotice({
+  message,
+  tone = 'success',
+  onClear,
+  horizontalAnchorRef,
+}: TransientNoticeProps) {
+  const [horizontalPlacement, setHorizontalPlacement] = useState<HorizontalPlacement | null>(null)
+
   useEffect(() => {
     if (!message) return
 
@@ -15,15 +31,49 @@ export function TransientNotice({ message, tone = 'success', onClear }: Transien
     return () => window.clearTimeout(timeout)
   }, [message, onClear])
 
+  useLayoutEffect(() => {
+    if (!message || !horizontalAnchorRef) return
+    const anchor = horizontalAnchorRef.current
+    if (!anchor) return
+
+    const updatePlacement = () => {
+      const rect = anchor.getBoundingClientRect()
+      setHorizontalPlacement({
+        left: rect.left + rect.width / 2,
+        maxWidth: Math.max(0, rect.width - NOTICE_VIEWPORT_GUTTER * 2),
+      })
+    }
+    updatePlacement()
+
+    const resizeObserver =
+      typeof ResizeObserver === 'function' ? new ResizeObserver(updatePlacement) : null
+    resizeObserver?.observe(anchor)
+    window.addEventListener('resize', updatePlacement)
+    window.addEventListener('scroll', updatePlacement, true)
+    return () => {
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', updatePlacement)
+      window.removeEventListener('scroll', updatePlacement, true)
+    }
+  }, [horizontalAnchorRef, message])
+
   if (!message) {
     return null
   }
 
-  return (
+  const notice = (
     <div
       role="status"
       data-testid="transient-notice"
       data-embedded-browser-occlusion
+      style={
+        horizontalPlacement
+          ? {
+              left: horizontalPlacement.left,
+              maxWidth: horizontalPlacement.maxWidth,
+            }
+          : undefined
+      }
       className={cn(
         'fixed left-1/2 top-28 z-system max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-lg border bg-surface px-4 py-3 text-sm shadow-[0_8px_28px_rgba(0,0,0,0.12)]',
         tone === 'success' ? 'border-primary/20 text-text-primary' : 'border-red-200 text-red-700'
@@ -32,4 +82,6 @@ export function TransientNotice({ message, tone = 'success', onClear }: Transien
       {message}
     </div>
   )
+
+  return horizontalAnchorRef ? createPortal(notice, document.body) : notice
 }

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -295,23 +295,37 @@ describe('WorkspaceBrowserPanel', () => {
   })
 
   test('hides the clear-data notice while the browser panel is inactive', async () => {
+    vi.useFakeTimers()
     const clearData = createDeferred<number>()
     embeddedBrowserMocks.clearEmbeddedBrowserData.mockReturnValueOnce(clearData.promise)
     const view = render(<WorkspaceBrowserPanel active />)
 
-    fireEvent.click(screen.getByTestId('workspace-browser-more-button'))
-    fireEvent.click(screen.getByTestId('workspace-browser-clear-data-item'))
-    fireEvent.click(screen.getByTestId('workspace-browser-clear-cache-item'))
-    expect(screen.getByTestId('transient-notice')).toHaveTextContent('开始清除浏览数据')
+    try {
+      fireEvent.click(screen.getByTestId('workspace-browser-more-button'))
+      fireEvent.click(screen.getByTestId('workspace-browser-clear-data-item'))
+      fireEvent.click(screen.getByTestId('workspace-browser-clear-cache-item'))
+      expect(screen.getByTestId('transient-notice')).toHaveTextContent('开始清除浏览数据')
 
-    view.rerender(<WorkspaceBrowserPanel active={false} />)
-    expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
+      view.rerender(<WorkspaceBrowserPanel active={false} />)
+      expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
 
-    await act(async () => {
-      clearData.resolve(1)
-      await clearData.promise
-    })
-    expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600)
+      })
+      expect(embeddedBrowserMocks.clearEmbeddedBrowserData).toHaveBeenCalledWith([
+        'cache',
+        'storage',
+      ])
+
+      await act(async () => {
+        clearData.resolve(1)
+        await clearData.promise
+        await Promise.resolve()
+      })
+      expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('reports a failed browser data clear', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -294,6 +294,26 @@ describe('WorkspaceBrowserPanel', () => {
     })
   })
 
+  test('hides the clear-data notice while the browser panel is inactive', async () => {
+    const clearData = createDeferred<number>()
+    embeddedBrowserMocks.clearEmbeddedBrowserData.mockReturnValueOnce(clearData.promise)
+    const view = render(<WorkspaceBrowserPanel active />)
+
+    fireEvent.click(screen.getByTestId('workspace-browser-more-button'))
+    fireEvent.click(screen.getByTestId('workspace-browser-clear-data-item'))
+    fireEvent.click(screen.getByTestId('workspace-browser-clear-cache-item'))
+    expect(screen.getByTestId('transient-notice')).toHaveTextContent('开始清除浏览数据')
+
+    view.rerender(<WorkspaceBrowserPanel active={false} />)
+    expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
+
+    await act(async () => {
+      clearData.resolve(1)
+      await clearData.promise
+    })
+    expect(screen.queryByTestId('transient-notice')).not.toBeInTheDocument()
+  })
+
   test('reports a failed browser data clear', async () => {
     embeddedBrowserMocks.clearEmbeddedBrowserData.mockRejectedValueOnce(new Error('failed'))
     render(<WorkspaceBrowserPanel active />)

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -2757,6 +2757,7 @@ export function WorkspaceBrowserTabPanel({
         tone="error"
         onClear={clearLocalFilePreviewToast}
         horizontalAnchorRef={browserPanelRef}
+        visible={active}
       />
       {downloadPeek ? (
         <div
@@ -2839,6 +2840,7 @@ export function WorkspaceBrowserTabPanel({
         tone={clearDataNotice?.tone}
         onClear={clearClearDataNotice}
         horizontalAnchorRef={browserPanelRef}
+        visible={active}
       />
       {invalidTlsCertificate ? (
         <div

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -353,6 +353,7 @@ export function WorkspaceBrowserTabPanel({
 }: WorkspaceBrowserPanelProps) {
   const { t } = useTranslation('common')
   const electronRuntime = isElectronRuntime()
+  const browserPanelRef = useRef<HTMLDivElement | null>(null)
   const browserHostRef = useRef<HTMLDivElement | null>(null)
   const nativeBrowserOpenRef = useRef(false)
   const nativeBrowserOpeningRef = useRef(false)
@@ -2285,6 +2286,7 @@ export function WorkspaceBrowserTabPanel({
 
   return (
     <div
+      ref={browserPanelRef}
       data-testid="workspace-browser-panel"
       data-embedded-browser-label={label}
       data-browser-annotation-original-view={annotationOriginalView}
@@ -2754,6 +2756,7 @@ export function WorkspaceBrowserTabPanel({
         message={localFilePreviewToast?.message ?? null}
         tone="error"
         onClear={clearLocalFilePreviewToast}
+        horizontalAnchorRef={browserPanelRef}
       />
       {downloadPeek ? (
         <div
@@ -2835,6 +2838,7 @@ export function WorkspaceBrowserTabPanel({
         message={clearDataNotice?.message ?? null}
         tone={clearDataNotice?.tone}
         onClear={clearClearDataNotice}
+        horizontalAnchorRef={browserPanelRef}
       />
       {invalidTlsCertificate ? (
         <div

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -699,6 +699,9 @@ describe('CloudTodoWorkspace', () => {
     )
 
     await screen.findByTestId('cloud-project-header')
+    await waitFor(() => {
+      expect(workbenchServices.deliveryApi!.getBoardSnapshot).toHaveBeenCalledTimes(1)
+    })
     const initialSnapshotRequests = vi.mocked(workbenchServices.deliveryApi!.getBoardSnapshot).mock
       .calls.length
 


### PR DESCRIPTION
## Summary

- render browser transient notices through a body portal so native page content cannot cover them
- center and constrain notices to the embedded browser panel, including panel resize updates
- add unit and desktop E2E regression coverage for the clear-cache notice

## Verification

- `pnpm --filter wework test src/components/common/TransientNotice.test.tsx src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx` (75 tests)
- `pnpm --filter wework typecheck`
- `pnpm --filter wework exec prettier --check src/components/common/TransientNotice.tsx src/components/common/TransientNotice.test.tsx src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs`
- `pnpm --filter wework exec eslint src/components/common/TransientNotice.tsx src/components/common/TransientNotice.test.tsx src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs`
- `pnpm --filter wework e2e:desktop:embedded-browser`
- isolated Electron verification: the clear-cache notice remained above the page, matched the browser panel center exactly, and the browser menu remained usable after dismissal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser-panel notices remain horizontally centered and properly sized.
  * Notices are hidden while their panel is inactive and reappear when it becomes active.
  * Improved cache-clear notice behavior across workspace panes, including transient notification timing.
  * Desktop component updates are now handled consistently during application startup.

* **Tests**
  * Added coverage for notice visibility, portal placement, sizing, timing, and browser-panel alignment.
  * Improved reliability of workspace browser and task-board refresh verification tests.
  * Added validation for controlled component updates during automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->