### PR TITLE
fix(frontend): hide app devices from Wegent pages

### DIFF
--- a/frontend/src/__tests__/contexts/DeviceContext.test.tsx
+++ b/frontend/src/__tests__/contexts/DeviceContext.test.tsx
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { DeviceInfo } from '@/apis/devices'
+import { deviceApis } from '@/apis/devices'
+import { DeviceProvider, useDevices } from '@/contexts/DeviceContext'
+
+jest.mock('@/apis/devices', () => {
+  const actual = jest.requireActual('@/apis/devices')
+  return {
+    ...actual,
+    deviceApis: {
+      ...actual.deviceApis,
+      getAllDevices: jest.fn(),
+    },
+  }
+})
+
+jest.mock('@/contexts/SocketContext', () => ({
+  useSocket: () => ({ socket: null, isConnected: false }),
+}))
+
+function createDevice(overrides: Partial<DeviceInfo>): DeviceInfo {
+  return {
+    id: 1,
+    device_id: 'device-1',
+    name: 'Device 1',
+    status: 'online',
+    is_default: false,
+    device_type: 'local',
+    connection_mode: 'websocket',
+    slot_used: 0,
+    slot_max: 1,
+    running_tasks: [],
+    executor_version: null,
+    latest_version: null,
+    update_available: false,
+    ...overrides,
+  }
+}
+
+function DeviceProbe() {
+  const { devices, selectedDeviceId, setSelectedDeviceId, isLoading } = useDevices()
+
+  return (
+    <div>
+      <span data-testid="device-list">{devices.map(device => device.name).join(',')}</span>
+      <span data-testid="selected-device">{selectedDeviceId ?? 'cloud'}</span>
+      <span data-testid="loading-state">{String(isLoading)}</span>
+      <button type="button" onClick={() => setSelectedDeviceId('app-device')}>
+        Select app device
+      </button>
+    </div>
+  )
+}
+
+describe('DeviceContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(deviceApis.getAllDevices as jest.Mock).mockResolvedValue({
+      items: [
+        createDevice({ id: 1, device_id: 'local-device', name: 'Local Device' }),
+        createDevice({
+          id: 2,
+          device_id: 'app-device',
+          name: 'App Device',
+          device_type: 'app',
+        }),
+        createDevice({
+          id: 3,
+          device_id: 'remote-device',
+          name: 'Remote Device',
+          device_type: 'remote',
+        }),
+      ],
+      total: 3,
+    })
+  })
+
+  it('excludes app-only registrations from Wegent device consumers', async () => {
+    render(
+      <DeviceProvider>
+        <DeviceProbe />
+      </DeviceProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('false'))
+
+    expect(screen.getByTestId('device-list')).toHaveTextContent('Local Device,Remote Device')
+    expect(screen.getByTestId('device-list')).not.toHaveTextContent('App Device')
+  })
+
+  it('clears a selection that is not exposed to Wegent web', async () => {
+    render(
+      <DeviceProvider>
+        <DeviceProbe />
+      </DeviceProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('loading-state')).toHaveTextContent('false'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select app device' }))
+
+    await waitFor(() => expect(screen.getByTestId('selected-device')).toHaveTextContent('cloud'))
+  })
+})

--- a/frontend/src/__tests__/features/tasks/components/input/device-selector-tab.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/device-selector-tab.test.tsx
@@ -168,6 +168,16 @@ describe('DeviceSelectorTab', () => {
     expect(mockSetSelectedDeviceId).not.toHaveBeenCalledWith('other-online')
   })
 
