### PR TITLE
fix(wework): handle broken Electron Node pipes

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -169,6 +169,14 @@ Electron, and sets `ELECTRON_RUN_AS_NODE=1`. Core DSH and Codex skills therefore
 use Electron's version-bound Node for both explicit `node script.ts` commands
 and `#!/usr/bin/env node` entry points.
 
+The entry point also preloads a standard-stream guard. After the consumer of a
+stdio MCP or another Node child process closes, diagnostic writes to a broken
+`stderr` must not surface as an Electron main-process error dialog. A broken
+protocol `stdout` means the caller has gone away, so the child exits normally.
+The guard handles only `EPIPE`; other stream errors still fail and expose their
+root cause. A configured external Node executable keeps native Node error
+handling and does not load this Electron-specific guard.
+
 ## Bundled sidecars and resources
 
 Prepare Codex and DWS before packaging:

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -136,6 +136,12 @@ Electron，并设置 `ELECTRON_RUN_AS_NODE=1`。因此 Core DSH 以及 Codex ski
 显式执行的 `node script.ts` 或 `#!/usr/bin/env node` 都使用与当前 Electron
 版本绑定的 Node。
 
+该入口还会预加载标准流保护脚本。stdio MCP 或其他 Node 子进程的消费端关闭后，
+向已断开的 `stderr` 写诊断信息不得触发 Electron 的主进程异常弹窗；协议
+`stdout` 断开则表示调用方已经离开，子进程应正常退出。保护只处理 `EPIPE`，
+其他标准流错误仍保持失败并暴露根因。自定义 Node 可执行文件使用原生 Node
+错误处理，不加载这段 Electron 专用逻辑。
+
 ## Bundled sidecars 与资源
 
 构建前必须准备 Codex 和 DWS：

--- a/wework/electron/src/runtime/electron-node-runtime.test.ts
+++ b/wework/electron/src/runtime/electron-node-runtime.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 import { mkdir, readFile, stat, symlink, writeFile } from 'node:fs/promises'
 import { delimiter, join } from 'node:path'
 import { promisify } from 'node:util'
