### PR TITLE
feat(wework): show AI cursor for browser actions

### DIFF
--- a/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-agent.scenario.mjs
@@ -10,9 +10,12 @@ const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
 const BROWSER_INPUT_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-url-input"]`
 const BROWSER_AGENT_STATUS_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-status"]`
-const BROWSER_AGENT_PAUSE_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-pause-button"]`
 const BROWSER_AGENT_RESUME_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-resume-button"]`
 const BROWSER_AGENT_APPROVE_SELECTOR = `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-browser-agent-approval-approve-button"]`
+const BROWSER_AGENT_CURSOR_SELECTOR =
+  '[data-testid="workspace-browser-agent-cursor"][data-visible="true"]'
+const BROWSER_AGENT_TAB_ICON_SELECTOR =
+  '[data-testid^="right-workspace-browser-tab-"][aria-selected="true"] [data-testid$="-agent-icon"]'
 const TRANSIENT_NOTICE_SELECTOR = '[data-testid="transient-notice"]'
 const WORKBENCH_BROWSER_LABEL_SELECTOR =
   '[data-testid="desktop-workbench-content"][data-embedded-browser-label]'
@@ -509,7 +512,12 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         'The fresh local task did not expose its task-scoped embedded browser label'
       )
       const bridgeIdentity = await waitForBridgeIdentity(executorHome, uiTimeoutMs)
-      const bridgeCall = payload => callBridge(bridgeIdentity, { label: browserLabel, ...payload })
+      const bridgeCall = payload =>
+        withTimeout(
+          callBridge(bridgeIdentity, { label: browserLabel, ...payload }),
+          (payload.timeoutMs ?? uiTimeoutMs) + 5_000,
+          `Timed out waiting for embedded browser bridge action: ${payload.action}`
+        )
       const firstTaskTabTestId = await control.command(
         'getAttribute',
         '[data-tab-kind="task"][aria-selected="true"]',
@@ -819,9 +827,17 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         text: 'WEWORK_AGENT_STATUS_E2E_NEVER_APPEARS',
         timeoutMs: 4_000,
       })
