### PR TITLE
fix(wework): defer computer use until workbench is ready

### DIFF
--- a/docs/en/wework/developer-guide/wework-computer-use.md
+++ b/docs/en/wework/developer-guide/wework-computer-use.md
@@ -61,11 +61,21 @@ the corresponding application process after a permission change. Windows and
 Linux do not show the macOS permission flow, but Driver capability and runtime
 errors remain visible.
 
-The master switch is stored in Wework desktop preferences. At startup, the
-application reads that preference and attempts to start the Driver. If
-permissions are missing, it preserves the enabled intent without creating the
-bridge and the settings page continues to show the missing permissions. A
-later status check retries startup after permissions become available.
+The master switch is stored in Wework desktop preferences. While configuring
+the Desktop Runtime, Electron only creates `ComputerUseService`; it does not
+read the enablement preference or load the Driver. Once the main surface is
+actionable, the Renderer closes the startup window through
+`renderer.startupReady`. Electron then schedules one background preference
+restore without waiting for native Driver initialization. CUA native module
+loading and macOS permission checks therefore do not block Executor, Core DSH,
+or the first actionable workbench.
+
+The background restore reads the latest preference before it starts. It skips
+Driver startup when the feature has been disabled or the application is
+quitting. If permissions are missing, it preserves the enabled intent without
+creating the bridge and the settings page continues to show the missing
+permissions. A later status check retries startup after permissions become
+available.
 
 ## Release integration
 
@@ -117,7 +127,9 @@ Focused verification includes:
 
 ```bash
 pnpm --dir wework/electron typecheck
-pnpm --dir wework/electron test src/host/computer-use-service.test.ts
+pnpm --dir wework/electron test \
+  src/host/computer-use-startup.test.ts \
+  src/host/computer-use-service.test.ts
 pnpm --filter wework test \
   src/components/settings/ComputerUseSettingsPage.test.tsx \
   src/features/computer-use/ComputerUseActivityIndicator.test.tsx \

--- a/docs/zh/wework/developer-guide/wework-computer-use.md
+++ b/docs/zh/wework/developer-guide/wework-computer-use.md
@@ -51,9 +51,15 @@ macOS 需要向实际运行的 Wework 应用授予：
 `Electron`。macOS 修改权限后通常需要重启对应应用进程。Windows 和 Linux
 不显示 macOS 权限引导，但仍由 Driver 报告平台能力和运行错误。
 
-总开关保存在 Wework 桌面偏好中。应用启动后读取偏好并尝试启动 Driver；权限尚未
-满足时保持启用意图但不创建 bridge，设置页持续显示缺少的权限。权限满足后状态查询
-会再次尝试启动。
+总开关保存在 Wework 桌面偏好中。Electron 配置 Desktop Runtime 时只创建
+`ComputerUseService`，不读取启用偏好，也不加载 Driver。主界面达到可操作状态后，
+Renderer 通过 `renderer.startupReady` 关闭启动页；Electron 随后只调度一次后台偏好
+恢复，不等待原生 Driver 初始化完成。这样 CUA 原生模块加载和 macOS 权限检查不会
+阻塞 Executor、Core DSH 或首个可操作工作台。
+
+后台恢复开始前会重新读取最新偏好；功能已关闭或应用正在退出时不启动 Driver。权限
+尚未满足时保持启用意图但不创建 bridge，设置页持续显示缺少的权限。权限满足后状态
+查询会再次尝试启动。
 
 ## 发布集成
 
@@ -97,7 +103,9 @@ WeWork.app/Contents/Resources/
 
 ```bash
 pnpm --dir wework/electron typecheck
-pnpm --dir wework/electron test src/host/computer-use-service.test.ts
+pnpm --dir wework/electron test \
+  src/host/computer-use-startup.test.ts \
+  src/host/computer-use-service.test.ts
 pnpm --filter wework test \
   src/components/settings/ComputerUseSettingsPage.test.tsx \
   src/features/computer-use/ComputerUseActivityIndicator.test.tsx \

--- a/wework/electron/src/host/computer-use-startup.test.ts
+++ b/wework/electron/src/host/computer-use-startup.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test, vi } from 'vitest'
+import { restoreComputerUseAfterStartup } from './computer-use-startup.js'
+
+describe('restoreComputerUseAfterStartup', () => {
+  test('restores enabled computer use after startup', async () => {
+    const setEnabled = vi.fn().mockResolvedValue(undefined)
+
+    await restoreComputerUseAfterStartup({
+      isShuttingDown: () => false,
+      readPreferences: async () => ({ computerUseEnabled: true }),
+      setEnabled,
+    })
+
+    expect(setEnabled).toHaveBeenCalledOnce()
+    expect(setEnabled).toHaveBeenCalledWith(true)
+  })
+
+  test('does not initialize computer use when it is disabled', async () => {
+    const setEnabled = vi.fn().mockResolvedValue(undefined)
+
+    await restoreComputerUseAfterStartup({
+      isShuttingDown: () => false,
+      readPreferences: async () => ({ computerUseEnabled: false }),
+      setEnabled,
+    })
+
+    expect(setEnabled).not.toHaveBeenCalled()
+  })
+
+  test('does not initialize computer use during shutdown', async () => {
+    const setEnabled = vi.fn().mockResolvedValue(undefined)
+    let shuttingDown = false
+
+    await restoreComputerUseAfterStartup({
+      isShuttingDown: () => shuttingDown,
+      readPreferences: async () => {
+        shuttingDown = true
+        return { computerUseEnabled: true }
+      },
+      setEnabled,
+    })
+
+    expect(setEnabled).not.toHaveBeenCalled()
+  })
+})