@@ -34,6 +34,8 @@ describe('prepareElectronNodeRuntime', () => {
     expect(runtime.environment.WEWORK_NODE_RUNTIME_KIND).toBe('electron')
     expect(runtimeNodeArgs(runtime.environment, ['dsh.js'])).toEqual([
       '--expose-internals',
+      '--require',
+      join(directory, 'runtime', 'bin', 'electron-node-bootstrap.cjs'),
       'dsh.js',
     ])
     expect(runtime.status).toMatchObject({
@@ -44,7 +46,10 @@ describe('prepareElectronNodeRuntime', () => {
     })
     expect((await stat(nodePath)).isFile()).toBe(true)
     expect(await readFile(nodePath, 'utf8')).toContain('export ELECTRON_RUN_AS_NODE=1')
-    expect(await readFile(nodePath, 'utf8')).toContain(`exec '${helperExecPath}' "$@"`)
+    expect(await readFile(nodePath, 'utf8')).toContain(`exec '${helperExecPath}' --require`)
+    expect(await readFile(nodePath, 'utf8')).toContain(
+      `--require '${join(directory, 'runtime', 'bin', 'electron-node-bootstrap.cjs')}'`
+    )
   })
 
   test('preserves an explicitly configured Node executable', async () => {
@@ -93,6 +98,53 @@ describe('prepareElectronNodeRuntime', () => {
       )
 
       expect(result.stdout).toBe('1')
+    }
+  )
+
+  test.skipIf(process.platform === 'win32')(
+    'keeps Electron Node children alive when their diagnostic pipe closes',
+    async () => {
+      const directory = await import('node:fs/promises').then(fs => fs.mkdtemp('/tmp/wework-node-'))
+      const runtime = await prepareElectronNodeRuntime({
+        dataDirectory: directory,
+        environment: { PATH: process.env.PATH },
+        helperExecPath: process.execPath,
+        nodeVersion: process.version,
+        platform: process.platform,
+      })
+      const child = spawn(
+        runtime.environment.WEWORK_NODE_PATH!,
+        [
+          '-e',
+          [
+            "process.stdin.once('data', () => {",
+            "  process.emitWarning('closed diagnostic pipe')",
+            "  setTimeout(() => process.stdout.write('survived'), 50)",
+            '})',
+          ].join('\n'),
+        ],
+        {
+          env: runtime.environment,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }
+      )
+
+      const stdout = new Promise<string>((resolve, reject) => {
+        let output = ''
+        child.stdout.setEncoding('utf8')
+        child.stdout.on('data', chunk => {
+          output += chunk
+        })
+        child.once('error', reject)
+        child.once('close', code => {
+          if (code === 0) resolve(output)
+          else reject(new Error(`Electron Node child exited with ${code}`))
+        })
+      })
+      child.stderr.destroy()
+      child.stdin.end('warn')
+
+      await expect(stdout).resolves.toBe('survived')
     }
   )
 
@@ -155,7 +207,10 @@ describe('prepareElectronNodeRuntime', () => {
     const launcherPath = join(directory, 'runtime', 'bin', 'node.cmd')
     expect(runtime.environment.WEWORK_NODE_PATH).toBe(helperExecPath)
     expect(await readFile(launcherPath, 'utf8')).toContain('set ELECTRON_RUN_AS_NODE=1')
-    expect(await readFile(launcherPath, 'utf8')).toContain(`"${helperExecPath}" %*`)
+    expect(await readFile(launcherPath, 'utf8')).toContain(`"${helperExecPath}" --require`)
+    expect(await readFile(launcherPath, 'utf8')).toContain(
+      `--require "${join(directory, 'runtime', 'bin', 'electron-node-bootstrap.cjs')}"`
+    )
     expect(runtime.environment.Path).toBeUndefined()
     expect(runtime.environment.PATH?.split(';')).toEqual([
       join(directory, 'runtime', 'bin'),

--- a/wework/electron/src/runtime/electron-node-runtime.test.ts
+++ b/wework/electron/src/runtime/electron-node-runtime.test.ts
@@ -141,7 +141,11 @@ describe('prepareElectronNodeRuntime', () => {
           else reject(new Error(`Electron Node child exited with ${code}`))
         })
       })
+      const stderrClosed = new Promise<void>(resolve => {
+        child.stderr.once('close', resolve)
+      })
       child.stderr.destroy()
+      await stderrClosed
       child.stdin.end('warn')
 
       await expect(stdout).resolves.toBe('survived')

--- a/wework/electron/src/runtime/electron-node-runtime.ts
+++ b/wework/electron/src/runtime/electron-node-runtime.ts
@@ -28,6 +28,20 @@ export interface ElectronNodeRuntime {
   status: ElectronNodeRuntimeStatus
 }
 
+const ELECTRON_NODE_BOOTSTRAP = `'use strict'
+
+function preserveStreamErrors(error) {
+  if (error?.code === 'EPIPE') return
+  throw error
+}
+
+process.stdout.on('error', error => {
+  if (error?.code === 'EPIPE') process.exit(0)
+  preserveStreamErrors(error)
+})
+process.stderr.on('error', preserveStreamErrors)
+`
+
 export async function prepareElectronNodeRuntime(
   options: ElectronNodeRuntimeOptions
 ): Promise<ElectronNodeRuntime> {
@@ -49,7 +63,13 @@ export async function prepareElectronNodeRuntime(
 
   const runtimeBin = join(options.dataDirectory, 'runtime', 'bin')
   const launcherPath = join(runtimeBin, options.platform === 'win32' ? 'node.cmd' : 'node')
-  await materializeNodeLauncher(launcherPath, options.helperExecPath, options.platform)
+  const bootstrapPath = join(runtimeBin, 'electron-node-bootstrap.cjs')
+  await materializeNodeLauncher(
+    launcherPath,
+    bootstrapPath,
+    options.helperExecPath,
+    options.platform
+  )
   const nodePath = options.platform === 'win32' ? options.helperExecPath : launcherPath
 
   return {
@@ -65,9 +85,10 @@ export async function prepareElectronNodeRuntime(
 }
 
 export function runtimeNodeArgs(environment: NodeJS.ProcessEnv, args: string[]): string[] {
-  return environment.WEWORK_NODE_RUNTIME_KIND === 'electron'
-    ? ['--expose-internals', ...args]
-    : args
+  if (environment.WEWORK_NODE_RUNTIME_KIND !== 'electron') return args
+  const runtimeBin = environment.WEWORK_RUNTIME_BIN?.trim()
+  const bootstrapPath = runtimeBin ? join(runtimeBin, 'electron-node-bootstrap.cjs') : null
+  return ['--expose-internals', ...(bootstrapPath ? ['--require', bootstrapPath] : []), ...args]
 }
 
 export function resolveConfiguredNodePath(
@@ -102,16 +123,19 @@ function createStatus(
 
 async function materializeNodeLauncher(
   launcherPath: string,
+  bootstrapPath: string,
   helperExecPath: string,
   platform: NodeJS.Platform
 ): Promise<void> {
   await mkdir(dirname(launcherPath), { recursive: true, mode: 0o700 })
   await rm(launcherPath, { force: true })
+  await writeFile(bootstrapPath, ELECTRON_NODE_BOOTSTRAP, { mode: 0o600 })
   if (platform === 'win32') {
     const escaped = helperExecPath.replaceAll('%', '%%').replaceAll('"', '""')
+    const escapedBootstrap = bootstrapPath.replaceAll('%', '%%').replaceAll('"', '""')
     await writeFile(
       launcherPath,
-      `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${escaped}" %*\r\n`,
+      `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${escaped}" --require "${escapedBootstrap}" %*\r\n`,
       { mode: 0o600 }
     )
     return
@@ -119,7 +143,7 @@ async function materializeNodeLauncher(
 
   await writeFile(
     launcherPath,
-    `#!/bin/sh\nexport ELECTRON_RUN_AS_NODE=1\nexec ${shellQuote(helperExecPath)} "$@"\n`,
+    `#!/bin/sh\nexport ELECTRON_RUN_AS_NODE=1\nexec ${shellQuote(helperExecPath)} --require ${shellQuote(bootstrapPath)} "$@"\n`,
     { mode: 0o700 }
   )
   await chmod(launcherPath, 0o700)


### PR DESCRIPTION
## Summary

- preload a focused stdio guard in Wework's Electron-backed Node runtime
- ignore diagnostic `stderr` EPIPE failures and exit normally when the protocol `stdout` consumer is gone
- keep non-EPIPE stream failures visible
- document the runtime boundary in Chinese and English

## Root cause

Wework runs plugin MCP servers through `Electron Helper` with `ELECTRON_RUN_AS_NODE=1`. When a consumer closed a child diagnostic pipe, a later Node warning wrote to the broken `stderr`. The unhandled EPIPE was then presented by Electron as a JavaScript main-process error dialog.

## Verification

- `pnpm --dir wework/electron test src/runtime/electron-node-runtime.test.ts`
- `pnpm --dir wework/electron typecheck`
- `pnpm --filter wework exec prettier --check electron/src/runtime/electron-node-runtime.ts electron/src/runtime/electron-node-runtime.test.ts`
- real isolated Electron session via `pnpm --filter wework ai:verify start`
- actual Electron Helper process survived a closed stderr followed by `process.emitWarning`
- pre-push ESLint, Electron TypeScript, and unit-test checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented broken standard-output and standard-error pipes from triggering unnecessary Electron error dialogs or abnormal child-process failures.
  * Electron-managed Node processes now exit cleanly when their output consumers disconnect.
  * Other stream errors continue to surface normally for troubleshooting.
  * External Node executables retain their native error-handling behavior.

* **Documentation**
  * Added English and Chinese developer guidance describing the updated standard-stream behavior and its scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->