+  it('falls back to cloud when the account default is not exposed to Wegent', async () => {
+    mockDefaultExecutionTarget = 'app-device'
+    mockDevices = [createDevice({ device_id: 'available-device' })]
+
+    render(<DeviceSelectorTab />)
+
+    await waitFor(() => expect(mockSetSelectedDeviceId).toHaveBeenCalledWith(null))
+    expect(mockSetSelectedDeviceId).not.toHaveBeenCalledWith('app-device')
+  })
+
   it('renders an existing task target read-only without changing draft selection', () => {
     mockSelectedDeviceId = 'stale-draft-device'
     mockDevices = [createDevice({ device_id: 'task-device', name: 'Task Device' })]

--- a/frontend/src/contexts/DeviceContext.tsx
+++ b/frontend/src/contexts/DeviceContext.tsx
@@ -24,6 +24,7 @@ import React, {
 } from 'react'
 import { useSocket } from './SocketContext'
 import { deviceApis, DeviceInfo } from '@/apis/devices'
+import { isWegentExecutionDevice } from '@/features/devices/utils/device-visibility'
 import {
   DeviceOnlinePayload,
   DeviceOfflinePayload,
@@ -41,7 +42,7 @@ export interface DeviceUpgradeState {
 }
 
 interface DeviceContextType {
-  /** List of all devices (including offline) */
+  /** List of Wegent execution devices (including offline) */
   devices: DeviceInfo[]
   /** Currently selected device ID (null = cloud executor) */
   selectedDeviceId: string | null
@@ -105,13 +106,13 @@ export function DeviceProvider({ children }: DeviceProviderProps) {
     [upgradingDevices]
   )
 
-  // Fetch all devices (including offline)
+  // Fetch all Wegent execution devices (including offline)
   const refreshDevices = useCallback(async () => {
     setIsLoading(true)
     setError(null)
     try {
       const response = await deviceApis.getAllDevices()
-      setDevices(response.items || [])
+      setDevices((response.items || []).filter(isWegentExecutionDevice))
     } catch (err) {
       console.error('[DeviceContext] Failed to fetch devices:', err)
       setError('Failed to load devices')
@@ -154,6 +155,18 @@ export function DeviceProvider({ children }: DeviceProviderProps) {
   useEffect(() => {
     refreshDevices()
   }, [refreshDevices])
+
+  // Drop stale selections that are no longer available to Wegent web. This
+  // includes app-only registrations filtered out by refreshDevices.
+  useEffect(() => {
+    if (
+      !isLoading &&
+      selectedDeviceId &&
+      !devices.some(device => device.device_id === selectedDeviceId)
+    ) {
+      setSelectedDeviceId(null)
+    }
+  }, [devices, isLoading, selectedDeviceId])
 
   // Handle real-time device events via WebSocket
   useEffect(() => {

--- a/frontend/src/features/devices/utils/device-visibility.ts
+++ b/frontend/src/features/devices/utils/device-visibility.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DeviceInfo } from '@/apis/devices'
+
+/**
+ * Return whether a device can be exposed as an execution target in Wegent web.
+ * App-only registrations are local Wework connections and reject backend dispatch.
+ */
+export function isWegentExecutionDevice(device: DeviceInfo): boolean {
+  return device.device_type !== 'app'
+}

--- a/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
+++ b/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
@@ -346,10 +346,15 @@ export function DeviceSelectorTab({
     // selection only on the first mount, where it may be an explicit launch
     // choice made by the device page before this selector mounted.
     if (returningFromTask || !selectedDeviceId) {
-      setSelectedDeviceId(getAccountDefaultDeviceId(defaultExecutionTarget))
+      const defaultDeviceId = getAccountDefaultDeviceId(defaultExecutionTarget)
+      const availableDefaultDeviceId = devices.some(device => device.device_id === defaultDeviceId)
+        ? defaultDeviceId
+        : null
+      setSelectedDeviceId(availableDefaultDeviceId)
     }
   }, [
     defaultExecutionTarget,
+    devices,
     hasExplicitDeviceParam,
     isExistingTask,
     isLoading,


### PR DESCRIPTION
## Summary

- exclude app-only Wework registrations from the shared Wegent device context
- clear hidden or stale device selections and fall back to cloud when the account default is unavailable
- cover device filtering, stale selection cleanup, and default-target fallback

## Testing

- `pnpm --filter wecode-ai-assistant exec jest src/__tests__/contexts/DeviceContext.test.tsx src/__tests__/features/tasks/components/input/device-selector-tab.test.tsx --runInBand`
- `pnpm --filter wecode-ai-assistant exec eslint ...` (changed frontend files)
- `pnpm --filter wecode-ai-assistant exec tsc --noEmit`
- pre-push quality gate: frontend ESLint, TypeScript, and full unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Excluded app-only devices from available execution targets.
  - Automatically falls back to the cloud target when a selected or account-default device is unavailable.
  - Prevented tasks from selecting execution targets that cannot be used by Wegent web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->