### PR TITLE
fix(frontend): hide workflow video generation mode selector

### DIFF
--- a/frontend/src/__tests__/features/tasks/utils/teamModeSpec.test.ts
+++ b/frontend/src/__tests__/features/tasks/utils/teamModeSpec.test.ts
@@ -15,7 +15,7 @@ const minuteVideoTeam = {
   name: 'workflow-video-team',
   mode_spec: {
     allowedModelCategories: ['video'],
-    hiddenVideoParams: ['duration'],
+    hiddenVideoParams: ['duration', 'generation_mode'],
   },
 } as unknown as Team
 
@@ -26,8 +26,9 @@ describe('teamModeSpec', () => {
     expect(teamUsesModeSpecCategory(minuteVideoTeam, 'image')).toBe(false)
   })
 
-  it('hides only the workflow-owned duration parameter', () => {
+  it('hides configured workflow-owned video controls', () => {
     expect(teamHidesVideoParam(minuteVideoTeam, 'duration')).toBe(true)
+    expect(teamHidesVideoParam(minuteVideoTeam, 'generation_mode')).toBe(true)
     expect(teamHidesVideoParam(minuteVideoTeam, 'ratio')).toBe(false)
     expect(teamHidesVideoParam(minuteVideoTeam, 'resolution')).toBe(false)
   })

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -414,8 +414,11 @@ function ChatAreaContent({
   const imageCapabilities = imageConfig?.capabilities
   const imageReferenceFormats = imageCapabilities?.image_formats
   const videoGenerationModes = useMemo(
-    () => videoCapabilities?.generation_modes ?? [],
-    [videoCapabilities?.generation_modes]
+    () =>
+      teamHidesVideoParam(chatState.selectedTeam, 'generation_mode')
+        ? []
+        : (videoCapabilities?.generation_modes ?? []),
+    [chatState.selectedTeam, videoCapabilities?.generation_modes]
   )
   const [selectedVideoGenerationMode, setSelectedVideoGenerationMode] = useState<
     string | undefined

--- a/frontend/src/features/tasks/utils/teamModeSpec.ts
+++ b/frontend/src/features/tasks/utils/teamModeSpec.ts
@@ -36,7 +36,7 @@ export function teamUsesModeSpecCategory(team: Team | null | undefined, category
 
 export function teamHidesVideoParam(
   team: Team | null | undefined,
-  param: 'duration' | 'model' | 'ratio' | 'resolution'
+  param: 'duration' | 'generation_mode' | 'model' | 'ratio' | 'resolution'
 ): boolean {
   return team?.mode_spec?.hiddenVideoParams?.includes(param) === true
 }


### PR DESCRIPTION
## Summary

- Add `generation_mode` to the existing `modeSpec.hiddenVideoParams` contract.
- Hide the entire video generation mode selector for workflow-managed teams using the same visibility mechanism as model, duration, ratio, and resolution.
- Preserve the model-declared generation modes for teams that do not hide the control.

## Motivation

Workflow-owned video agents already hide model and video parameter controls through `hiddenVideoParams`, but the generation mode selector remained visible. Reusing the same Team-level configuration keeps all workflow-owned control visibility in one place and avoids per-mode or model-specific UI flags.

## Implementation

A Team can now configure:

```json
{
  "hiddenVideoParams": [
    "duration",
    "model",
    "resolution",
    "ratio",
    "generation_mode"
  ]
}
```

When `generation_mode` is hidden, `ChatArea` exposes no selectable generation modes. Existing selector behavior then hides the control and clears any previously selected hidden mode.

## Testing

- Focused Team mode-spec and video-mode selector tests — 2 suites and 5 tests passed.
- `pnpm --dir frontend exec tsc --noEmit`.
- Prettier check for all changed files.
- `SKIP_FONT_DOWNLOAD=1 pnpm --dir frontend build`.
- Repository pre-push gate — ESLint, TypeScript, and unit tests passed.

## Documentation

No documentation update is required because this extends the existing `hiddenVideoParams` configuration without introducing a new configuration structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teams can now hide video generation mode controls when configured, providing a more tailored task creation experience.

* **Bug Fixes**
  * Prevented hidden generation mode options from appearing in the video generation interface.
  * Updated validation coverage to ensure configured video controls are hidden correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->