--- a/wework/electron/src/host/computer-use-startup.ts
+++ b/wework/electron/src/host/computer-use-startup.ts
@@ -1,0 +1,14 @@
+interface ComputerUseStartupOptions {
+  isShuttingDown: () => boolean
+  readPreferences: () => Promise<{ computerUseEnabled?: boolean }>
+  setEnabled: (enabled: boolean) => Promise<unknown>
+}
+
+export async function restoreComputerUseAfterStartup(
+  options: ComputerUseStartupOptions
+): Promise<void> {
+  if (options.isShuttingDown()) return
+  const preferences = await options.readPreferences()
+  if (options.isShuttingDown() || preferences.computerUseEnabled !== true) return
+  await options.setEnabled(true)
+}

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -45,6 +45,7 @@ import {
 } from './host/embedded-browser-manager.js'
 import { EmbeddedBrowserBridge } from './host/embedded-browser-bridge.js'
 import { ComputerUseService } from './host/computer-use-service.js'
+import { restoreComputerUseAfterStartup } from './host/computer-use-startup.js'
 import { materializeBundledRuntimes } from './runtime/bundled-runtime-materializer.js'
 import { waitForRendererSelector } from './host/renderer-readiness.js'
 import { desktopWindowFrameOptions } from './host/window-layout.js'
@@ -146,6 +147,7 @@ let pendingSystemDrops: Array<{
 let runtimeError: string | null = null
 let runtimePhase: 'initializing' | 'ready' | 'failed' = 'initializing'
 let runtimeStartPromise: Promise<void> | null = null
+let computerUseStartupScheduled = false
 let electronNodeRuntimePromise: Promise<ElectronNodeRuntime> | null = null
 let quitting = false
 let shutdownPromise: Promise<void> | null = null
@@ -1084,8 +1086,6 @@ async function configureDesktopRuntime(): Promise<void> {
   computerUse = new ComputerUseService(
     environment.WEGENT_EXECUTOR_HOME?.trim() || join(app.getPath('home'), '.wework')
   )
-  const savedPreferences = await preferences.read()
-  await computerUse.setEnabled(savedPreferences.computerUseEnabled === true)
   const runtimeRoot = environment.WEWORK_HARNESS_RUNTIME_ROOT?.trim()
   if (runtimeRoot) {
     smartApps = new SmartAppManager({
@@ -1163,6 +1163,7 @@ async function configureDesktopRuntime(): Promise<void> {
             await startupSplash?.close({
               capturePath: process.env.WEWORK_E2E_STARTUP_SPLASH_CAPTURE?.trim(),
             })
+            scheduleComputerUseStartup()
           },
           startupSplashSnapshot: () => startupSplash?.snapshot() ?? null,
           trayActivate: activation => trayManager?.activate(activation) ?? false,
@@ -1242,6 +1243,23 @@ async function configureDesktopRuntime(): Promise<void> {
       return desktopRuntime.requestExecutor(method, params)
     },
     apply: status => trayManager?.setNativeStatus(status),
+  })
+}
+
+function scheduleComputerUseStartup(): void {
+  if (computerUseStartupScheduled || quitting) return
+  const service = computerUse
+  const store = preferences
+  if (!service || !store) return
+  computerUseStartupScheduled = true
+  setImmediate(() => {
+    void restoreComputerUseAfterStartup({
+      isShuttingDown: () => quitting || computerUse !== service,
+      readPreferences: () => store.read(),
+      setEnabled: enabled => service.setEnabled(enabled),
+    }).catch(error => {
+      console.error('[computer-use] lazy startup failed', error)
+    })
   })
 }
 


### PR DESCRIPTION
## Summary

- remove computer-use native initialization from the Desktop Runtime startup critical path
- restore the saved computer-use preference once, in the background, after `renderer.startupReady` closes the startup window
- skip deferred initialization when the preference is disabled or the application is shutting down
- document the startup boundary in the Chinese and English computer-use developer guides

## Root cause

When `computerUseEnabled` was persisted as `true`, `configureDesktopRuntime()` synchronously awaited `ComputerUseService.setEnabled(true)`. Loading the CUA native module and checking macOS permissions therefore delayed Executor and Core DSH startup before the workbench could become actionable.

## Verification

- `pnpm --filter wework test electron/src/host/computer-use-startup.test.ts electron/src/host/computer-use-service.test.ts` — 8 tests passed
- `pnpm --dir wework/electron typecheck`
- Wework pre-push ESLint, Electron TypeScript, and unit-test gates passed
- isolated real Electron verification confirmed the workbench becomes actionable before computer use is enabled, and the setting can still be enabled and disabled
- isolated startup with `computerUseEnabled: true` confirmed the workbench becomes actionable and computer use is then restored to the expected macOS permission-waiting state

Related work item: WORK-312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Computer use now starts in the background after the main interface is ready, helping the app become usable faster.
  * Startup avoids loading computer-use components when the feature is disabled or the app is closing.
  * Latest computer-use preferences are checked before background initialization.
  * Startup errors no longer prevent the application from opening.

* **Documentation**
  * Updated English and Chinese setup and verification guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->