-      await control.command('waitFor', BROWSER_AGENT_STATUS_SELECTOR, { timeoutMs: uiTimeoutMs })
-      await control.command('waitFor', BROWSER_AGENT_PAUSE_SELECTOR, { timeoutMs: uiTimeoutMs })
-      await control.command('click', BROWSER_AGENT_PAUSE_SELECTOR)
+      await control.command('waitFor', BROWSER_AGENT_TAB_ICON_SELECTOR, {
+        timeoutMs: uiTimeoutMs,
+      })
+      assert.equal(
+        Number(await control.command('getElementCount', BROWSER_AGENT_STATUS_SELECTOR)),
+        0,
+        'Running agent state should use the tab icon instead of a separate status bar'
+      )
+      await control.command('setEmbeddedBrowserAgentControlPaused', 'body', {
+        value: JSON.stringify({ label: browserLabel, paused: true }),
+      })
       await control.command('waitFor', BROWSER_AGENT_RESUME_SELECTOR, { timeoutMs: uiTimeoutMs })
       const pausedClick = await withTimeout(
         bridgeCall({
@@ -1003,7 +1019,6 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
         assert.equal(clickJson.action, 'click')
         assert.equal(clickJson.ok, true)
         assert.equal(clickJson.effect.domChanged, true)
-
         const waitText = await callTool('browser_wait_and_inspect', {
           condition: { textVisible: CLICKED_TEXT },
           inspectOptions: { interactiveOnly: false, includeTextBlocks: true, maxNodes: 80 },
@@ -1115,14 +1130,40 @@ export function createDesktopScenario({ executorHome, resultDir, uiTimeoutMs }) 
       })
       assert.ok(afterFillInspect.inspectText.includes(DIRECT_FILLED_TEXT))
 
-      const clickResult = await bridgeCall({
+      const clickPromise = bridgeCall({
         action: 'click',
         ref: buttonNode.ref,
         timeoutMs: 5_000,
       })
+      await control.command('waitFor', BROWSER_AGENT_CURSOR_SELECTOR, {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('waitFor', BROWSER_AGENT_TAB_ICON_SELECTOR, {
+        timeoutMs: uiTimeoutMs,
+      })
+      const cursorStyle = await control.command('getAttribute', BROWSER_AGENT_CURSOR_SELECTOR, {
+        value: 'style',
+      })
+      assert.ok(
+        cursorStyle.includes('translate3d'),
+        `The host AI cursor did not move to the click target: ${cursorStyle}`
+      )
+      const clickResult = await clickPromise
       assert.equal(clickResult.ok, true, `Click failed: ${JSON.stringify(clickResult)}`)
       assert.equal(clickResult.effect.domChanged, true)
-
+      await new Promise(resolve => setTimeout(resolve, 1_000))
+      const cursorVisibleAfterClick = await control.command(
+        'getAttribute',
+        BROWSER_AGENT_CURSOR_SELECTOR,
+        {
+          value: 'data-visible',
+        }
+      )
+      assert.equal(
+        cursorVisibleAfterClick,
+        'true',
+        'The host AI cursor disappeared immediately after the click'
+      )
       const finalInspect = await bridgeCall({
         action: 'inspect',
         options: { interactiveOnly: false, includeTextBlocks: true, maxNodes: 80 },

--- a/wework/e2e/desktop/scenarios/embedded-browser-annotation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-annotation.scenario.mjs
@@ -291,7 +291,11 @@ async function fillEditorElement(bridge, selector, value) {
     text: value,
     timeoutMs: 5_000,
   })
-  assert.equal(result.ok, true, `Could not fill in-page annotation editor control: ${selector}`)
+  assert.equal(
+    result.ok,
+    true,
+    `Could not fill in-page annotation editor control: ${selector}; result=${JSON.stringify(result)}`
+  )
 }
 
 async function captureBrowserScreenshot(bridge, resultDir, name) {
@@ -762,6 +766,12 @@ async function clickMarker(bridge) {
   )
 }
 
+async function resumeAgentControl(control, browserLabel) {
+  await control.command('setEmbeddedBrowserAgentControlPaused', 'body', {
+    value: JSON.stringify({ label: browserLabel, paused: false }),
+  })
+}
+
 async function verifyCore(
   control,
   executorHome,
@@ -771,7 +781,7 @@ async function verifyCore(
   resultDir
 ) {
   const fixtureUrl = `${control.url}${FIXTURE_PATH}`
-  const { bridge } = await setupBrowser(
+  const { bridge, browserLabel } = await setupBrowser(
     control,
     executorHome,
     fixtureUrl,
@@ -877,6 +887,7 @@ async function verifyCore(
   await captureScreenshot(control, 'browser-annotation-03d-three-annotations.png')
 
   await clickMarker(bridge)
+  await resumeAgentControl(control, browserLabel)
   await waitForEditorElement(bridge, OVERLAY_INPUT_SELECTOR, uiTimeoutMs)
   await captureBrowserScreenshot(bridge, resultDir, 'browser-annotation-04-edit-card.png')
   await fillEditorElement(bridge, OVERLAY_INPUT_SELECTOR, 'Edited browser annotation comment')
@@ -885,6 +896,7 @@ async function verifyCore(
   await waitForAnnotationSave(control, bridge, editRevision, uiTimeoutMs)
 
   await clickMarker(bridge)
+  await resumeAgentControl(control, browserLabel)
   await waitForEditorElement(bridge, OVERLAY_DELETE_SELECTOR, uiTimeoutMs)
   const deleteRevision = await browserAnnotationRevision(control)
   await clickEditorElement(bridge, OVERLAY_DELETE_SELECTOR)

--- a/wework/electron/src/host/browser-runtime/embedded_browser_action.js
+++ b/wework/electron/src/host/browser-runtime/embedded_browser_action.js
@@ -21,6 +21,21 @@
       return approvalRequired(action, risk, startedAt, warnings, target, before, preflight)
     }
 
+    if (input.previewOnly) {
+      return {
+        ok: true,
+        action,
+        backend: 'wkwebview-js',
+        previewOnly: true,
+        target: {
+          ...target.summary,
+          ...preflight.summary,
+        },
+        elapsedMs: elapsed(startedAt),
+        warnings,
+      }
+    }
+
     const execution = executeAction(action, target.element, input.text || '')
     warnings.push(...execution.warnings)
     if (!execution.ok) return failure(action, execution, startedAt, warnings, target, before)

--- a/wework/electron/src/host/capability-router.ts
+++ b/wework/electron/src/host/capability-router.ts
@@ -26,6 +26,7 @@ export const HOST_CAPABILITIES = [
   'browser.historyRemove',
   'browser.historySearch',
   'browser.navigate',
+  'browser.notifyAgentCursorArrived',
   'browser.open',
   'browser.pageState',
   'browser.pauseDownload',

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -297,6 +297,12 @@ export function createElectronCapabilityRouter(
       booleanParam(params, 'approved') ?? false
     )
   )
+  router.register('browser.notifyAgentCursorArrived', params =>
+    browser.notifyAgentCursorArrived(
+      stringParam(params, 'label'),
+      integerParam(params, 'moveSequence') ?? 0
+    )
+  )
   router.register('browser.close', params =>
     browser.close(stringParam(params, 'label'), optionalStringParam(params, 'expectedNativeLabel'))
   )

--- a/wework/electron/src/host/embedded-browser-bridge.test.ts
+++ b/wework/electron/src/host/embedded-browser-bridge.test.ts
@@ -177,6 +177,42 @@ describe('EmbeddedBrowserBridge', () => {
     expect(browser.hideAgentCursor).not.toHaveBeenCalled()
   })
 
+  test('does not dispatch a click when the host cursor does not arrive', async () => {
+    const executorHome = await mkdtemp(join(tmpdir(), 'wework-browser-bridge-'))
+    const browser = fakeBrowser()
+    browser.evaluate.mockResolvedValue({
+      ok: true,
+      target: { rect: { x: 40, y: 30, width: 120, height: 40 } },
+    })
+    browser.waitForAgentCursorArrival.mockResolvedValue(false)
+    const bridge = new EmbeddedBrowserBridge(browser.manager, executorHome)
+    bridges.push(bridge)
+    const runtimePath = await bridge.start()
+    const identity = JSON.parse(await readFile(runtimePath, 'utf8')) as {
+      address: string
+      token: string
+    }
+
+    const response = await fetch(`http://${identity.address}/browser`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${identity.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        action: 'click',
+        label: 'workspace-browser',
+        selector: '#run-agent',
+      }),
+    })
+
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Timed out waiting for embedded browser agent cursor arrival',
+    })
+    expect(browser.evaluate).toHaveBeenCalledOnce()
+  })
+
   test('follows an active browser label published after the open request', async () => {
     const executorHome = await mkdtemp(join(tmpdir(), 'wework-browser-bridge-'))
     const browser = fakeBrowser()

--- a/wework/electron/src/host/embedded-browser-bridge.test.ts
+++ b/wework/electron/src/host/embedded-browser-bridge.test.ts
@@ -124,6 +124,59 @@ describe('EmbeddedBrowserBridge', () => {
     expect(browser.navigate).toHaveBeenCalledWith('workspace-browser-2', 'https://example.test/')
   })
 
+  test('waits for the host cursor to arrive before dispatching a click', async () => {
+    const executorHome = await mkdtemp(join(tmpdir(), 'wework-browser-bridge-'))
+    const browser = fakeBrowser()
+    let resolveArrival: (arrived: boolean) => void = () => undefined
+    const arrival = new Promise<boolean>(resolve => {
+      resolveArrival = resolve
+    })
+    browser.evaluate.mockImplementation(async (_label, expression) => {
+      if (expression.includes('"previewOnly":true')) {
+        return {
+          ok: true,
+          target: { rect: { x: 40, y: 30, width: 120, height: 40 } },
+        }
+      }
+      return { ok: true, action: 'click' }
+    })
+    browser.waitForAgentCursorArrival.mockReturnValue(arrival)
+    const bridge = new EmbeddedBrowserBridge(browser.manager, executorHome)
+    bridges.push(bridge)
+    const runtimePath = await bridge.start()
+    const identity = JSON.parse(await readFile(runtimePath, 'utf8')) as {
+      address: string
+      token: string
+    }
+
+    const responsePromise = fetch(`http://${identity.address}/browser`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${identity.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        action: 'click',
+        label: 'workspace-browser',
+        selector: '#run-agent',
+      }),
+    })
+
+    await vi.waitFor(() => {
+      expect(browser.showAgentCursor).toHaveBeenCalledWith('workspace-browser', 100, 50)
+    })
+    expect(browser.evaluate).toHaveBeenCalledOnce()
+    resolveArrival(true)
+
+    const response = await responsePromise
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: { ok: true, action: 'click' },
+    })
+    expect(browser.evaluate).toHaveBeenCalledTimes(2)
+    expect(browser.hideAgentCursor).not.toHaveBeenCalled()
+  })
+
   test('follows an active browser label published after the open request', async () => {
     const executorHome = await mkdtemp(join(tmpdir(), 'wework-browser-bridge-'))
     const browser = fakeBrowser()
@@ -314,6 +367,9 @@ function fakeBrowser() {
   const navigate = vi.fn(async () => undefined)
   const evaluate = vi.fn()
   const clickAt = vi.fn()
+  const hideAgentCursor = vi.fn()
+  const showAgentCursor = vi.fn(() => 1)
+  const waitForAgentCursorArrival = vi.fn(async () => true)
   const manager = {
     activeLabel,
     has,
@@ -330,15 +386,21 @@ function fakeBrowser() {
     consumeApprovedAgentRisk: vi.fn(() => false),
     registerAgentApproval: vi.fn(() => null),
     emitAgentState: vi.fn(),
+    hideAgentCursor,
+    showAgentCursor,
+    waitForAgentCursorArrival,
   } as unknown as EmbeddedBrowserManager
   return {
     activeLabel,
     clickAt,
     evaluate,
     has,
+    hideAgentCursor,
     manager,
     navigate,
     requestOpen,
+    showAgentCursor,
     state,
+    waitForAgentCursorArrival,
   }
 }

--- a/wework/electron/src/host/embedded-browser-bridge.ts
+++ b/wework/electron/src/host/embedded-browser-bridge.ts
@@ -344,7 +344,8 @@ export class EmbeddedBrowserBridge {
     const point = actionCursorPoint(request, preview)
     if (!point) return preview
     const moveSequence = this.browser.showAgentCursor(label, point.x, point.y)
-    await this.browser.waitForAgentCursorArrival(label, moveSequence)
+    const arrived = await this.browser.waitForAgentCursorArrival(label, moveSequence)
+    if (!arrived) throw new Error('Timed out waiting for embedded browser agent cursor arrival')
     if (this.browser.isAgentControlPaused(label)) return agentControlPausedResult(request.action)
     return this.runAction(label, request)
   }

--- a/wework/electron/src/host/embedded-browser-bridge.ts
+++ b/wework/electron/src/host/embedded-browser-bridge.ts
@@ -258,6 +258,7 @@ export class EmbeddedBrowserBridge {
           )
         )
       case 'click':
+        return this.runClickAction(label, request)
       case 'typeText':
       case 'fill':
       case 'hover':
@@ -338,7 +339,21 @@ export class EmbeddedBrowserBridge {
     )
   }
 
-  private async runAction(label: string, request: BrowserBridgeRequest): Promise<unknown> {
+  private async runClickAction(label: string, request: BrowserBridgeRequest): Promise<unknown> {
+    const preview = await this.runAction(label, request, true)
+    const point = actionCursorPoint(request, preview)
+    if (!point) return preview
+    const moveSequence = this.browser.showAgentCursor(label, point.x, point.y)
+    await this.browser.waitForAgentCursorArrival(label, moveSequence)
+    if (this.browser.isAgentControlPaused(label)) return agentControlPausedResult(request.action)
+    return this.runAction(label, request)
+  }
+
+  private async runAction(
+    label: string,
+    request: BrowserBridgeRequest,
+    previewOnly = false
+  ): Promise<unknown> {
     const input = {
       action: request.action === 'typeText' ? 'type' : request.action,
       selector: request.selector ?? null,
@@ -350,6 +365,7 @@ export class EmbeddedBrowserBridge {
       index: request.index ?? null,
       ref: request.ref ?? null,
       options: request.options ?? null,
+      previewOnly,
     }
     return this.evaluate(
       label,
@@ -634,6 +650,32 @@ function requiredCoordinate(value: unknown, name: string): number {
     throw new Error(`Embedded browser ${name} coordinate is invalid`)
   }
   return coordinate
+}
+
+function actionCursorPoint(
+  request: BrowserBridgeRequest,
+  preview: unknown
+): { x: number; y: number } | null {
+  if (!preview || typeof preview !== 'object' || Array.isArray(preview)) return null
+  const result = preview as Record<string, unknown>
+  if (result.ok !== true) return null
+  if (Number.isFinite(request.x) && Number.isFinite(request.y)) {
+    return { x: request.x as number, y: request.y as number }
+  }
+  const target = result.target
+  if (!target || typeof target !== 'object' || Array.isArray(target)) return null
+  const rect = (target as Record<string, unknown>).rect
+  if (!rect || typeof rect !== 'object' || Array.isArray(rect)) return null
+  const values = rect as Record<string, unknown>
+  const x = Number(values.x)
+  const y = Number(values.y)
+  const width = Number(values.width)
+  const height = Number(values.height)
+  if (![x, y, width, height].every(Number.isFinite)) return null
+  return {
+    x: x + width / 2,
+    y: y + height / 2,
+  }
 }
 
 function actionSignature(action: string, request: BrowserBridgeRequest): string {

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -123,6 +123,129 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     vi.clearAllMocks()
   })
 
+  test('publishes host cursor events and waits for renderer arrival', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const events: BrowserHostEvent[] = []
+    const manager = new EmbeddedBrowserManager(directory, event => events.push(event))
+
+    const moveSequence = manager.showAgentCursor('workspace-browser', 120, 80)
+    const arrival = manager.waitForAgentCursorArrival('workspace-browser', moveSequence)
+    manager.notifyAgentCursorArrived('workspace-browser', moveSequence)
+
+    await expect(arrival).resolves.toBe(true)
+    manager.hideAgentCursor('workspace-browser')
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-cursor',
+          payload: expect.objectContaining({
+            label: 'workspace-browser',
+            visible: true,
+            x: 120,
+            y: 80,
+            moveSequence,
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-cursor',
+          payload: expect.objectContaining({
+            label: 'workspace-browser',
+            visible: false,
+            moveSequence,
+          }),
+        }),
+      ])
+    )
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('keeps the host cursor visible briefly between adjacent agent actions', async () => {
+    vi.useFakeTimers()
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const events: BrowserHostEvent[] = []
+    const manager = new EmbeddedBrowserManager(directory, event => events.push(event))
+
+    manager.emitAgentState('workspace-browser', 'running', { action: 'click' })
+    manager.showAgentCursor('workspace-browser', 120, 80)
+    manager.emitAgentState('workspace-browser', 'idle', { action: 'click' })
+
+    expect(events.filter(event => event.type === 'agent-cursor').at(-1)?.payload).toMatchObject({
+      visible: true,
+    })
+
+    vi.advanceTimersByTime(3_999)
+    expect(events.filter(event => event.type === 'agent-cursor').at(-1)?.payload).toMatchObject({
+      visible: true,
+    })
+
+    vi.advanceTimersByTime(1)
+    expect(events.filter(event => event.type === 'agent-cursor').at(-1)?.payload).toMatchObject({
+      visible: false,
+    })
+
+    vi.useRealTimers()
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('cancels a pending cursor hide when another agent action starts', async () => {
+    vi.useFakeTimers()
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const events: BrowserHostEvent[] = []
+    const manager = new EmbeddedBrowserManager(directory, event => events.push(event))
+
+    manager.emitAgentState('workspace-browser', 'running', { action: 'click' })
+    manager.showAgentCursor('workspace-browser', 120, 80)
+    manager.emitAgentState('workspace-browser', 'idle', { action: 'click' })
+    vi.advanceTimersByTime(2_000)
+
+    manager.emitAgentState('workspace-browser', 'running', { action: 'click' })
+    vi.advanceTimersByTime(4_000)
+
+    expect(events.filter(event => event.type === 'agent-cursor').at(-1)?.payload).toMatchObject({
+      visible: true,
+    })
+
+    manager.emitAgentState('workspace-browser', 'idle', { action: 'click' })
+    vi.advanceTimersByTime(4_000)
+    expect(events.filter(event => event.type === 'agent-cursor').at(-1)?.payload).toMatchObject({
+      visible: false,
+    })
+
+    vi.useRealTimers()
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('pauses active agent control when the user presses the mouse in the page', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const events: BrowserHostEvent[] = []
+    const manager = new EmbeddedBrowserManager(directory, event => events.push(event))
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+    manager.emitAgentState('workspace-browser', 'running', { action: 'waitFor' })
+
+    contents.emit('before-mouse-event', {}, { type: 'mouseDown' })
+
+    expect(manager.isAgentControlPaused('workspace-browser')).toBe(true)
+    expect(events.at(-1)).toMatchObject({
+      type: 'agent-state',
+      payload: {
+        label: 'workspace-browser',
+        status: 'paused',
+      },
+    })
+    await rm(directory, { recursive: true, force: true })
+  })
+
   test('registers an attached browser before its initial navigation settles', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
     const manager = new EmbeddedBrowserManager(directory)

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -159,6 +159,30 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     await rm(directory, { recursive: true, force: true })
   })
 
+  test('settles pending cursor arrival when the browser label changes', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+    const moveSequence = manager.showAgentCursor('workspace-browser', 120, 80)
+    const arrival = manager.waitForAgentCursorArrival('workspace-browser', moveSequence)
+
+    manager.relabel('workspace-browser', 'workspace-browser-task-1')
+
+    await expect(arrival).resolves.toBe(false)
+    await rm(directory, { recursive: true, force: true })
+  })
+
   test('keeps the host cursor visible briefly between adjacent agent actions', async () => {
     vi.useFakeTimers()
     const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -59,6 +59,7 @@ interface BrowserEntry {
 export interface BrowserHostEvent {
   sequence: number
   type:
+    | 'agent-cursor'
     | 'agent-state'
     | 'close-request'
     | 'download'
@@ -84,6 +85,18 @@ interface BrowserAgentApproval {
   }
 }
 
+interface BrowserAgentCursorState {
+  x: number
+  y: number
+  moveSequence: number
+}
+
+interface BrowserAgentCursorArrivalWaiter {
+  moveSequence: number
+  resolve: (arrived: boolean) => void
+  timeout: NodeJS.Timeout
+}
+
 interface BrowserDownload {
   id: string
   item: DownloadItem
@@ -92,6 +105,7 @@ interface BrowserDownload {
   path: string | null
 }
 
+const AGENT_CURSOR_IDLE_HIDE_MS = 4_000
 export const EMBEDDED_BROWSER_PARTITION = 'persist:wework-browser'
 export const EMBEDDED_BROWSER_ROUTE_PARTITION_PREFIX = 'persist:wework-browser-app-route:'
 export const EMBEDDED_BROWSER_ROUTE_HOST_SEPARATOR = ':host:'
@@ -110,8 +124,17 @@ export class EmbeddedBrowserManager {
   private readonly activeTabs = new Map<string, string>()
   private readonly downloads = new Map<string, BrowserDownload>()
   private readonly agentControlPaused = new Set<string>()
+  private readonly agentActive = new Set<string>()
   private readonly agentApprovals = new Map<string, BrowserAgentApproval>()
+  private readonly agentCursorStates = new Map<string, BrowserAgentCursorState>()
+  private readonly agentCursorArrivals = new Map<string, number>()
+  private readonly agentCursorArrivalWaiters = new Map<
+    string,
+    Set<BrowserAgentCursorArrivalWaiter>
+  >()
+  private readonly agentCursorHideTimers = new Map<string, NodeJS.Timeout>()
   private readonly history: BrowserHistoryStore
+  private agentCursorSequence = 0
   private eventSequence = 0
   private historyGeneration = 0
 
@@ -139,6 +162,14 @@ export class EmbeddedBrowserManager {
     const previous = this.attachedContents.get(normalizedLabel)
     if (previous && previous.id !== contents.id && !previous.isDestroyed()) previous.close()
     this.attachedContents.set(normalizedLabel, contents)
+    contents.on('before-mouse-event', (_event, mouse) => {
+      if (mouse.type !== 'mouseDown') return
+      const entry = [...this.entries.values()].find(
+        candidate => candidate.contents.id === contents.id
+      )
+      if (!entry || !this.agentActive.has(entry.label)) return
+      this.setAgentControlPaused(entry.label, true)
+    })
     contents.once('destroyed', () => {
       if (this.attachedContents.get(normalizedLabel)?.id === contents.id) {
         this.attachedContents.delete(normalizedLabel)
@@ -421,6 +452,19 @@ export class EmbeddedBrowserManager {
     this.entries.delete(entry.label)
     entry.label = target
     this.entries.set(target, entry)
+    const cursorState = this.agentCursorStates.get(fromLabel)
+    if (cursorState) {
+      this.agentCursorStates.delete(fromLabel)
+      this.agentCursorStates.set(target, cursorState)
+    }
+    const arrivedSequence = this.agentCursorArrivals.get(fromLabel)
+    if (arrivedSequence !== undefined) {
+      this.agentCursorArrivals.delete(fromLabel)
+      this.agentCursorArrivals.set(target, arrivedSequence)
+    }
+    this.clearAgentCursorHide(fromLabel)
+    if (cursorState && !this.agentActive.has(fromLabel)) this.scheduleAgentCursorHide(target)
+    if (this.agentActive.delete(fromLabel)) this.agentActive.add(target)
   }
 
   setActiveTab(baseLabel: string, activeLabel: string): void {
@@ -541,8 +585,17 @@ export class EmbeddedBrowserManager {
       approval?: BrowserAgentApproval['payload'] | null
     } = {}
   ): void {
+    const normalizedLabel = requiredLabel(label)
+    if (status === 'running') {
+      this.agentActive.add(normalizedLabel)
+      this.clearAgentCursorHide(normalizedLabel)
+    } else {
+      this.agentActive.delete(normalizedLabel)
+      if (status === 'idle') this.scheduleAgentCursorHide(normalizedLabel)
+      else this.hideAgentCursor(normalizedLabel)
+    }
     this.emit('agent-state', {
-      label: requiredLabel(label),
+      label: normalizedLabel,
       status,
       action: detail.action ?? null,
       target: detail.target ?? null,
@@ -550,6 +603,86 @@ export class EmbeddedBrowserManager {
       errorCode: detail.errorCode ?? null,
       approval: detail.approval ?? null,
       createdAtUnixMs: Date.now(),
+    })
+  }
+
+  showAgentCursor(label: string, x: number, y: number): number {
+    const normalizedLabel = requiredLabel(label)
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      throw new Error('Browser agent cursor coordinates are invalid')
+    }
+    this.clearAgentCursorHide(normalizedLabel)
+    const moveSequence = ++this.agentCursorSequence
+    this.agentCursorStates.set(normalizedLabel, { x, y, moveSequence })
+    this.emit('agent-cursor', {
+      label: normalizedLabel,
+      visible: true,
+      x,
+      y,
+      animateMovement: true,
+      moveSequence,
+      createdAtUnixMs: Date.now(),
+    })
+    return moveSequence
+  }
+
+  hideAgentCursor(label: string): void {
+    const normalizedLabel = requiredLabel(label)
+    this.clearAgentCursorHide(normalizedLabel)
+    const state = this.agentCursorStates.get(normalizedLabel)
+    if (!state) return
+    this.emit('agent-cursor', {
+      label: normalizedLabel,
+      visible: false,
+      x: state.x,
+      y: state.y,
+      animateMovement: false,
+      moveSequence: state.moveSequence,
+      createdAtUnixMs: Date.now(),
+    })
+  }
+
+  notifyAgentCursorArrived(label: string, moveSequence: number): void {
+    const normalizedLabel = requiredLabel(label)
+    if (!Number.isInteger(moveSequence) || moveSequence < 1) {
+      throw new Error('Browser agent cursor sequence is invalid')
+    }
+    const latest = Math.max(this.agentCursorArrivals.get(normalizedLabel) ?? 0, moveSequence)
+    this.agentCursorArrivals.set(normalizedLabel, latest)
+    const waiters = this.agentCursorArrivalWaiters.get(normalizedLabel)
+    if (!waiters) return
+    for (const waiter of waiters) {
+      if (waiter.moveSequence > latest) continue
+      clearTimeout(waiter.timeout)
+      waiters.delete(waiter)
+      waiter.resolve(true)
+    }
+    if (waiters.size === 0) this.agentCursorArrivalWaiters.delete(normalizedLabel)
+  }
+
+  waitForAgentCursorArrival(
+    label: string,
+    moveSequence: number,
+    timeoutMs = 2_500
+  ): Promise<boolean> {
+    const normalizedLabel = requiredLabel(label)
+    if ((this.agentCursorArrivals.get(normalizedLabel) ?? 0) >= moveSequence) {
+      return Promise.resolve(true)
+    }
+    return new Promise(resolve => {
+      const timeout = setTimeout(() => {
+        const waiters = this.agentCursorArrivalWaiters.get(normalizedLabel)
+        if (waiters) {
+          for (const waiter of waiters) {
+            if (waiter.moveSequence === moveSequence) waiters.delete(waiter)
+          }
+          if (waiters.size === 0) this.agentCursorArrivalWaiters.delete(normalizedLabel)
+        }
+        resolve(false)
+      }, timeoutMs)
+      const waiters = this.agentCursorArrivalWaiters.get(normalizedLabel) ?? new Set()
+      waiters.add({ moveSequence, resolve, timeout })
+      this.agentCursorArrivalWaiters.set(normalizedLabel, waiters)
     })
   }
 
@@ -575,6 +708,18 @@ export class EmbeddedBrowserManager {
     if (expectedNativeLabel && entry.nativeLabel !== expectedNativeLabel) return
     this.entries.delete(label)
     this.agentControlPaused.delete(label)
+    this.agentActive.delete(label)
+    this.clearAgentCursorHide(label)
+    this.agentCursorStates.delete(label)
+    this.agentCursorArrivals.delete(label)
+    const cursorWaiters = this.agentCursorArrivalWaiters.get(label)
+    if (cursorWaiters) {
+      this.agentCursorArrivalWaiters.delete(label)
+      for (const waiter of cursorWaiters) {
+        clearTimeout(waiter.timeout)
+        waiter.resolve(false)
+      }
+    }
     for (const [approvalId, approval] of this.agentApprovals) {
       if (approval.label === label) this.agentApprovals.delete(approvalId)
     }
@@ -584,6 +729,24 @@ export class EmbeddedBrowserManager {
 
   closeMany(labels: string[]): void {
     for (const label of labels) this.close(label)
+  }
+
+  private scheduleAgentCursorHide(label: string): void {
+    const normalizedLabel = requiredLabel(label)
+    this.clearAgentCursorHide(normalizedLabel)
+    if (!this.agentCursorStates.has(normalizedLabel)) return
+    const timer = setTimeout(() => {
+      this.agentCursorHideTimers.delete(normalizedLabel)
+      this.hideAgentCursor(normalizedLabel)
+    }, AGENT_CURSOR_IDLE_HIDE_MS)
+    this.agentCursorHideTimers.set(normalizedLabel, timer)
+  }
+
+  private clearAgentCursorHide(label: string): void {
+    const timer = this.agentCursorHideTimers.get(label)
+    if (!timer) return
+    clearTimeout(timer)
+    this.agentCursorHideTimers.delete(label)
   }
 
   async clearData(kinds: string[] | null): Promise<number> {

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -462,6 +462,7 @@ export class EmbeddedBrowserManager {
       this.agentCursorArrivals.delete(fromLabel)
       this.agentCursorArrivals.set(target, arrivedSequence)
     }
+    this.cancelAgentCursorArrivalWaiters(fromLabel)
     this.clearAgentCursorHide(fromLabel)
     if (cursorState && !this.agentActive.has(fromLabel)) this.scheduleAgentCursorHide(target)
     if (this.agentActive.delete(fromLabel)) this.agentActive.add(target)
@@ -712,14 +713,7 @@ export class EmbeddedBrowserManager {
     this.clearAgentCursorHide(label)
     this.agentCursorStates.delete(label)
     this.agentCursorArrivals.delete(label)
-    const cursorWaiters = this.agentCursorArrivalWaiters.get(label)
-    if (cursorWaiters) {
-      this.agentCursorArrivalWaiters.delete(label)
-      for (const waiter of cursorWaiters) {
-        clearTimeout(waiter.timeout)
-        waiter.resolve(false)
-      }
-    }
+    this.cancelAgentCursorArrivalWaiters(label)
     for (const [approvalId, approval] of this.agentApprovals) {
       if (approval.label === label) this.agentApprovals.delete(approvalId)
     }
@@ -747,6 +741,16 @@ export class EmbeddedBrowserManager {
     if (!timer) return
     clearTimeout(timer)
     this.agentCursorHideTimers.delete(label)
+  }
+
+  private cancelAgentCursorArrivalWaiters(label: string): void {
+    const waiters = this.agentCursorArrivalWaiters.get(label)
+    if (!waiters) return
+    this.agentCursorArrivalWaiters.delete(label)
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout)
+      waiter.resolve(false)
+    }
   }
 
   async clearData(kinds: string[] | null): Promise<number> {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -460,6 +460,7 @@ function normalizeRightWorkspaceBrowserState(
     title: state?.title ?? null,
     faviconUrl: state?.faviconUrl ?? null,
     isLoading: state?.isLoading ?? false,
+    agentActive: false,
     hasActiveDownload: state?.hasActiveDownload ?? false,
     openRequest: state?.openRequest ?? null,
   }
@@ -1468,6 +1469,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
       title: null,
       faviconUrl: null,
       isLoading: false,
+      agentActive: false,
       hasActiveDownload: false,
       openRequest: null,
       ...overrides,

--- a/wework/src/components/layout/workspace-panels/BrowserAgentCursorIcon.tsx
+++ b/wework/src/components/layout/workspace-panels/BrowserAgentCursorIcon.tsx
@@ -1,0 +1,26 @@
+import { MousePointer2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface BrowserAgentCursorIconProps {
+  className?: string
+  testId?: string
+}
+
+export function BrowserAgentCursorIcon({ className, testId }: BrowserAgentCursorIconProps) {
+  return (
+    <span
+      data-testid={testId}
+      aria-hidden="true"
+      className={cn('relative block shrink-0', className)}
+    >
+      <MousePointer2
+        className="absolute inset-0 h-full w-full fill-white text-white"
+        strokeWidth={4}
+      />
+      <MousePointer2
+        className="absolute inset-0 h-full w-full fill-neutral-950 text-neutral-950"
+        strokeWidth={1.4}
+      />
+    </span>
+  )
+}

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
@@ -1,0 +1,136 @@
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { ElectronEmbeddedBrowserView } from './ElectronEmbeddedBrowserView'
+
+const embeddedBrowserMocks = vi.hoisted(() => ({
+  notifyEmbeddedBrowserAgentCursorArrived: vi.fn(),
+}))
+
+vi.mock('@/lib/embedded-browser', () => embeddedBrowserMocks)
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  disconnect = vi.fn()
+}
+
+describe('ElectronEmbeddedBrowserView', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived.mockReset()
+    embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived.mockResolvedValue(undefined)
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    document.querySelector('[data-wework-browser-webview-host-root]')?.remove()
+  })
+
+  test('renders and acknowledges the host-layer AI cursor before a click continues', async () => {
+    render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser"
+        visualRect={null}
+        cursorScale={1}
+        cursor={{
+          label: 'workspace-browser',
+          visible: true,
+          x: 100,
+          y: 50,
+          animateMovement: true,
+          moveSequence: 7,
+          createdAtUnixMs: Date.now(),
+        }}
+      />
+    )
+
+    const container = document.querySelector('[data-testid="workspace-browser-electron-webview"]')
+    expect(container?.querySelector('webview')).not.toBeNull()
+    expect(
+      container?.querySelector('[data-testid="workspace-browser-agent-cursor-overlay"]')
+    ).not.toBeNull()
+    await act(async () => {
+      vi.advanceTimersByTime(16)
+    })
+    expect(screen.getByTestId('workspace-browser-agent-cursor')).toHaveAttribute(
+      'data-visible',
+      'true'
+    )
+    expect(screen.getByTestId('workspace-browser-agent-cursor')).toHaveStyle({
+      transform: 'translate3d(97px, 47px, 0)',
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(180)
+    })
+
+    expect(embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived).toHaveBeenCalledWith(
+      'workspace-browser',
+      7
+    )
+  })
+
+  test('keeps the cursor visible while it moves smoothly between agent targets', async () => {
+    const cursor = {
+      label: 'workspace-browser',
+      visible: true,
+      x: 100,
+      y: 50,
+      animateMovement: true,
+      moveSequence: 7,
+      createdAtUnixMs: Date.now(),
+    }
+    const view = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser"
+        visualRect={null}
+        cursorScale={1}
+        cursor={cursor}
+      />
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(180)
+    })
+    embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived.mockClear()
+
+    view.rerender(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser"
+        visualRect={null}
+        cursorScale={1}
+        cursor={{
+          ...cursor,
+          x: 500,
+          y: 300,
+          moveSequence: 8,
+        }}
+      />
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(160)
+    })
+
+    const movingStyle = screen.getByTestId('workspace-browser-agent-cursor').style.transform
+    expect(movingStyle).not.toBe('translate3d(497px, 297px, 0)')
+    expect(screen.getByTestId('workspace-browser-agent-cursor')).toHaveAttribute(
+      'data-visible',
+      'true'
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_200)
+    })
+
+    expect(screen.getByTestId('workspace-browser-agent-cursor')).toHaveStyle({
+      transform: 'translate3d(497px, 297px, 0)',
+    })
+    expect(embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived).toHaveBeenCalledWith(
+      'workspace-browser',
+      8
+    )
+  })
+})

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
@@ -1,4 +1,10 @@
-import { useLayoutEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type MutableRefObject } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  notifyEmbeddedBrowserAgentCursorArrived,
+  type EmbeddedBrowserAgentCursorEvent,
+} from '@/lib/embedded-browser'
+import { BrowserAgentCursorIcon } from './BrowserAgentCursorIcon'
 
 interface BrowserVisualRect {
   x: number
@@ -12,6 +18,8 @@ interface ElectronEmbeddedBrowserViewProps {
   interactionBlocked: boolean
   label: string
   visualRect: BrowserVisualRect | null
+  cursor?: EmbeddedBrowserAgentCursorEvent | null
+  cursorScale?: number
 }
 
 interface ElectronWebviewElement extends HTMLElement {
@@ -23,6 +31,15 @@ const ROUTE_PARTITION_PREFIX = 'persist:wework-browser-app-route:'
 const ROUTE_HOST_SEPARATOR = ':host:'
 const rendererInstanceId = getRendererInstanceId()
 let nextHostGeneration = 0
+const CURSOR_FADE_MS = 180
+const CURSOR_CURVE_THRESHOLD = 196
+const CURSOR_SPRING_DAMPING = 0.9
+const CURSOR_SPRING_DURATION_MULTIPLIER = 3_000
+
+interface CursorPoint {
+  x: number
+  y: number
+}
 
 function getRendererInstanceId() {
   const storageKey = 'wework.browser.renderer-instance-id'
@@ -62,16 +79,20 @@ export function ElectronEmbeddedBrowserView({
   interactionBlocked,
   label,
   visualRect,
+  cursor = null,
+  cursorScale = 1,
 }: ElectronEmbeddedBrowserViewProps) {
   const placeholderRef = useRef<HTMLDivElement | null>(null)
   const initialLabelRef = useRef(label)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const [cursorOverlayHost, setCursorOverlayHost] = useState<HTMLDivElement | null>(null)
 
   useLayoutEffect(() => {
     const placeholder = placeholderRef.current
     if (!placeholder) return
     const container = document.createElement('div')
     const webview = document.createElement('webview') as ElectronWebviewElement
+    const cursorHost = document.createElement('div')
     const hostGeneration = ++nextHostGeneration
     container.dataset.testid = 'workspace-browser-electron-webview'
     container.dataset.weworkBrowserWebview = initialLabelRef.current
@@ -92,9 +113,17 @@ export function ElectronEmbeddedBrowserView({
       overflow: 'hidden',
       position: 'fixed',
     })
-    container.append(webview)
+    cursorHost.dataset.testid = 'workspace-browser-agent-cursor-overlay'
+    Object.assign(cursorHost.style, {
+      inset: '0',
+      pointerEvents: 'none',
+      position: 'absolute',
+      zIndex: '1',
+    })
+    container.append(webview, cursorHost)
     getWebviewHostRoot().append(container)
     containerRef.current = container
+    setCursorOverlayHost(cursorHost)
 
     const syncBounds = () => {
       const rect = placeholder.getBoundingClientRect()
@@ -116,6 +145,7 @@ export function ElectronEmbeddedBrowserView({
       window.removeEventListener('resize', syncBounds)
       window.removeEventListener('scroll', syncBounds, true)
       containerRef.current = null
+      setCursorOverlayHost(null)
       if (typeof webview.destroy === 'function') webview.destroy()
       else webview.remove()
       container.remove()
@@ -130,16 +160,276 @@ export function ElectronEmbeddedBrowserView({
   }, [active, interactionBlocked])
 
   return (
-    <div
-      ref={placeholderRef}
-      data-testid="workspace-browser-electron-webview-placeholder"
-      className="pointer-events-none absolute overflow-hidden bg-background"
-      style={{
-        left: visualRect?.x ?? 0,
-        top: visualRect?.y ?? 0,
-        width: visualRect?.width ?? '100%',
-        height: visualRect?.height ?? '100%',
-      }}
-    />
+    <>
+      <div
+        ref={placeholderRef}
+        data-testid="workspace-browser-electron-webview-placeholder"
+        className="pointer-events-none absolute overflow-hidden bg-background"
+        style={{
+          left: visualRect?.x ?? 0,
+          top: visualRect?.y ?? 0,
+          width: visualRect?.width ?? '100%',
+          height: visualRect?.height ?? '100%',
+        }}
+      />
+      {cursorOverlayHost
+        ? createPortal(
+            <BrowserAgentCursorOverlay cursor={cursor} label={label} scale={cursorScale} />,
+            cursorOverlayHost
+          )
+        : null}
+    </>
   )
+}
+
+function BrowserAgentCursorOverlay({
+  cursor,
+  label,
+  scale,
+}: {
+  cursor: EmbeddedBrowserAgentCursorEvent | null
+  label: string
+  scale: number
+}) {
+  const cursorRef = useRef<HTMLDivElement | null>(null)
+  const cursorMotionRef = useRef<HTMLDivElement | null>(null)
+  const currentPointRef = useRef<CursorPoint | null>(null)
+  const animationFrameRef = useRef<number | null>(null)
+  const arrivalTimerRef = useRef<number | null>(null)
+  const acknowledgedSequenceRef = useRef(0)
+  const visibleRef = useRef(false)
+
+  useEffect(() => {
+    if (!cursor || cursor.label !== label) return
+    const element = cursorRef.current
+    const motionElement = cursorMotionRef.current
+    if (!element || !motionElement) return
+    const point: CursorPoint = {
+      x: Math.max(0, cursor.x * scale),
+      y: Math.max(0, cursor.y * scale),
+    }
+    cancelCursorAnimation(animationFrameRef)
+    clearCursorArrivalTimer(arrivalTimerRef)
+
+    if (!cursor.visible) {
+      visibleRef.current = false
+      element.dataset.visible = 'false'
+      element.style.opacity = '0'
+      motionElement.style.transform = 'rotate(0deg) scale(1)'
+      return
+    }
+
+    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+    const previous = currentPointRef.current
+    const distance = previous ? distanceBetween(previous, point) : 0
+    const shouldMove =
+      visibleRef.current &&
+      previous !== null &&
+      cursor.animateMovement &&
+      !reducedMotion &&
+      distance >= 0.5
+
+    visibleRef.current = true
+    element.dataset.visible = 'true'
+    element.style.opacity = '1'
+
+    if (!shouldMove || !previous) {
+      currentPointRef.current = point
+      renderCursor(element, motionElement, point, 0, 1)
+      scheduleCursorArrival(
+        arrivalTimerRef,
+        acknowledgedSequenceRef,
+        label,
+        cursor.moveSequence,
+        reducedMotion ? 0 : CURSOR_FADE_MS
+      )
+      return
+    }
+
+    const curved = distance > CURSOR_CURVE_THRESHOLD
+    const control = curved ? curveControlPoint(previous, point, element.parentElement) : null
+    const responseSeconds = curved ? Math.min(0.34, 0.24 + distance / 4_000) : 0.22
+    const durationMs = responseSeconds * CURSOR_SPRING_DURATION_MULTIPLIER
+    const startedAt = performance.now()
+    const animate = (now: number) => {
+      const elapsedMs = Math.max(0, now - startedAt)
+      const progress = Math.min(
+        1,
+        springProgress(elapsedMs, responseSeconds, CURSOR_SPRING_DAMPING)
+      )
+      const nextPoint = control
+        ? quadraticPoint(previous, control, point, progress)
+        : interpolatePoint(previous, point, progress)
+      const motionAmount = Math.sin(Math.min(1, progress) * Math.PI)
+      const tangent = control
+        ? quadraticTangent(previous, control, point, progress)
+        : { x: point.x - previous.x, y: point.y - previous.y }
+      const rotation = Math.max(
+        -9,
+        Math.min(9, (Math.atan2(tangent.y, tangent.x) * 180) / Math.PI / 8)
+      )
+      currentPointRef.current = nextPoint
+      renderCursor(element, motionElement, nextPoint, rotation, 1 - motionAmount * 0.12)
+      if (elapsedMs >= durationMs) {
+        animationFrameRef.current = null
+        currentPointRef.current = point
+        renderCursor(element, motionElement, point, 0, 1)
+        scheduleCursorArrival(
+          arrivalTimerRef,
+          acknowledgedSequenceRef,
+          label,
+          cursor.moveSequence,
+          0
+        )
+        return
+      }
+      animationFrameRef.current = window.requestAnimationFrame(animate)
+    }
+    animationFrameRef.current = window.requestAnimationFrame(animate)
+    return () => cancelCursorAnimation(animationFrameRef)
+  }, [cursor, label, scale])
+
+  useEffect(
+    () => () => {
+      cancelCursorAnimation(animationFrameRef)
+      clearCursorArrivalTimer(arrivalTimerRef)
+    },
+    []
+  )
+
+  return (
+    <div
+      ref={cursorRef}
+      data-testid="workspace-browser-agent-cursor"
+      data-visible="false"
+      className="absolute left-0 top-0 h-6 w-6"
+      style={{
+        filter:
+          'drop-shadow(0 0 6px rgb(59 130 246 / 90%)) drop-shadow(0 0 15px rgb(59 130 246 / 48%))',
+        opacity: 0,
+        transform: 'translate3d(-3px, -3px, 0)',
+        transition: `opacity ${CURSOR_FADE_MS}ms ease`,
+        willChange: 'transform, opacity',
+      }}
+    >
+      <div ref={cursorMotionRef} className="h-6 w-6" style={{ willChange: 'transform' }}>
+        <BrowserAgentCursorIcon className="h-6 w-6" />
+      </div>
+    </div>
+  )
+}
+
+function renderCursor(
+  element: HTMLDivElement,
+  motionElement: HTMLDivElement,
+  point: CursorPoint,
+  rotation: number,
+  stretch: number
+) {
+  element.style.transform = `translate3d(${roundCursorValue(point.x - 3)}px, ${roundCursorValue(point.y - 3)}px, 0)`
+  motionElement.style.transform = `rotate(${roundCursorValue(rotation)}deg) scale(${roundCursorValue(2 - stretch)}, ${roundCursorValue(stretch)})`
+}
+
+function scheduleCursorArrival(
+  timerRef: MutableRefObject<number | null>,
+  acknowledgedSequenceRef: MutableRefObject<number>,
+  label: string,
+  moveSequence: number,
+  delayMs: number
+) {
+  if (moveSequence <= acknowledgedSequenceRef.current) return
+  timerRef.current = window.setTimeout(() => {
+    timerRef.current = null
+    acknowledgedSequenceRef.current = moveSequence
+    void notifyEmbeddedBrowserAgentCursorArrived(label, moveSequence).catch(error => {
+      console.error('Failed to acknowledge embedded browser agent cursor:', error)
+    })
+  }, delayMs)
+}
+
+function cancelCursorAnimation(frameRef: MutableRefObject<number | null>) {
+  if (frameRef.current === null) return
+  window.cancelAnimationFrame(frameRef.current)
+  frameRef.current = null
+}
+
+function clearCursorArrivalTimer(timerRef: MutableRefObject<number | null>) {
+  if (timerRef.current === null) return
+  window.clearTimeout(timerRef.current)
+  timerRef.current = null
+}
+
+function springProgress(elapsedMs: number, responseSeconds: number, dampingFraction: number) {
+  const elapsedSeconds = elapsedMs / 1_000
+  const angularFrequency = (Math.PI * 2) / responseSeconds
+  const dampedFrequency = angularFrequency * Math.sqrt(1 - dampingFraction ** 2)
+  const envelope = Math.exp(-dampingFraction * angularFrequency * elapsedSeconds)
+  const dampingRatio = dampingFraction / Math.sqrt(1 - dampingFraction ** 2)
+  return (
+    1 -
+    envelope *
+      (Math.cos(dampedFrequency * elapsedSeconds) +
+        dampingRatio * Math.sin(dampedFrequency * elapsedSeconds))
+  )
+}
+
+function curveControlPoint(
+  start: CursorPoint,
+  end: CursorPoint,
+  container: HTMLElement | null
+): CursorPoint {
+  const distance = distanceBetween(start, end)
+  const midpoint = interpolatePoint(start, end, 0.5)
+  const normal = {
+    x: -(end.y - start.y) / distance,
+    y: (end.x - start.x) / distance,
+  }
+  const bend = Math.min(112, distance * 0.18)
+  const direction = end.x >= start.x ? -1 : 1
+  const width = container?.clientWidth ?? Number.POSITIVE_INFINITY
+  const height = container?.clientHeight ?? Number.POSITIVE_INFINITY
+  return {
+    x: Math.max(0, Math.min(width, midpoint.x + normal.x * bend * direction)),
+    y: Math.max(0, Math.min(height, midpoint.y + normal.y * bend * direction)),
+  }
+}
+
+function quadraticPoint(
+  start: CursorPoint,
+  control: CursorPoint,
+  end: CursorPoint,
+  progress: number
+): CursorPoint {
+  const inverse = 1 - progress
+  return {
+    x: inverse ** 2 * start.x + 2 * inverse * progress * control.x + progress ** 2 * end.x,
+    y: inverse ** 2 * start.y + 2 * inverse * progress * control.y + progress ** 2 * end.y,
+  }
+}
+
+function quadraticTangent(
+  start: CursorPoint,
+  control: CursorPoint,
+  end: CursorPoint,
+  progress: number
+): CursorPoint {
+  return {
+    x: 2 * (1 - progress) * (control.x - start.x) + 2 * progress * (end.x - control.x),
+    y: 2 * (1 - progress) * (control.y - start.y) + 2 * progress * (end.y - control.y),
+  }
+}
+
+function interpolatePoint(start: CursorPoint, end: CursorPoint, progress: number): CursorPoint {
+  return {
+    x: start.x + (end.x - start.x) * progress,
+    y: start.y + (end.y - start.y) * progress,
+  }
+}
+
+function distanceBetween(start: CursorPoint, end: CursorPoint) {
+  return Math.hypot(end.x - start.x, end.y - start.y)
+}
+
+function roundCursorValue(value: number) {
+  return Math.round(value * 1_000) / 1_000
 }

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -47,6 +47,7 @@ import { WorkspaceBrowserPanel } from './WorkspaceBrowserPanelContainer'
 import { WorkspacePanelCards } from './WorkspacePanelCards'
 import { TemporaryChatPanel } from './TemporaryChatPanel'
 import { DshSidebarExtensionPanel } from './DshSidebarExtensionPanel'
+import { BrowserAgentCursorIcon } from './BrowserAgentCursorIcon'
 import {
   resolveRightWorkspaceExtensionDescriptor,
   rightWorkspaceDshSidebar,
@@ -132,6 +133,7 @@ export interface RightWorkspaceBrowserState {
   title: string | null
   faviconUrl: string | null
   isLoading: boolean
+  agentActive?: boolean
   hasActiveDownload: boolean
   openRequest: EmbeddedBrowserOpenRequest | null
   developmentPreview?: {
@@ -270,6 +272,10 @@ function RightWorkspaceBrowserPanelSlot({
     (isLoading: boolean) => onBrowserStateChange(tab, { isLoading }),
     [onBrowserStateChange, tab]
   )
+  const handleAgentActiveChange = useCallback(
+    (agentActive: boolean) => onBrowserStateChange(tab, { agentActive }),
+    [onBrowserStateChange, tab]
+  )
   const handleTitleChange = useCallback(
     (title: string | null) => onBrowserStateChange(tab, { title }),
     [onBrowserStateChange, tab]
@@ -295,6 +301,7 @@ function RightWorkspaceBrowserPanelSlot({
       onDownloadActivityChange={handleDownloadActivityChange}
       onFaviconChange={handleFaviconChange}
       onLoadingChange={handleLoadingChange}
+      onAgentActiveChange={handleAgentActiveChange}
       onTitleChange={handleTitleChange}
       onNativeLabelChange={handleNativeLabelChange}
     />
@@ -582,6 +589,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
               browserStates[tab]?.developmentPreview?.status === 'starting' ||
               browserStates[tab]?.developmentPreview?.status === 'reloading')
           }
+          agentActive={isRightWorkspaceBrowserTab(tab) && browserStates[tab]?.agentActive}
           onSelect={getTabSelectHandler(tab)}
           onClose={() => closeTab(tab)}
         />
@@ -915,6 +923,7 @@ function RightWorkspaceTitleTab({
   extensionState,
   iconSrc,
   loading = false,
+  agentActive = false,
   onSelect,
   onClose,
 }: {
@@ -925,6 +934,7 @@ function RightWorkspaceTitleTab({
   extensionState?: RightWorkspaceExtensionTabState
   iconSrc?: string | null
   loading?: boolean
+  agentActive?: boolean
   onSelect: () => void
   onClose: () => void
 }) {
@@ -965,6 +975,7 @@ function RightWorkspaceTitleTab({
           extensionState={extensionState}
           iconSrc={iconSrc}
           loading={loading}
+          agentActive={agentActive}
           testId={getRightWorkspaceTabTestId(tab)}
         />
         <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -992,16 +1003,22 @@ function RightWorkspaceTabIcon({
   extensionState,
   iconSrc,
   loading,
+  agentActive,
   testId,
 }: {
   icon: ComponentType<{ className?: string }>
   extensionState?: RightWorkspaceExtensionTabState
   iconSrc?: string | null
   loading: boolean
+  agentActive: boolean
   testId: string
 }) {
   const [failedIconSrc, setFailedIconSrc] = useState<string | null>(null)
   const imageFailed = Boolean(iconSrc && failedIconSrc === iconSrc)
+
+  if (agentActive) {
+    return <BrowserAgentCursorIcon testId={`${testId}-agent-icon`} className="h-4 w-4" />
+  }
 
   if (loading) {
     return (

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -1017,6 +1017,52 @@ describe('WorkspaceBrowserPanel', () => {
     expect(onAgentActiveChange).toHaveBeenLastCalledWith(false)
   })
 
+  test('clears visible agent cursor activity when the browser closes', async () => {
+    let handleAgentCursor!: (event: {
+      label: string
+      visible: boolean
+      x: number
+      y: number
+      animateMovement: boolean
+      moveSequence: number
+      createdAtUnixMs: number
+    }) => void
+    let handleClose!: (event: { label: string; nativeLabel: string }) => void
+    embeddedBrowserMocks.listenEmbeddedBrowserAgentCursor.mockImplementation(handler => {
+      handleAgentCursor = handler
+      return null
+    })
+    embeddedBrowserMocks.listenEmbeddedBrowserCloseRequests.mockImplementation(handler => {
+      handleClose = handler
+      return Promise.resolve(vi.fn())
+    })
+    const onAgentActiveChange = vi.fn()
+    render(<WorkspaceBrowserPanel active onAgentActiveChange={onAgentActiveChange} />)
+    await screen.findByTestId('workspace-browser-native-view')
+
+    act(() => {
+      handleAgentCursor({
+        label: 'workspace-browser',
+        visible: true,
+        x: 100,
+        y: 50,
+        animateMovement: true,
+        moveSequence: 1,
+        createdAtUnixMs: Date.now(),
+      })
+    })
+    expect(onAgentActiveChange).toHaveBeenLastCalledWith(true)
+
+    act(() => {
+      handleClose({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+      })
+    })
+
+    expect(onAgentActiveChange).toHaveBeenLastCalledWith(false)
+  })
+
   test('keeps agent control paused until the user returns it to AI', async () => {
     let handleAgentState!: (event: {
       label: string

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -35,6 +35,7 @@ const embeddedBrowserMocks = vi.hoisted(() => ({
   goBackEmbeddedBrowser: vi.fn(),
   goForwardEmbeddedBrowser: vi.fn(),
   isEmbeddedBrowserLabelTransferred: vi.fn(),
+  listenEmbeddedBrowserAgentCursor: vi.fn(),
   listenEmbeddedBrowserAgentState: vi.fn(),
   listenEmbeddedBrowserAnnotationState: vi.fn(),
   listenEmbeddedBrowserAnnotationRequests: vi.fn(),
@@ -44,6 +45,7 @@ const embeddedBrowserMocks = vi.hoisted(() => ({
   listenEmbeddedBrowserLocalFilePreview: vi.fn(),
   listenEmbeddedBrowserPageStateChanges: vi.fn(),
   navigateEmbeddedBrowser: vi.fn(),
+  notifyEmbeddedBrowserAgentCursorArrived: vi.fn(),
   openEmbeddedBrowser: vi.fn(),
   pauseEmbeddedBrowserDownload: vi.fn(),
   readEmbeddedBrowserPageState: vi.fn(),
@@ -198,6 +200,7 @@ describe('WorkspaceBrowserPanel', () => {
     embeddedBrowserMocks.listenEmbeddedBrowserAgentState.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserAnnotationState.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserAnnotationRequests.mockReturnValue(null)
+    embeddedBrowserMocks.listenEmbeddedBrowserAgentCursor.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserCloseRequests.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserDownloads.mockReturnValue(null)
     embeddedBrowserMocks.listenEmbeddedBrowserInvalidTlsCertificates.mockReturnValue(null)
@@ -909,7 +912,7 @@ describe('WorkspaceBrowserPanel', () => {
     consoleError.mockRestore()
   })
 
-  test('shows agent browser state and lets the user take over', async () => {
+  test('reports active agent control without adding a running status bar', () => {
     let handleAgentState!: (event: {
       label: string
       status: string
@@ -924,7 +927,8 @@ describe('WorkspaceBrowserPanel', () => {
       return null
     })
 
-    render(<WorkspaceBrowserPanel active />)
+    const onAgentActiveChange = vi.fn()
+    render(<WorkspaceBrowserPanel active onAgentActiveChange={onAgentActiveChange} />)
 
     act(() => {
       handleAgentState({
@@ -939,12 +943,78 @@ describe('WorkspaceBrowserPanel', () => {
       })
     })
 
-    expect(screen.getByTestId('workspace-browser-agent-status')).toHaveTextContent('AI 正在点击')
-    fireEvent.click(screen.getByTestId('workspace-browser-agent-pause-button'))
-    expect(embeddedBrowserMocks.setEmbeddedBrowserAgentControlPaused).toHaveBeenCalledWith(
-      true,
-      'workspace-browser'
-    )
+    expect(screen.queryByTestId('workspace-browser-agent-status')).not.toBeInTheDocument()
+    expect(onAgentActiveChange).toHaveBeenLastCalledWith(true)
+  })
+
+  test('keeps the tab agent icon active while the cursor remains visible', () => {
+    let handleAgentState!: (event: {
+      label: string
+      status: string
+      action: string | null
+      target: string | null
+      message: string | null
+      errorCode: string | null
+      createdAtUnixMs: number
+    }) => void
+    let handleAgentCursor!: (event: {
+      label: string
+      visible: boolean
+      x: number
+      y: number
+      animateMovement: boolean
+      moveSequence: number
+      createdAtUnixMs: number
+    }) => void
+    embeddedBrowserMocks.listenEmbeddedBrowserAgentState.mockImplementation(handler => {
+      handleAgentState = handler
+      return null
+    })
+    embeddedBrowserMocks.listenEmbeddedBrowserAgentCursor.mockImplementation(handler => {
+      handleAgentCursor = handler
+      return null
+    })
+
+    const onAgentActiveChange = vi.fn()
+    render(<WorkspaceBrowserPanel active onAgentActiveChange={onAgentActiveChange} />)
+
+    act(() => {
+      handleAgentCursor({
+        label: 'workspace-browser',
+        visible: true,
+        x: 100,
+        y: 50,
+        animateMovement: true,
+        moveSequence: 1,
+        createdAtUnixMs: Date.now(),
+      })
+      handleAgentState({
+        label: 'workspace-browser',
+        status: 'idle',
+        action: 'click',
+        target: 'index 2',
+        message: null,
+        errorCode: null,
+        approval: null,
+        createdAtUnixMs: Date.now(),
+      })
+    })
+
+    expect(onAgentActiveChange).toHaveBeenLastCalledWith(true)
+
+    act(() => {
+      handleAgentCursor({
+        label: 'workspace-browser',
+        visible: false,
+        x: 100,
+        y: 50,
+        animateMovement: false,
+        moveSequence: 1,
+        createdAtUnixMs: Date.now(),
+      })
+    })
+
+    expect(onAgentActiveChange).toHaveBeenLastCalledWith(false)
   })
 
   test('keeps agent control paused until the user returns it to AI', async () => {

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -745,6 +745,7 @@ export function WorkspaceBrowserTabPanel({
       setClearDataNotice(null)
       setClearingDataKind(null)
       setAgentState(null)
+      setAgentCursor(null)
       onTitleChange?.(null)
       onFaviconChange?.(null)
     })

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -42,6 +42,7 @@ import {
   listenEmbeddedBrowserLocalFilePreview,
   listenEmbeddedBrowserPageStateChanges,
   isEmbeddedBrowserLabelTransferred,
+  listenEmbeddedBrowserAgentCursor,
   navigateEmbeddedBrowser,
   openEmbeddedBrowser,
   pauseEmbeddedBrowserDownload,
@@ -59,6 +60,7 @@ import {
   stopEmbeddedBrowserAnnotation,
   type EmbeddedBrowserAgentStateEvent,
   type EmbeddedBrowserAnnotationRequest,
+  type EmbeddedBrowserAgentCursorEvent,
   type EmbeddedBrowserDataKind,
   type EmbeddedBrowserBounds,
   type EmbeddedBrowserDownloadEvent,
@@ -197,6 +199,7 @@ export interface WorkspaceBrowserPanelProps {
   onFaviconChange?: (faviconUrl: string | null) => void
   onLoadingChange?: (isLoading: boolean) => void
   onTitleChange?: (title: string | null) => void
+  onAgentActiveChange?: (agentActive: boolean) => void
 }
 
 export const WorkspaceBrowserPanel = WorkspaceBrowserTabPanel
@@ -204,6 +207,7 @@ export const WorkspaceBrowserPanel = WorkspaceBrowserTabPanel
 type BrowserStatus = 'idle' | 'loading' | 'ready' | 'error'
 type BrowserDownload = EmbeddedBrowserDownloadEvent
 type BrowserAgentState = EmbeddedBrowserAgentStateEvent
+type BrowserAgentCursor = EmbeddedBrowserAgentCursorEvent
 type BrowserOpenDiagnosticStage =
   | 'request_consumed'
   | 'host_ready'
@@ -261,7 +265,7 @@ function formatDownloadBytes(bytes: number | null) {
 }
 
 function shouldShowAgentState(state: BrowserAgentState | null) {
-  return Boolean(state && state.status !== 'idle')
+  return Boolean(state && ['paused', 'needs_user', 'error'].includes(state.status))
 }
 
 function getElementBounds(element: HTMLElement): EmbeddedBrowserBounds | null {
@@ -350,6 +354,7 @@ export function WorkspaceBrowserTabPanel({
   onFaviconChange,
   onLoadingChange,
   onTitleChange,
+  onAgentActiveChange,
 }: WorkspaceBrowserPanelProps) {
   const { t } = useTranslation('common')
   const electronRuntime = isElectronRuntime()
@@ -439,6 +444,7 @@ export function WorkspaceBrowserTabPanel({
   } | null>(null)
   const [clearingDataKind, setClearingDataKind] = useState<EmbeddedBrowserDataKind | null>(null)
   const [agentState, setAgentState] = useState<BrowserAgentState | null>(null)
+  const [agentCursor, setAgentCursor] = useState<BrowserAgentCursor | null>(null)
   const [invalidTlsCertificate, setInvalidTlsCertificate] =
     useState<EmbeddedBrowserInvalidTlsCertificateEvent | null>(null)
   const deviceFitScaleRef = useRef(1)
@@ -613,6 +619,42 @@ export function WorkspaceBrowserTabPanel({
       unlisten?.()
     }
   }, [])
+
+  useEffect(() => {
+    const listener = listenEmbeddedBrowserAgentCursor(event => {
+      if (event.label !== currentLabelRef.current) return
+      setAgentCursor(event)
+    })
+    if (!listener) return undefined
+    let disposed = false
+    let unlisten: (() => void) | null = null
+    void listener
+      .then(nextUnlisten => {
+        if (disposed) {
+          nextUnlisten()
+          return
+        }
+        unlisten = nextUnlisten
+      })
+      .catch(error => {
+        console.error('Failed to listen for embedded browser agent cursor:', error)
+      })
+    return () => {
+      disposed = true
+      unlisten?.()
+    }
+  }, [])
+
+  useEffect(() => {
+    onAgentActiveChange?.(agentState?.status === 'running' || Boolean(agentCursor?.visible))
+  }, [agentCursor?.visible, agentState?.status, onAgentActiveChange])
+
+  useEffect(
+    () => () => {
+      onAgentActiveChange?.(false)
+    },
+    [onAgentActiveChange]
+  )
 
   useEffect(() => {
     const listener = listenEmbeddedBrowserInvalidTlsCertificates(certificate => {
@@ -2573,9 +2615,7 @@ export function WorkspaceBrowserTabPanel({
           data-testid="workspace-browser-agent-status"
           className="flex h-9 shrink-0 items-center gap-2 border-b border-border bg-surface px-3 text-xs text-text-secondary"
         >
-          {agentState?.status === 'running' ? (
-            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary" />
-          ) : agentState?.status === 'paused' ? (
+          {agentState?.status === 'paused' ? (
             <Pause className="h-3.5 w-3.5 shrink-0 text-text-muted" />
           ) : (
             <CircleAlert className="h-3.5 w-3.5 shrink-0 text-amber-600" />
@@ -2617,17 +2657,7 @@ export function WorkspaceBrowserTabPanel({
               <Play className="h-3.5 w-3.5" />
               {t('workbench.browser_agent_resume')}
             </button>
-          ) : (
-            <button
-              type="button"
-              data-testid="workspace-browser-agent-pause-button"
-              className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-border bg-background px-2 font-medium text-text-primary hover:bg-muted"
-              onClick={() => setAgentControlPaused(true)}
-            >
-              <Pause className="h-3.5 w-3.5" />
-              {t('workbench.browser_agent_take_control')}
-            </button>
-          )}
+          ) : null}
         </div>
       ) : null}
       {(!annotationMode || internalDesktopPage) && downloadsOpen ? (
@@ -2893,6 +2923,13 @@ export function WorkspaceBrowserTabPanel({
             {electronRuntime ? (
               <ElectronEmbeddedBrowserView
                 active={active}
+                cursor={agentCursor}
+                cursorScale={
+                  deviceToolbar.isEnabled
+                    ? (deviceVisualRect ? deviceVisualRect.width / deviceToolbar.width : 1) *
+                      zoomPercentToScaleFactor(zoomPercent)
+                    : zoomPercentToScaleFactor(zoomPercent)
+                }
                 interactionBlocked={embeddedBrowserOccluded || Boolean(navigationError)}
                 label={label}
                 visualRect={deviceVisualRect}

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1447,6 +1447,20 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
           label: command.value,
         })
       )
+    case 'setEmbeddedBrowserAgentControlPaused': {
+      const input = JSON.parse(command.value ?? '{}') as {
+        label?: string
+        paused?: boolean
+      }
+      if (!input.label?.trim()) {
+        throw new Error('setEmbeddedBrowserAgentControlPaused requires label')
+      }
+      await invokeDesktopHost('browser.setAgentControlPaused', {
+        label: input.label,
+        paused: input.paused ?? false,
+      })
+      return ''
+    }
     case 'verifyEmbeddedBrowserDetachedInspector':
       return JSON.stringify(
         await invokeDesktopHost('e2e.verifyEmbeddedBrowserDetachedInspector', {

--- a/wework/src/lib/embedded-browser-action-runtime.test.ts
+++ b/wework/src/lib/embedded-browser-action-runtime.test.ts
@@ -115,4 +115,37 @@ describe('embedded browser action runtime', () => {
     expect(result.ok).toBe(false)
     expect(result.error?.code).toBe('approval_required')
   })
+
+  test('previews a click target without dispatching the click', () => {
+    document.body.innerHTML = `
+      <button id="run-agent" type="button">Run agent</button>
+    `
+    const button = document.getElementById('run-agent') as HTMLButtonElement
+    mockRect(button, {
+      x: 40,
+      y: 30,
+      width: 120,
+      height: 40,
+    })
+    let clicked = false
+    button.addEventListener('click', () => {
+      clicked = true
+    })
+
+    const result = runAction({
+      action: 'click',
+      selector: '#run-agent',
+      previewOnly: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.previewOnly).toBe(true)
+    expect(result.target.rect).toEqual({
+      x: 40,
+      y: 30,
+      width: 120,
+      height: 40,
+    })
+    expect(clicked).toBe(false)
+  })
 })

--- a/wework/src/lib/embedded-browser.test.ts
+++ b/wework/src/lib/embedded-browser.test.ts
@@ -5,10 +5,12 @@ import {
   closeEmbeddedBrowser,
   evalEmbeddedBrowserJson,
   listenEmbeddedBrowserAnnotationRequests,
+  listenEmbeddedBrowserAgentCursor,
   listenEmbeddedBrowserAgentState,
   listenEmbeddedBrowserOpenRequests,
   listenEmbeddedBrowserPageStateChanges,
   relabelEmbeddedBrowser,
+  notifyEmbeddedBrowserAgentCursorArrived,
   resolveEmbeddedBrowserAgentApproval,
   requestEmbeddedBrowserOpen,
   setEmbeddedBrowserAgentControlPaused,
@@ -124,10 +126,56 @@ describe('embedded-browser', () => {
     })
   })
 
+  test('acknowledges AI cursor arrival through Electron', async () => {
+    await notifyEmbeddedBrowserAgentCursorArrived('workspace-browser-task-1', 7)
+
+    expect(desktopHostMocks.invoke).toHaveBeenCalledWith('browser.notifyAgentCursorArrived', {
+      label: 'workspace-browser-task-1',
+      moveSequence: 7,
+    })
+  })
+
   test('listens for embedded browser agent state events', async () => {
     const handler = vi.fn()
 
     const unlisten = await listenEmbeddedBrowserAgentState(handler)
+    expect(desktopHostMocks.subscribe).toHaveBeenCalledOnce()
+    unlisten?.()
+  })
+
+  test('listens for embedded browser agent cursor events', async () => {
+    desktopHostMocks.subscribe.mockImplementation(handler => {
+      handler({
+        sequence: 1,
+        type: 'browser.event',
+        payload: {
+          sequence: 7,
+          type: 'agent-cursor',
+          payload: {
+            label: 'workspace-browser',
+            visible: true,
+            x: 120,
+            y: 80,
+            animateMovement: true,
+            moveSequence: 3,
+            createdAtUnixMs: 1_788_249_600_000,
+          },
+        },
+      })
+      return () => {}
+    })
+    const handler = vi.fn()
+
+    const unlisten = await listenEmbeddedBrowserAgentCursor(handler)
+    expect(handler).toHaveBeenCalledWith({
+      label: 'workspace-browser',
+      visible: true,
+      x: 120,
+      y: 80,
+      animateMovement: true,
+      moveSequence: 3,
+      createdAtUnixMs: 1_788_249_600_000,
+    })
     expect(desktopHostMocks.subscribe).toHaveBeenCalledOnce()
     unlisten?.()
   })

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -20,6 +20,7 @@ export const EMBEDDED_BROWSER_INVALID_TLS_CERTIFICATE_EVENT =
 export const EMBEDDED_BROWSER_DEBUG_PANEL_VISIBILITY_EVENT = 'wework:debug-panel-visibility-change'
 export const EMBEDDED_BROWSER_OCCLUSION_EVENT = 'wework:embedded-browser-occlusion-change'
 export const EMBEDDED_BROWSER_AGENT_STATE_EVENT = 'wework:embedded-browser-agent-state'
+export const EMBEDDED_BROWSER_AGENT_CURSOR_EVENT = 'wework:embedded-browser-agent-cursor'
 export const EMBEDDED_BROWSER_POPUP_EVENT = 'wework:embedded-browser-popup'
 export const EMBEDDED_BROWSER_ANNOTATION_STATE_EVENT = 'wework:embedded-browser-annotation-state'
 
@@ -108,6 +109,16 @@ export interface EmbeddedBrowserAgentStateEvent {
   createdAtUnixMs: number
 }
 
+export interface EmbeddedBrowserAgentCursorEvent {
+  label: string
+  visible: boolean
+  x: number
+  y: number
+  animateMovement: boolean
+  moveSequence: number
+  createdAtUnixMs: number
+}
+
 export interface EmbeddedBrowserAgentApproval {
   approvalId: string
   risk: string
@@ -148,6 +159,7 @@ export interface EmbeddedBrowserInvalidTlsCertificateEvent {
 interface ElectronBrowserHostEvent {
   sequence: number
   type:
+    | 'agent-cursor'
     | 'agent-state'
     | 'annotation-request'
     | 'close-request'
@@ -216,6 +228,16 @@ export async function setEmbeddedBrowserAgentControlPaused(
   label = DEFAULT_EMBEDDED_BROWSER_LABEL
 ): Promise<void> {
   await invokeDesktopHost<void>('browser.setAgentControlPaused', { label, paused })
+}
+
+export async function notifyEmbeddedBrowserAgentCursorArrived(
+  label: string,
+  moveSequence: number
+): Promise<void> {
+  await invokeDesktopHost<void>('browser.notifyAgentCursorArrived', {
+    label,
+    moveSequence,
+  })
 }
 
 export async function resolveEmbeddedBrowserAgentApproval(
@@ -294,6 +316,13 @@ export function listenEmbeddedBrowserAgentState(
 ): Promise<UnlistenFn> | null {
   if (!canUseEmbeddedBrowser()) return null
   return listenElectronBrowserEvents('agent-state', handler)
+}
+
+export function listenEmbeddedBrowserAgentCursor(
+  handler: (event: EmbeddedBrowserAgentCursorEvent) => void
+): Promise<UnlistenFn> | null {
+  if (!canUseEmbeddedBrowser()) return null
+  return listenElectronBrowserEvents('agent-cursor', handler)
 }
 
 export function canUseEmbeddedBrowser(): boolean {


### PR DESCRIPTION
## Summary

- show a persistent AI cursor while the Wework built-in browser is being automated
- animate cursor movement and wait for visual arrival before click execution
- keep the cursor visible briefly after actions, and pause it when the user takes control
- replace the running status strip with a compact tab cursor indicator
- add bridge, renderer, panel, runtime, and desktop E2E coverage

## Verification

- pre-push repository quality checks
- `pnpm --dir wework typecheck`
- focused Wework tests: 120 passed
- focused ESLint and Prettier checks
- `pnpm --dir wework ai:verify:electron:build`
- desktop browser scenario verified cursor movement, click completion, and post-click visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible, animated cursor overlay to show browser agent actions.
  * Browser tabs now indicate when the agent is active.
  * Added click previews before actions are executed.
  * User mouse interaction pauses active agent control.
  * Status messaging now covers paused, attention-required, and error states.

* **Bug Fixes**
  * Improved click reliability by waiting for cursor arrival confirmation.
  * Prevented clicks from executing when cursor movement is not acknowledged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->