### PR TITLE
fix(wework): recover stalled desktop startup

### DIFF
--- a/wework/e2e/desktop/scenarios/native-window-startup.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/native-window-startup.scenario.mjs
@@ -21,6 +21,26 @@ async function waitForClosedStartupSplash(control) {
   )
 }
 
+async function waitForStartupLogs(resultDir) {
+  const logPath = join(resultDir, 'app.log')
+  const deadline = Date.now() + SPLASH_CLOSE_TIMEOUT_MS
+  let appLog = ''
+
+  do {
+    appLog = await readFile(logPath, 'utf8')
+    if (
+      appLog.includes("source: 'task-list'") &&
+      appLog.includes("step: 'renderer-startup-ready'") &&
+      appLog.includes("step: 'startup-splash-close'")
+    ) {
+      return appLog
+    }
+    await delay(SPLASH_CLOSE_POLL_INTERVAL_MS)
+  } while (Date.now() < deadline)
+
+  assert.fail(`The Electron startup log did not contain the required stages:\n${appLog}`)
+}
+
 export async function createDesktopScenario({ resultDir }) {
   return {
     async verify(control) {
@@ -40,6 +60,15 @@ export async function createDesktopScenario({ resultDir }) {
         image.subarray(1, 4).toString('ascii'),
         'PNG',
         'The Electron startup splash evidence was not a PNG'
+      )
+      const appLog = await waitForStartupLogs(resultDir)
+      const startupReady = appLog.indexOf("step: 'renderer-startup-ready'")
+      const taskListReady = appLog.indexOf("source: 'task-list'", startupReady)
+      const splashClosed = appLog.indexOf("step: 'startup-splash-close'")
+      assert.ok(taskListReady >= 0, 'The renderer did not log task-list readiness')
+      assert.ok(
+        startupReady <= taskListReady && taskListReady < splashClosed,
+        'The startup stages were logged out of order'
       )
     },
 

--- a/wework/electron/src/host/capability-router.ts
+++ b/wework/electron/src/host/capability-router.ts
@@ -88,6 +88,7 @@ export const HOST_CAPABILITIES = [
   'plugins.start',
   'plugins.stop',
   'rendererHealth.getState',
+  'renderer.startupFailed',
   'renderer.startupReady',
   'runtime.installCoreDshPlugin',
   'runtime.listCoreDshPlugins',

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -123,7 +123,8 @@ export interface ElectronE2EHost {
     executorPid: number | null
     workbenchRuntimes: unknown[]
   }
-  rendererStartupReady: () => void | Promise<void>
+  rendererStartupReady: (source: 'task-list' | 'other') => void | Promise<void>
+  rendererStartupFailed: () => void | Promise<void>
   startupSplashSnapshot: () => StartupSplashSnapshot | null
   trayActivate: (activation: TrayActivation) => boolean
   traySetState: (state: TrayMenuState) => void
@@ -180,6 +181,7 @@ export function createElectronCapabilityRouter(
       workbenchRuntimes: [],
     }),
     rendererStartupReady: () => undefined,
+    rendererStartupFailed: () => undefined,
     startupSplashSnapshot: () => null,
     trayActivate: () => false,
     traySetState: () => undefined,
@@ -210,7 +212,12 @@ export function createElectronCapabilityRouter(
   router.register('desktop.events', params =>
     desktopServices.events.read(integerParam(params, 'after') ?? 0)
   )
-  router.register('renderer.startupReady', () => e2eHost.rendererStartupReady())
+  router.register('renderer.startupReady', params =>
+    e2eHost.rendererStartupReady(
+      optionalStringParam(params, 'source') === 'task-list' ? 'task-list' : 'other'
+    )
+  )
+  router.register('renderer.startupFailed', () => e2eHost.rendererStartupFailed())
   router.register('diagnostics.filePreview', params => {
     const event = recordParam(params, 'event')
     return filePreviewLog.write('supervisor', JSON.stringify(event))

--- a/wework/electron/src/host/preferences-store.test.ts
+++ b/wework/electron/src/host/preferences-store.test.ts
@@ -31,4 +31,15 @@ describe('PreferencesStore', () => {
     })
     expect(await readFile(join(root, 'app-preferences.json'), 'utf8')).toContain('"theme": "dark"')
   })
+
+  test('clears persisted application preferences', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'wework-preferences-'))
+    roots.push(root)
+    const store = new PreferencesStore(root)
+    await store.update({ locale: 'zh-CN', appearanceMode: 'dark' })
+
+    await store.clear()
+
+    await expect(new PreferencesStore(root).read()).resolves.toEqual({})
+  })
 })

--- a/wework/electron/src/host/preferences-store.ts
+++ b/wework/electron/src/host/preferences-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 export class PreferencesStore {
@@ -22,6 +22,10 @@ export class PreferencesStore {
       await rename(temporary, path)
       return preferences
     })
+  }
+
+  clear(): Promise<void> {
+    return this.serial(() => rm(this.path(), { force: true }))
   }
 
   private path(): string {

--- a/wework/electron/src/host/renderer-storage-store.test.ts
+++ b/wework/electron/src/host/renderer-storage-store.test.ts
@@ -128,4 +128,30 @@ describe('RendererStorageStore', () => {
       '{"version":1,"entries":{"__proto__":"safe","constructor":"value"}}\n'
     )
   })
+
+  it('removes only matching recovery prefixes', async () => {
+    const { root, store } = await createStore()
+    await store.initialize({
+      auth_token: 'preserved-token',
+      appearance: 'dark',
+      'wework:workbench-split-groups:v3:fixed-task': 'stale-layout',
+      'wework.workspaceTabs.v3:workspace-1': 'stale-tabs',
+    })
+
+    await store.removeByPrefixes(['wework:workbench-split-groups:', 'wework.workspaceTabs.v3:'])
+
+    await expect(new RendererStorageStore(root).initialize({})).resolves.toEqual({
+      auth_token: 'preserved-token',
+      appearance: 'dark',
+    })
+  })
+
+  it('clears all renderer application state', async () => {
+    const { root, store } = await createStore()
+    await store.initialize({ auth_token: 'token', appearance: 'dark' })
+
+    await store.clear()
+
+    await expect(new RendererStorageStore(root).initialize({})).resolves.toEqual({})
+  })
 })

--- a/wework/electron/src/host/renderer-storage-store.ts
+++ b/wework/electron/src/host/renderer-storage-store.ts
@@ -75,6 +75,23 @@ export class RendererStorageStore {
     })
   }
 
+  removeByPrefixes(prefixes: readonly string[]): Promise<void> {
+    return this.serial(async () => {
+      const state = await this.readFile()
+      if (!state) return
+      const entries = Object.fromEntries(
+        Object.entries(state.entries).filter(
+          ([key]) => !prefixes.some(prefix => key.startsWith(prefix))
+        )
+      )
+      await this.writeFile({ version: 1, entries })
+    })
+  }
+
+  clear(): Promise<void> {
+    return this.serial(() => this.writeFile({ version: 1, entries: {} }))
+  }
+
   private path(): string {
     return join(this.dataDirectory, 'renderer-local-storage.json')
   }

--- a/wework/electron/src/host/startup-recovery.test.ts
+++ b/wework/electron/src/host/startup-recovery.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  assertStartupRecoverySender,
+  StartupRecoveryService,
+  WORKBENCH_RECOVERY_STORAGE_PREFIXES,
+  type StartupRecoveryDependencies,
+} from './startup-recovery.js'
+
+function createFixture() {
+  const dependencies = {
+    rendererStorage: {
+      clear: vi.fn(async () => undefined),
+      removeByPrefixes: vi.fn(async () => undefined),
+    },
+    preferences: {
+      clear: vi.fn(async () => undefined),
+    },
+    cloudCredentials: {
+      clear: vi.fn(async () => undefined),
+    },
+    clearCache: vi.fn(async () => undefined),
+    clearAppStorage: vi.fn(async () => undefined),
+    log: vi.fn(),
+    relaunch: vi.fn(),
+    shutdown: vi.fn(),
+  } satisfies StartupRecoveryDependencies
+  return {
+    dependencies,
+    recovery: new StartupRecoveryService(dependencies),
+  }
+}
+
+describe('StartupRecoveryService', () => {
+  test('allows only the startup splash sender', () => {
+    expect(() => assertStartupRecoverySender(7, 7)).not.toThrow()
+    expect(() => assertStartupRecoverySender(7, null)).toThrow(
+      'Startup recovery is only available from the startup splash'
+    )
+    expect(() => assertStartupRecoverySender(7, 8)).toThrow(
+      'Startup recovery is only available from the startup splash'
+    )
+  })
+
+  test('recovers workbench restore state without clearing sign-in or preferences', async () => {
+    const { dependencies, recovery } = createFixture()
+
+    await recovery.run('workbench')
+
+    expect(dependencies.rendererStorage.removeByPrefixes).toHaveBeenCalledWith(
+      WORKBENCH_RECOVERY_STORAGE_PREFIXES
+    )
+    expect(dependencies.rendererStorage.clear).not.toHaveBeenCalled()
+    expect(dependencies.preferences.clear).not.toHaveBeenCalled()
+    expect(dependencies.cloudCredentials.clear).not.toHaveBeenCalled()
+    expect(dependencies.relaunch).toHaveBeenCalledOnce()
+    expect(dependencies.shutdown).toHaveBeenCalledOnce()
+  })
+
+  test('clears application state without deleting runtime-owned data', async () => {
+    const { dependencies, recovery } = createFixture()
+
+    await recovery.run('app-state')
+
+    expect(dependencies.rendererStorage.clear).toHaveBeenCalledOnce()
+    expect(dependencies.preferences.clear).toHaveBeenCalledOnce()
+    expect(dependencies.cloudCredentials.clear).toHaveBeenCalledOnce()
+    expect(dependencies.clearCache).toHaveBeenCalledOnce()
+    expect(dependencies.clearAppStorage).toHaveBeenCalledOnce()
+    expect(dependencies.rendererStorage.removeByPrefixes).not.toHaveBeenCalled()
+    expect(dependencies.relaunch).toHaveBeenCalledOnce()
+    expect(dependencies.shutdown).toHaveBeenCalledOnce()
+  })
+
+  test('shares one recovery operation across repeated clicks', async () => {
+    const { dependencies, recovery } = createFixture()
+
+    await Promise.all([recovery.run('retry'), recovery.run('app-state')])
+
+    expect(dependencies.rendererStorage.clear).not.toHaveBeenCalled()
+    expect(dependencies.relaunch).toHaveBeenCalledOnce()
+    expect(dependencies.shutdown).toHaveBeenCalledOnce()
+  })
+
+  test('logs cleanup failures without relaunching', async () => {
+    const { dependencies, recovery } = createFixture()
+    dependencies.rendererStorage.removeByPrefixes.mockRejectedValueOnce(
+      new Error('storage unavailable')
+    )
+
+    await expect(recovery.run('workbench')).rejects.toThrow('storage unavailable')
+
+    expect(dependencies.log).toHaveBeenLastCalledWith(
+      'startup-recovery-workbench-cleanup',
+      'failed',
+      { errorType: 'Error' }
+    )
+    expect(dependencies.relaunch).not.toHaveBeenCalled()
+    expect(dependencies.shutdown).not.toHaveBeenCalled()
+  })
+})

--- a/wework/electron/src/host/startup-recovery.ts
+++ b/wework/electron/src/host/startup-recovery.ts
@@ -1,0 +1,76 @@
+export type StartupRecoveryMode = 'retry' | 'workbench' | 'app-state'
+
+export const WORKBENCH_RECOVERY_STORAGE_PREFIXES = [
+  'wework:workbench-split-groups:',
+  'wework:workbench-split-layout:',
+  'wework.workspaceTabs.v3:',
+  'wework.workspaceTabTransfer.v1:',
+] as const
+
+export interface StartupRecoveryDependencies {
+  rendererStorage: {
+    clear: () => Promise<void>
+    removeByPrefixes: (prefixes: readonly string[]) => Promise<void>
+  }
+  preferences: {
+    clear: () => Promise<void>
+  }
+  cloudCredentials: {
+    clear: () => Promise<void>
+  }
+  clearCache: () => Promise<void>
+  clearAppStorage: () => Promise<void>
+  log: (
+    step: string,
+    status: 'started' | 'completed' | 'failed',
+    details?: Record<string, unknown>
+  ) => void
+  relaunch: () => void
+  shutdown: () => void
+}
+
+export function assertStartupRecoverySender(senderId: number, splashWebContentsId: number | null) {
+  if (splashWebContentsId === null || senderId !== splashWebContentsId) {
+    throw new Error('Startup recovery is only available from the startup splash')
+  }
+}
+
+export class StartupRecoveryService {
+  private operation: Promise<void> | null = null
+
+  constructor(private readonly dependencies: StartupRecoveryDependencies) {}
+
+  run(mode: StartupRecoveryMode): Promise<void> {
+    if (this.operation) return this.operation
+    this.operation = this.runOnce(mode)
+    return this.operation
+  }
+
+  private async runOnce(mode: StartupRecoveryMode): Promise<void> {
+    this.dependencies.log(`startup-recovery-${mode}-cleanup`, 'started')
+    try {
+      if (mode === 'workbench') {
+        await this.dependencies.rendererStorage.removeByPrefixes(
+          WORKBENCH_RECOVERY_STORAGE_PREFIXES
+        )
+      } else if (mode === 'app-state') {
+        await Promise.all([
+          this.dependencies.rendererStorage.clear(),
+          this.dependencies.preferences.clear(),
+          this.dependencies.cloudCredentials.clear(),
+          this.dependencies.clearCache(),
+          this.dependencies.clearAppStorage(),
+        ])
+      }
+      this.dependencies.log(`startup-recovery-${mode}-cleanup`, 'completed')
+    } catch (error) {
+      this.dependencies.log(`startup-recovery-${mode}-cleanup`, 'failed', {
+        errorType: error instanceof Error ? error.name : typeof error,
+      })
+      throw error
+    }
+    this.dependencies.relaunch()
+    this.dependencies.log('startup-recovery-relaunch', 'completed')
+    this.dependencies.shutdown()
+  }
+}

--- a/wework/electron/src/host/startup-splash.test.ts
+++ b/wework/electron/src/host/startup-splash.test.ts
@@ -93,6 +93,9 @@ describe('StartupSplash', () => {
     expect(html).toContain('class="human-working-arm"')
     expect(html).toContain('class="robot-working-arm"')
     expect(html).toContain('aria-valuemax="3"')
+    expect(html).toContain('id="startup-recover"')
+    expect(html).toContain('id="startup-reset-open"')
+    expect(html).toContain('id="startup-confirmation"')
     expect(styles).toContain('@keyframes robot-bob')
     expect(styles).toContain('@keyframes human-bob')
     expect(styles).toContain('@keyframes splash-enter')
@@ -105,8 +108,13 @@ describe('StartupSplash', () => {
     expect(script).toContain("navigator.language.toLowerCase().startsWith('zh')")
     expect(script).toContain("stageIndicator.setAttribute('aria-valuenow'")
     expect(script).toContain('启动时间比预期稍长')
-    expect(script).toContain('仍在加载项目和会话，请稍候…')
+    expect(script).toContain('仍在加载任务列表，请稍候…')
     expect(script).toContain('}, 10_000)')
+    expect(script).toContain('}, 30_000)')
+    expect(script).toContain("'wework-startup-error'")
+    expect(script).toContain("runRecoveryAction('retry')")
+    expect(script).toContain("showConfirmation('recover')")
+    expect(script).toContain("showConfirmation('resetAppState')")
     expect(script).toMatch(
       /requestAnimationFrame\(\(\) => \{\s+requestAnimationFrame\(\(\) => \{\s+document\.documentElement\.dataset\.animationReady = 'true'/
     )
@@ -143,6 +151,17 @@ describe('StartupSplash', () => {
     const snapshot = await show()
 
     expect(snapshot.theme).toBe('dark')
+  })
+
+  test('notifies the splash renderer when startup fails', async () => {
+    const { show, splash, target } = createFixture()
+    await show()
+
+    await splash.showError()
+
+    expect(target.webContents.executeJavaScript).toHaveBeenLastCalledWith(
+      expect.stringContaining('wework-startup-error')
+    )
   })
 
   test('resolves explicit appearance modes before falling back to the system theme', () => {

--- a/wework/electron/src/host/startup-splash.test.ts
+++ b/wework/electron/src/host/startup-splash.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
+import { runInNewContext } from 'node:vm'
 import { describe, expect, test, vi } from 'vitest'
 import {
   createStartupSplash,
@@ -70,6 +71,31 @@ function createFixture(theme: StartupSplashTheme = 'light') {
   return { show, splash, target, writePng }
 }
 
+class FakeSplashElement {
+  readonly classList = {
+    add: vi.fn(),
+    remove: vi.fn(),
+    toggle: vi.fn(),
+  }
+  readonly dataset: Record<string, string> = {}
+  readonly listeners = new Map<string, () => void>()
+  disabled = false
+  hidden = true
+  textContent = ''
+
+  addEventListener(event: string, listener: () => void): void {
+    this.listeners.set(event, listener)
+  }
+
+  click(): void {
+    this.listeners.get('click')?.()
+  }
+
+  focus(): void {}
+
+  setAttribute(): void {}
+}
+
 describe('StartupSplash', () => {
   test('ships a visible loading animation that reports readiness after two frames', async () => {
     const electronRoot =
@@ -118,6 +144,64 @@ describe('StartupSplash', () => {
     expect(script).toMatch(
       /requestAnimationFrame\(\(\) => \{\s+requestAnimationFrame\(\(\) => \{\s+document\.documentElement\.dataset\.animationReady = 'true'/
     )
+  })
+
+  test('invokes recoverWorkbench after confirming workbench recovery', async () => {
+    const electronRoot =
+      basename(process.cwd()) === 'electron' ? process.cwd() : join(process.cwd(), 'electron')
+    const script = await readFile(
+      join(electronRoot, 'src', 'shell', 'startup-splash', 'splash.js'),
+      'utf8'
+    )
+    const elements = new Map<string, FakeSplashElement>()
+    const element = (selector: string) => {
+      const existing = elements.get(selector)
+      if (existing) return existing
+      const created = new FakeSplashElement()
+      elements.set(selector, created)
+      return created
+    }
+    const recoverWorkbench = vi.fn(async () => undefined)
+    const windowListeners = new Map<string, () => void>()
+    const documentElement = element('documentElement')
+
+    runInNewContext(script, {
+      document: {
+        activeElement: null,
+        body: element('body'),
+        documentElement,
+        querySelector: (selector: string) => element(selector),
+        querySelectorAll: () => [
+          new FakeSplashElement(),
+          new FakeSplashElement(),
+          new FakeSplashElement(),
+        ],
+      },
+      HTMLElement: FakeSplashElement,
+      navigator: { language: 'en-US' },
+      performance: { now: () => 0 },
+      requestAnimationFrame: vi.fn(),
+      window: {
+        addEventListener: (event: string, listener: () => void) => {
+          windowListeners.set(event, listener)
+        },
+        matchMedia: () => ({ matches: true }),
+        requestAnimationFrame: vi.fn(),
+        setInterval: vi.fn(),
+        setTimeout: vi.fn(),
+        weworkStartupRecovery: {
+          recoverWorkbench,
+          resetAppState: vi.fn(),
+          retry: vi.fn(),
+        },
+      },
+    })
+
+    element('#startup-recover').click()
+    element('#startup-confirmation-submit').click()
+    await Promise.resolve()
+
+    expect(recoverWorkbench).toHaveBeenCalledOnce()
   })
 
   test('shows the branded animation in the main startup window and records its timeline', async () => {

--- a/wework/electron/src/host/startup-splash.ts
+++ b/wework/electron/src/host/startup-splash.ts
@@ -94,6 +94,7 @@ export class StartupSplash {
   private state: StartupSplashSnapshot['state'] = 'idle'
   private showPromise: Promise<StartupSplashSnapshot> | null = null
   private closePromise: Promise<StartupSplashSnapshot> | null = null
+  private showErrorPromise: Promise<void> | null = null
   private controlledClose = false
 
   constructor(private readonly options: StartupSplashOptions) {
@@ -124,6 +125,19 @@ export class StartupSplash {
       this.closePromise = null
     })
     return this.closePromise
+  }
+
+  showError(): Promise<void> {
+    if (this.showErrorPromise) return this.showErrorPromise
+    const target = this.options.window
+    if (target.webContents.isDestroyed()) return Promise.resolve()
+    this.showErrorPromise = target.webContents
+      .executeJavaScript("window.dispatchEvent(new CustomEvent('wework-startup-error')); true")
+      .then(() => undefined)
+      .finally(() => {
+        this.showErrorPromise = null
+      })
+    return this.showErrorPromise
   }
 
   private async closeOnce(options: CloseStartupSplashOptions): Promise<StartupSplashSnapshot> {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -58,6 +58,7 @@ import {
   startupSplashBlocksMainWindowActivation,
   type StartupSplashTheme,
 } from './host/startup-splash.js'
+import { assertStartupRecoverySender, StartupRecoveryService } from './host/startup-recovery.js'
 import { ElectronTrayManager, type TrayAction } from './host/tray-manager.js'
 import { createTrayIcon } from './host/tray-icon.js'
 import { TrayNativeStatusController } from './host/tray-native-status.js'
@@ -97,6 +98,7 @@ const packageMetadata = createRequire(import.meta.url)('../package.json') as {
   weworkUpdateBaseUrl?: string
 } & BrandRuntimeMetadata
 const dshPreloadPath = resolve(packageRoot, 'dist/dsh-preload.cjs')
+const startupSplashPreloadPath = resolve(packageRoot, 'dist/startup-splash-preload.cjs')
 const browserAnnotationPreloadPath = resolve(packageRoot, 'dist/browser-annotation-preload.cjs')
 const developmentResourcesRoot = resolve(packageRoot, '..', 'resources')
 const { autoUpdater } = electronUpdater
@@ -111,6 +113,20 @@ const applicationId =
   packageMetadata.weworkAppId?.trim() ||
   'io.wecode.wework'
 const DEFAULT_POPOUT_WINDOW_SHORTCUT = 'Alt+Shift+Space'
+const startupStartedAt = performance.now()
+
+function logStartupStep(
+  step: string,
+  status: 'started' | 'completed' | 'failed',
+  details: Record<string, unknown> = {}
+): void {
+  console.info('[startup]', {
+    step,
+    status,
+    elapsedMs: Math.round(performance.now() - startupStartedAt),
+    ...details,
+  })
+}
 
 const configuredUserDataPath = process.env.WEWORK_USER_DATA_DIR?.trim()
 const userDataPath = resolve(configuredUserDataPath || join(app.getPath('appData'), applicationId))
@@ -156,6 +172,7 @@ let rendererStorage: RendererStorageStore | null = null
 let cloudCredentials: CloudCredentialService | null = null
 let windowClosePolicy: WindowClosePolicy | null = null
 let startupSplash: StartupSplash | null = null
+let startupRecovery: StartupRecoveryService | null = null
 let componentUpdates: DesktopComponentUpdateController | null = null
 let trayManager: ElectronTrayManager<Electron.Menu | null, Tray> | null = null
 let trayNativeStatus: TrayNativeStatusController | null = null
@@ -389,6 +406,7 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
   if (!mainWindow || !desktopRuntime) return
   if (!desktopRuntime.state().ready) return
   if (primaryDshLoaded) return
+  logStartupStep('primary-renderer-load', 'started')
   rendererHealth.loading()
   const dshUrl = desktopRuntime.coreDshUrl()
   const contents = mainWindow.webContents
@@ -401,6 +419,7 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
     primaryDshLoaded = true
     runtimeError = null
     rendererHealth.ready()
+    logStartupStep('primary-renderer-load', 'completed')
   })
   contents.on('unresponsive', () => rendererHealth.unresponsive())
   contents.on('responsive', () => rendererHealth.responsive())
@@ -433,6 +452,7 @@ const loadPrimaryDshView = createSingleFlight(async (): Promise<void> => {
   } catch (error) {
     primaryDshLoaded = false
     rendererHealth.failed('renderer_load_failed')
+    logStartupStep('primary-renderer-load', 'failed')
     throw error
   }
 })
@@ -722,6 +742,7 @@ async function updateDesktopPreferences(
 }
 
 async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
+  logStartupStep('windows-create', 'started', { theme: startupTheme })
   mainWindow = new BrowserWindow({
     ...desktopWindowFrameOptions(),
     width: 1440,
@@ -746,6 +767,7 @@ async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
     backgroundColor: startupTheme === 'dark' ? '#101316' : '#fafafa',
     show: false,
     webPreferences: {
+      preload: startupSplashPreloadPath,
       nodeIntegration: false,
       contextIsolation: true,
       sandbox: true,
@@ -792,11 +814,18 @@ async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
   const mainShellLoading = mainWindow.loadFile(resolve(packageRoot, 'dist/shell/index.html'), {
     query: { theme: startupTheme },
   })
+  logStartupStep('startup-splash-load', 'started')
   await startupSplashWindow.loadFile(resolve(packageRoot, 'dist/shell/startup-splash/index.html'), {
     query: { theme: startupTheme },
   })
+  logStartupStep('startup-splash-load', 'completed')
+  logStartupStep('startup-splash-show', 'started')
   await startupSplash.show()
+  logStartupStep('startup-splash-show', 'completed')
+  logStartupStep('main-shell-load', 'started')
   await mainShellLoading
+  logStartupStep('main-shell-load', 'completed')
+  logStartupStep('windows-create', 'completed')
 }
 
 async function setDockVisible(visible: boolean): Promise<void> {
@@ -909,6 +938,21 @@ function createTrayManager(): ElectronTrayManager<Electron.Menu | null, Tray> {
 }
 
 function installIpc(): void {
+  ipcMain.handle('startup-recovery:retry', event => {
+    assertStartupRecoverySender(event.sender.id, startupSplashWindow?.webContents.id ?? null)
+    logStartupStep('startup-recovery-retry', 'started')
+    return requiredStartupRecovery().run('retry')
+  })
+  ipcMain.handle('startup-recovery:recover-workbench', event => {
+    assertStartupRecoverySender(event.sender.id, startupSplashWindow?.webContents.id ?? null)
+    logStartupStep('startup-recovery-workbench', 'started')
+    return requiredStartupRecovery().run('workbench')
+  })
+  ipcMain.handle('startup-recovery:reset-app-state', event => {
+    assertStartupRecoverySender(event.sender.id, startupSplashWindow?.webContents.id ?? null)
+    logStartupStep('startup-recovery-app-state', 'started')
+    return requiredStartupRecovery().run('app-state')
+  })
   ipcMain.handle('cloud-credentials:get-device-public-key', () =>
     requiredCloudCredentials().devicePublicKey()
   )
@@ -1054,9 +1098,10 @@ function smartAppRuntimeHost(): SmartAppRuntimeHost | null {
 
 async function configureDesktopRuntime(): Promise<void> {
   if (desktopRuntime) return
+  logStartupStep('runtime-configure', 'started')
   const environment = await desktopEnvironment()
   if (!preferences) throw new Error('Desktop preferences are unavailable')
-  rendererStorage = new RendererStorageStore(app.getPath('userData'))
+  if (!rendererStorage) throw new Error('Renderer storage is unavailable')
   workbenchPlugins = new WorkbenchPluginManager()
   const feedback = new FeedbackBundleManager({
     appVersion: () => app.getVersion(),
@@ -1157,12 +1202,19 @@ async function configureDesktopRuntime(): Promise<void> {
           },
           hideMainWindow: hideMainWindowToBackground,
           dockVisible: () => dockVisible,
-          rendererStartupReady: async () => {
+          rendererStartupReady: async source => {
             if (!mainWindow || mainWindow.isDestroyed()) return
+            logStartupStep('renderer-startup-ready', 'completed', { source })
             if (!keepE2EWindowInBackground) mainWindow.show()
+            logStartupStep('main-window-show', 'completed')
             await startupSplash?.close({
               capturePath: process.env.WEWORK_E2E_STARTUP_SPLASH_CAPTURE?.trim(),
             })
+            logStartupStep('startup-splash-close', 'completed')
+          },
+          rendererStartupFailed: () => {
+            logStartupStep('renderer-startup', 'failed')
+            return startupSplash?.showError()
           },
           startupSplashSnapshot: () => startupSplash?.snapshot() ?? null,
           trayActivate: activation => trayManager?.activate(activation) ?? false,
@@ -1243,6 +1295,7 @@ async function configureDesktopRuntime(): Promise<void> {
     },
     apply: status => trayManager?.setNativeStatus(status),
   })
+  logStartupStep('runtime-configure', 'completed')
 }
 
 function notifyRuntimeChanged(): void {
@@ -1251,16 +1304,22 @@ function notifyRuntimeChanged(): void {
 
 function startDesktopRuntime(): Promise<void> {
   if (runtimeStartPromise) return runtimeStartPromise
+  logStartupStep('desktop-runtime-start', 'started')
   runtimePhase = 'initializing'
   runtimeError = null
   notifyRuntimeChanged()
   runtimeStartPromise = (async () => {
     await configureDesktopRuntime()
+    logStartupStep('core-dsh-start', 'started')
     await desktopRuntime?.start()
+    logStartupStep('core-dsh-start', 'completed')
     trayNativeStatus?.start()
     await loadPrimaryDshView()
+    logStartupStep('component-update-confirmation', 'started')
     await componentUpdates?.confirmStartup()
+    logStartupStep('component-update-confirmation', 'completed')
     runtimePhase = 'ready'
+    logStartupStep('desktop-runtime-start', 'completed')
     if (shouldStageDesktopComponentUpdates(process.env)) {
       void componentUpdates
         ?.stageAvailableUpdate()
@@ -1281,10 +1340,14 @@ function startDesktopRuntime(): Promise<void> {
       }
       runtimePhase = 'failed'
       runtimeError = error instanceof Error ? error.message : String(error)
+      logStartupStep('desktop-runtime-start', 'failed', {
+        errorType: error instanceof Error ? error.name : typeof error,
+      })
       console.error('[runtime] startup failed', error)
-      if (!keepE2EWindowInBackground) mainWindow?.show()
-      void startupSplash?.close().catch(splashError => {
-        console.error('[startup-splash] failed to close after runtime failure', splashError)
+      void startupSplash?.showError().catch(async splashError => {
+        console.error('[startup-splash] failed to show runtime failure', splashError)
+        if (!keepE2EWindowInBackground) mainWindow?.show()
+        await startupSplash?.close()
       })
     })
     .finally(() => {
@@ -1296,19 +1359,39 @@ function startDesktopRuntime(): Promise<void> {
 
 if (hasSingleInstanceLock) {
   app.whenReady().then(async () => {
+    logStartupStep('electron-ready', 'completed')
+    logStartupStep('log-retention-start', 'started')
     await logRetention.start()
+    logStartupStep('log-retention-start', 'completed')
     if (keepE2EWindowInBackground) {
       app.hide()
       app.dock?.hide()
       dockVisible = false
     }
     preferences = new PreferencesStore(app.getPath('userData'))
+    rendererStorage = new RendererStorageStore(app.getPath('userData'))
+    logStartupStep('desktop-stores-create', 'completed')
     popoutShortcut = new GlobalShortcutController(globalShortcut, showPopoutWindow, error =>
       console.error('[popout-window] global shortcut failed', error)
     )
     cloudCredentials = new CloudCredentialService(app.getPath('userData'))
+    startupRecovery = new StartupRecoveryService({
+      rendererStorage,
+      preferences,
+      cloudCredentials,
+      clearCache: () => session.defaultSession.clearCache(),
+      clearAppStorage: () =>
+        session.defaultSession.clearStorageData({
+          storages: ['serviceworkers', 'cachestorage'],
+        }),
+      log: logStartupStep,
+      relaunch: () => app.relaunch(),
+      shutdown: () => requestApplicationShutdown(() => app.exit(0)),
+    })
+    logStartupStep('startup-recovery-install', 'completed')
     installDshWindowLabelHeaders()
     installIpc()
+    logStartupStep('desktop-ipc-install', 'completed')
     systemResume.start()
     windowClosePolicy = new WindowClosePolicy({
       read: async () => {
@@ -1328,6 +1411,7 @@ if (hasSingleInstanceLock) {
     createdTrayManager.create()
     trayManager = createdTrayManager
     const startupPreferences = await preferences.read()
+    logStartupStep('startup-preferences-read', 'completed')
     try {
       popoutShortcut.configure(resolvePopoutShortcut(startupPreferences))
     } catch (error) {
@@ -1464,6 +1548,11 @@ function requiredPreferences(): PreferencesStore {
 function requiredCloudCredentials(): CloudCredentialService {
   if (!cloudCredentials) throw new Error('Desktop cloud credentials are unavailable')
   return cloudCredentials
+}
+
+function requiredStartupRecovery(): StartupRecoveryService {
+  if (!startupRecovery) throw new Error('Startup recovery is unavailable')
+  return startupRecovery
 }
 
 function requiredText(value: unknown, name: string): string {

--- a/wework/electron/src/shell/startup-splash/index.html
+++ b/wework/electron/src/shell/startup-splash/index.html
@@ -135,6 +135,61 @@
           <span class="stage-dot"></span>
           <span class="stage-dot"></span>
         </div>
+        <div id="startup-recovery" class="startup-recovery" hidden>
+          <div class="startup-actions">
+            <button
+              id="startup-retry"
+              data-testid="startup-retry-button"
+              class="startup-button startup-button-secondary"
+              type="button"
+            >
+              Retry
+            </button>
+            <button
+              id="startup-recover"
+              data-testid="startup-recover-button"
+              class="startup-button startup-button-primary"
+              type="button"
+            >
+              Recover workbench
+            </button>
+            <button
+              id="startup-reset-open"
+              data-testid="startup-reset-options-button"
+              class="startup-link-button"
+              type="button"
+            >
+              More reset options
+            </button>
+          </div>
+          <p id="startup-action-error" class="startup-action-error" role="alert" hidden></p>
+        </div>
+        <div
+          id="startup-confirmation"
+          class="startup-confirmation"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="startup-confirmation-title"
+          aria-describedby="startup-confirmation-description"
+          hidden
+        >
+          <h2 id="startup-confirmation-title"></h2>
+          <p id="startup-confirmation-description"></p>
+          <div class="startup-confirmation-actions">
+            <button
+              id="startup-confirmation-cancel"
+              data-testid="startup-confirmation-cancel-button"
+              class="startup-button startup-button-secondary"
+              type="button"
+            ></button>
+            <button
+              id="startup-confirmation-submit"
+              data-testid="startup-confirmation-submit-button"
+              class="startup-button startup-button-danger"
+              type="button"
+            ></button>
+          </div>
+        </div>
       </main>
     </div>
     <script src="./splash.js"></script>

--- a/wework/electron/src/shell/startup-splash/splash.js
+++ b/wework/electron/src/shell/startup-splash/splash.js
@@ -203,7 +203,9 @@ recoverButton.addEventListener('click', () => showConfirmation('recover'))
 resetOpenButton.addEventListener('click', () => showConfirmation('resetAppState'))
 confirmationCancel.addEventListener('click', hideConfirmation)
 confirmationSubmit.addEventListener('click', () => {
-  if (pendingResetMode) void runRecoveryAction(pendingResetMode)
+  if (!pendingResetMode) return
+  const action = pendingResetMode === 'recover' ? 'recoverWorkbench' : pendingResetMode
+  void runRecoveryAction(action)
 })
 window.addEventListener('keydown', event => {
   if (event.key === 'Escape' && !confirmationElement.hidden) {

--- a/wework/electron/src/shell/startup-splash/splash.js
+++ b/wework/electron/src/shell/startup-splash/splash.js
@@ -38,6 +38,16 @@ const stageIndicator = document.querySelector('#stage-indicator')
 const statusElement = document.querySelector('#splash-status')
 const titleElement = document.querySelector('#splash-title')
 const stageDots = [...document.querySelectorAll('.stage-dot')]
+const recoveryElement = document.querySelector('#startup-recovery')
+const retryButton = document.querySelector('#startup-retry')
+const recoverButton = document.querySelector('#startup-recover')
+const resetOpenButton = document.querySelector('#startup-reset-open')
+const actionErrorElement = document.querySelector('#startup-action-error')
+const confirmationElement = document.querySelector('#startup-confirmation')
+const confirmationTitle = document.querySelector('#startup-confirmation-title')
+const confirmationDescription = document.querySelector('#startup-confirmation-description')
+const confirmationCancel = document.querySelector('#startup-confirmation-cancel')
+const confirmationSubmit = document.querySelector('#startup-confirmation-submit')
 const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
 const isChinese = navigator.language.toLowerCase().startsWith('zh')
 const currentPaths = stages[0].paths.map(path => [...path])
@@ -45,6 +55,10 @@ const velocities = stages[0].paths.map(path => path.map(() => 0))
 let stageIndex = prefersReducedMotion ? stages.length - 1 : 0
 let previousTime = performance.now()
 let slowStartup = false
+let startupFailed = false
+let pendingResetMode = null
+let actionPending = false
+let confirmationTrigger = null
 
 function pathData(points) {
   let data = `M${points[0]} ${points[1]}`
@@ -64,13 +78,17 @@ function updateCopy(index, animate) {
   const stage = stages[index]
   document.documentElement.lang = isChinese ? 'zh-CN' : 'en'
   document.body.dataset.stage = String(index)
-  titleElement.textContent = slowStartup
+  titleElement.textContent = startupFailed
     ? isChinese
-      ? '启动时间比预期稍长'
-      : 'Startup is taking longer than expected'
-    : isChinese
-      ? '我们正在准备工作台'
-      : "We're preparing your workbench"
+      ? 'Wework 启动失败'
+      : 'Wework could not start'
+    : slowStartup
+      ? isChinese
+        ? '启动时间比预期稍长'
+        : 'Startup is taking longer than expected'
+      : isChinese
+        ? '我们正在准备工作台'
+        : "We're preparing your workbench"
   splashRoot.setAttribute('aria-label', isChinese ? 'Wework 正在启动' : 'Wework is starting')
   stageIndicator.setAttribute(
     'aria-label',
@@ -79,13 +97,17 @@ function updateCopy(index, animate) {
   stageIndicator.setAttribute('aria-valuenow', String(index + 1))
 
   const replaceStatus = () => {
-    statusElement.textContent = slowStartup
+    statusElement.textContent = startupFailed
       ? isChinese
-        ? '仍在加载项目和会话，请稍候…'
-        : 'Still loading your projects and conversations…'
-      : isChinese
-        ? stage.zh
-        : stage.en
+        ? '你可以重试，或重置启动状态后重新打开'
+        : 'Retry, or reset startup state and reopen Wework'
+      : slowStartup
+        ? isChinese
+          ? '仍在加载任务列表，请稍候…'
+          : 'Still loading your task list…'
+        : isChinese
+          ? stage.zh
+          : stage.en
     statusElement.classList.remove('is-changing')
   }
 
@@ -100,6 +122,104 @@ function updateCopy(index, animate) {
     dot.classList.toggle('is-active', dotIndex === index)
   })
 }
+
+function setLocalizedActionCopy() {
+  retryButton.textContent = isChinese ? '重新启动' : 'Restart'
+  recoverButton.textContent = isChinese ? '恢复工作台' : 'Recover workbench'
+  resetOpenButton.textContent = isChinese ? '更多重置选项' : 'More reset options'
+  confirmationCancel.textContent = isChinese ? '取消' : 'Cancel'
+}
+
+function showRecovery() {
+  recoveryElement.hidden = false
+  document.documentElement.dataset.recoveryVisible = 'true'
+}
+
+function showConfirmation(mode) {
+  pendingResetMode = mode
+  confirmationTrigger = document.activeElement
+  confirmationElement.hidden = false
+  document.documentElement.dataset.confirmationVisible = 'true'
+  if (mode === 'recover') {
+    confirmationTitle.textContent = isChinese ? '恢复工作台？' : 'Recover the workbench?'
+    confirmationDescription.textContent = isChinese
+      ? '将清除标签页、分屏和上次会话恢复状态。登录、项目、任务和偏好设置不会受到影响。'
+      : 'This clears tabs, split layouts, and previous-session restore state. Your sign-in, projects, tasks, and preferences are preserved.'
+    confirmationSubmit.textContent = isChinese ? '恢复并重启' : 'Recover and restart'
+    confirmationSubmit.classList.remove('startup-button-danger')
+    confirmationSubmit.classList.add('startup-button-primary')
+    confirmationSubmit.focus()
+    return
+  }
+  confirmationTitle.textContent = isChinese ? '彻底重置应用状态？' : 'Reset all app state?'
+  confirmationDescription.textContent = isChinese
+    ? '将退出登录，并清除界面偏好、标签页和应用缓存。本地任务、插件、智能应用和工作目录会保留。'
+    : 'This signs you out and clears UI preferences, tabs, and app caches. Local tasks, plugins, Smart apps, and workspaces are preserved.'
+  confirmationSubmit.textContent = isChinese ? '彻底重置并重启' : 'Reset and restart'
+  confirmationSubmit.classList.remove('startup-button-primary')
+  confirmationSubmit.classList.add('startup-button-danger')
+  confirmationSubmit.focus()
+}
+
+function hideConfirmation() {
+  if (actionPending) return
+  pendingResetMode = null
+  confirmationElement.hidden = true
+  delete document.documentElement.dataset.confirmationVisible
+  if (confirmationTrigger instanceof HTMLElement) confirmationTrigger.focus()
+  confirmationTrigger = null
+}
+
+function setActionPending(pending) {
+  actionPending = pending
+  retryButton.disabled = pending
+  recoverButton.disabled = pending
+  resetOpenButton.disabled = pending
+  confirmationCancel.disabled = pending
+  confirmationSubmit.disabled = pending
+}
+
+async function runRecoveryAction(action) {
+  actionErrorElement.hidden = true
+  setActionPending(true)
+  try {
+    const recovery = window.weworkStartupRecovery
+    if (!recovery || typeof recovery[action] !== 'function') {
+      throw new Error('Startup recovery is unavailable')
+    }
+    await recovery[action]()
+  } catch {
+    setActionPending(false)
+    actionErrorElement.textContent = isChinese
+      ? '操作失败，请重新尝试。'
+      : 'The operation failed. Please try again.'
+    actionErrorElement.hidden = false
+  }
+}
+
+setLocalizedActionCopy()
+retryButton.addEventListener('click', () => void runRecoveryAction('retry'))
+recoverButton.addEventListener('click', () => showConfirmation('recover'))
+resetOpenButton.addEventListener('click', () => showConfirmation('resetAppState'))
+confirmationCancel.addEventListener('click', hideConfirmation)
+confirmationSubmit.addEventListener('click', () => {
+  if (pendingResetMode) void runRecoveryAction(pendingResetMode)
+})
+window.addEventListener('keydown', event => {
+  if (event.key === 'Escape' && !confirmationElement.hidden) {
+    event.preventDefault()
+    hideConfirmation()
+  }
+})
+
+window.addEventListener('wework-startup-error', () => {
+  startupFailed = true
+  slowStartup = true
+  document.body.dataset.startupError = 'true'
+  document.body.dataset.slowStartup = 'true'
+  updateCopy(stageIndex, true)
+  showRecovery()
+})
 
 function animateMorph(time) {
   const delta = Math.min((time - previousTime) / 1000, 0.032)
@@ -133,7 +253,7 @@ if (prefersReducedMotion) {
   requestAnimationFrame(animateMorph)
   window.setInterval(() => {
     stageIndex = (stageIndex + 1) % stages.length
-    if (!slowStartup) updateCopy(stageIndex, true)
+    if (!slowStartup && !startupFailed) updateCopy(stageIndex, true)
   }, 1150)
 }
 
@@ -142,6 +262,10 @@ window.setTimeout(() => {
   document.body.dataset.slowStartup = 'true'
   updateCopy(stageIndex, true)
 }, 10_000)
+
+window.setTimeout(() => {
+  if (!startupFailed) showRecovery()
+}, 30_000)
 
 requestAnimationFrame(() => {
   requestAnimationFrame(() => {

--- a/wework/electron/src/shell/startup-splash/styles.css
+++ b/wework/electron/src/shell/startup-splash/styles.css
@@ -173,6 +173,15 @@ body {
   box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
   opacity: 0;
   transform: translate(-50%, calc(-50% + 12px)) scale(0.97);
+  transition: height 220ms ease;
+}
+
+:root[data-recovery-visible='true'] .splash {
+  height: 304px;
+}
+
+:root[data-confirmation-visible='true'] .splash {
+  height: 286px;
 }
 
 :root[data-animation-ready='true'] .splash {
@@ -490,6 +499,98 @@ body[data-stage='2'] .monitor-status {
 .stage-dot.is-active {
   width: 14px;
   background: #7c3aed;
+}
+
+.startup-recovery {
+  width: 100%;
+  margin-top: 10px;
+  padding: 0 24px;
+}
+
+.startup-actions,
+.startup-confirmation-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.startup-button,
+.startup-link-button {
+  border: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.startup-button {
+  min-height: 30px;
+  padding: 6px 11px;
+  color: #383838;
+  border: 1px solid rgb(23 23 23 / 12%);
+  border-radius: 8px;
+  background: #fff;
+  font-size: 12px;
+}
+
+.startup-button-primary {
+  color: #fff;
+  border-color: #303030;
+  background: #303030;
+}
+
+.startup-button-danger {
+  color: #fff;
+  border-color: #dc2626;
+  background: #dc2626;
+}
+
+.startup-link-button {
+  padding: 5px 2px;
+  color: #1677c8;
+  background: transparent;
+  font-size: 12px;
+}
+
+.startup-button:focus-visible,
+.startup-link-button:focus-visible {
+  outline: 2px solid #339cff;
+  outline-offset: 2px;
+}
+
+.startup-button:disabled,
+.startup-link-button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.startup-action-error {
+  margin: 7px 0 0;
+  color: #b91c1c;
+  font-size: 11px;
+}
+
+.startup-confirmation {
+  width: calc(100% - 48px);
+  text-align: center;
+}
+
+.startup-confirmation h2 {
+  margin: 4px 0 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.startup-confirmation p {
+  margin: 8px auto 12px;
+  max-width: 330px;
+  line-height: 17px;
+}
+
+:root[data-confirmation-visible='true'] .workbench-scene,
+:root[data-confirmation-visible='true'] .splash-copy,
+:root[data-confirmation-visible='true'] .stage-indicator,
+:root[data-confirmation-visible='true'] .startup-recovery {
+  display: none;
 }
 
 @keyframes floor-arrive {
@@ -833,6 +934,32 @@ body[data-stage='2'] .monitor-status {
 
   .stage-dot {
     background: rgb(255 255 255 / 16%);
+  }
+
+  .startup-button {
+    color: #e5e5e5;
+    border-color: rgb(255 255 255 / 16%);
+    background: #262626;
+  }
+
+  .startup-button-primary {
+    color: #181818;
+    border-color: #f3f3f3;
+    background: #f3f3f3;
+  }
+
+  .startup-button-danger {
+    color: #fff;
+    border-color: #dc2626;
+    background: #dc2626;
+  }
+
+  .startup-link-button {
+    color: #66b8ff;
+  }
+
+  .startup-action-error {
+    color: #fca5a5;
   }
 }
 

--- a/wework/electron/src/shell/startup-splash/styles.css
+++ b/wework/electron/src/shell/startup-splash/styles.css
@@ -1,5 +1,9 @@
 :root {
   color-scheme: light;
+  --text-code-sm: 11px;
+  --text-xs: 12px;
+  --text-base: 14px;
+  --text-lg: 16px;
   font-family:
     ui-sans-serif,
     -apple-system,
@@ -457,7 +461,7 @@ body[data-stage='2'] .monitor-status {
 
 .splash h1 {
   margin: 0;
-  font-size: 16px;
+  font-size: var(--text-lg);
   font-weight: 500;
   letter-spacing: -0.015em;
 }
@@ -465,7 +469,7 @@ body[data-stage='2'] .monitor-status {
 .splash p {
   margin: 4px 0 0;
   color: rgb(23 23 23 / 62%);
-  font-size: 12px;
+  font-size: var(--text-xs);
   line-height: 16px;
   transition:
     opacity 140ms ease,
@@ -529,7 +533,7 @@ body[data-stage='2'] .monitor-status {
   border: 1px solid rgb(23 23 23 / 12%);
   border-radius: 8px;
   background: #fff;
-  font-size: 12px;
+  font-size: var(--text-xs);
 }
 
 .startup-button-primary {
@@ -548,7 +552,7 @@ body[data-stage='2'] .monitor-status {
   padding: 5px 2px;
   color: #1677c8;
   background: transparent;
-  font-size: 12px;
+  font-size: var(--text-xs);
 }
 
 .startup-button:focus-visible,
@@ -566,7 +570,7 @@ body[data-stage='2'] .monitor-status {
 .startup-action-error {
   margin: 7px 0 0;
   color: #b91c1c;
-  font-size: 11px;
+  font-size: var(--text-code-sm);
 }
 
 .startup-confirmation {
@@ -576,7 +580,7 @@ body[data-stage='2'] .monitor-status {
 
 .startup-confirmation h2 {
   margin: 4px 0 0;
-  font-size: 14px;
+  font-size: var(--text-base);
   font-weight: 600;
 }
 

--- a/wework/electron/src/startup-splash-preload.cts
+++ b/wework/electron/src/startup-splash-preload.cts
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron') as typeof import('electron')
+
+contextBridge.exposeInMainWorld('weworkStartupRecovery', {
+  retry: () => ipcRenderer.invoke('startup-recovery:retry'),
+  recoverWorkbench: () => ipcRenderer.invoke('startup-recovery:recover-workbench'),
+  resetAppState: () => ipcRenderer.invoke('startup-recovery:reset-app-state'),
+})

--- a/wework/electron/src/startup-splash-preload.test.ts
+++ b/wework/electron/src/startup-splash-preload.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises'
+import { basename, resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+describe('startup splash preload', () => {
+  test('exposes only the startup recovery actions', async () => {
+    const sourcePath = resolve(
+      process.cwd(),
+      basename(process.cwd()) === 'electron'
+        ? 'src/startup-splash-preload.cts'
+        : 'electron/src/startup-splash-preload.cts'
+    )
+    const source = await readFile(sourcePath, 'utf8')
+
+    expect(source).not.toMatch(/from\s+['"]\.\.?\//)
+    expect(source).toContain("'weworkStartupRecovery'")
+    expect(source).toContain("'startup-recovery:retry'")
+    expect(source).toContain("'startup-recovery:recover-workbench'")
+    expect(source).toContain("'startup-recovery:reset-app-state'")
+    expect(source).not.toContain('webUtils')
+  })
+})

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -10948,7 +10948,7 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
-  test('reveals the Electron startup window only after the active transcript is ready', async () => {
+  test('reveals the Electron startup window once the task list is ready', async () => {
     runtimeMocks.electron = true
     const { rerender } = render(
       <DesktopWorkbenchLayout {...baseProps} isRuntimeTranscriptLoading />
@@ -10957,30 +10957,114 @@ describe('DesktopWorkbenchLayout', () => {
     await act(async () => {
       await Promise.resolve()
     })
-    expect(desktopHostMocks.invoke).not.toHaveBeenCalledWith('renderer.startupReady')
+    expect(desktopHostMocks.invoke).not.toHaveBeenCalledWith('renderer.startupReady', {
+      source: 'task-list',
+    })
 
-    rerender(<DesktopWorkbenchLayout {...baseProps} isRuntimeTranscriptLoading={false} />)
+    rerender(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        isRuntimeTranscriptLoading
+        state={{
+          ...baseProps.state,
+          runtimeWork: {
+            projects: [],
+            chats: [],
+            totalTasks: 0,
+          },
+        }}
+      />
+    )
 
     await waitFor(() => {
-      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady')
+      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady', {
+        source: 'task-list',
+      })
     })
   })
 
-  test('keeps the startup animation visible until the routed task is restored', async () => {
+  test('reveals a blank workbench when the persisted startup pane no longer exists', async () => {
+    runtimeMocks.electron = true
+    localStorage.setItem(
+      'wework:workbench-split-groups:v3:fixed-task',
+      JSON.stringify({
+        version: 3,
+        state: {
+          version: 3,
+          groups: [],
+          activeView: {
+            type: 'single',
+            layout: {
+              version: 2,
+              root: {
+                id: 'stale-startup-pane',
+                type: 'pane',
+                paneKey: 'runtime:old-device:missing-task',
+              },
+              focusedPaneId: 'stale-startup-pane',
+            },
+          },
+        },
+      })
+    )
+
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        workspaceTabId="fixed-task"
+        state={{
+          ...baseProps.state,
+          runtimeWork: {
+            projects: [],
+            chats: [],
+            totalTasks: 0,
+          },
+        }}
+      />
+    )
+
+    expect(await screen.findByTestId('desktop-workbench-main')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady', {
+        source: 'task-list',
+      })
+    })
+    expect(localStorage.getItem('wework:workbench-split-groups:v3:fixed-task')).toContain(
+      'runtime:old-device:missing-task'
+    )
+  })
+
+  test('reveals the workbench after task-list loading without waiting for route restoration', async () => {
     runtimeMocks.electron = true
     window.history.pushState({}, '', '/runtime-tasks?deviceId=local-device&taskId=runtime-a')
-    const { propsForTask, taskA } = createLocalRuntimeTaskPanelFixture()
     const { rerender } = render(<DesktopWorkbenchLayout {...baseProps} />)
 
     await act(async () => {
       await Promise.resolve()
     })
-    expect(desktopHostMocks.invoke).not.toHaveBeenCalledWith('renderer.startupReady')
+    expect(desktopHostMocks.invoke).not.toHaveBeenCalledWith('renderer.startupReady', {
+      source: 'task-list',
+    })
 
-    rerender(<DesktopWorkbenchLayout {...propsForTask(taskA)} />)
+    rerender(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        isRuntimeTranscriptLoading
+        state={{
+          ...baseProps.state,
+          runtimeWork: {
+            projects: [],
+            chats: [],
+            totalTasks: 0,
+          },
+        }}
+      />
+    )
 
     await waitFor(() => {
-      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady')
+      expect(desktopHostMocks.invoke).toHaveBeenCalledWith('renderer.startupReady', {
+        source: 'task-list',
+      })
     })
   })
 

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -205,11 +205,8 @@ import {
 } from './desktopWorkbenchPaneTypes'
 import {
   findRuntimeTask,
-  isSameRuntimeTaskAddress,
   truncateRuntimeTaskTitle,
 } from '@/features/workbench/workbenchRuntimeHelpers'
-import { stripAppBasePath } from '@/config/runtime'
-import { parseRuntimeTaskRoute } from '@/lib/navigation'
 import { useWorkbenchPaneEnvironment } from './useWorkbenchPaneEnvironment'
 import { useWorkbenchProjectWorkControls } from './useWorkbenchProjectWorkControls'
 import { useRuntimeTaskContinueInIm } from './useRuntimeTaskContinueInIm'
@@ -733,9 +730,26 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
   const resolvePane = useCallback(
     (paneKey: string) => {
       if (paneKey === activePaneKey) return props.activePane
-      return resolveRuntimeWorkbenchPane(state.runtimeWork, paneKey)
+      const resolvedPane = resolveRuntimeWorkbenchPane(state.runtimeWork, paneKey)
+      if (resolvedPane) return resolvedPane
+
+      const activeLayout = props.splitGroups.activeLayout
+      const canShowBlankStartupPane =
+        state.runtimeWork !== null &&
+        props.activePane.currentRuntimeTask === null &&
+        activeLayout.root.type === 'pane' &&
+        activeLayout.root.paneKey === paneKey &&
+        paneKey.startsWith('runtime:') &&
+        !runtimePaneKeySet.has(paneKey)
+      return canShowBlankStartupPane ? props.activePane : null
     },
-    [activePaneKey, props.activePane, state.runtimeWork]
+    [
+      activePaneKey,
+      props.activePane,
+      props.splitGroups.activeLayout,
+      runtimePaneKeySet,
+      state.runtimeWork,
+    ]
   )
   const getPaneTitle = useCallback(
     (pane: WorkbenchPaneIdentity) => {
@@ -946,7 +960,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     createDeviceDirectory,
     startNewChat,
   } = useWorkbenchPaneContext()
-  const { services, openRuntimeTask, workspaceTabId, isStartupReady } = useWorkbench()
+  const { services, openRuntimeTask, workspaceTabId } = useWorkbench()
   const { t } = useTranslation('common')
   const [harnessSessionPickerTarget, setHarnessSessionPickerTarget] = useState<
     'main' | 'right' | null
@@ -972,26 +986,26 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     currentRuntimeTask,
     debugSnapshotEnabled: paneActive && paneVisible && workbenchVisible,
   })
-  const startupTaskRoute = parseRuntimeTaskRoute(
-    stripAppBasePath(window.location.pathname),
-    window.location.search
-  )
-  const startupTaskRouteReady =
-    !startupTaskRoute || isSameRuntimeTaskAddress(currentRuntimeTask, startupTaskRoute)
   const startupSurfaceReady =
-    isStartupReady &&
-    startupTaskRouteReady &&
-    !paneSession.transcriptLoading &&
-    paneActive &&
-    paneVisible &&
-    workbenchVisible
+    state.runtimeWork !== null && paneActive && paneVisible && workbenchVisible
   useEffect(() => {
     if (!startupSurfaceReady || !isElectronRuntime() || getDesktopWindowLabel() !== 'main') {
       return
     }
-    void invokeDesktopHost<void>('renderer.startupReady').catch(error => {
-      console.error('[Wework] Failed to reveal the ready workbench', error)
+    console.info('[startup][renderer]', {
+      step: 'task-list-ready',
+      status: 'completed',
     })
+    void invokeDesktopHost<void>('renderer.startupReady', { source: 'task-list' })
+      .then(() => {
+        console.info('[startup][renderer]', {
+          step: 'startup-ready-notification',
+          status: 'completed',
+        })
+      })
+      .catch(error => {
+        console.error('[Wework] Failed to reveal the ready workbench', error)
+      })
   }, [startupSurfaceReady])
   const refinePluginTrialPrompt = usePluginTrialPromptRefinement({
     source: currentRuntimeTask,

--- a/wework/src/components/layout/workbenchPaneStack.tsx
+++ b/wework/src/components/layout/workbenchPaneStack.tsx
@@ -143,7 +143,9 @@ export function SplitWorkbenchPaneStack({
       const cached = paneCacheRef.current.get(paneKey)
       if (cached) return cached
       const resolved = resolvePane(paneKey)
-      if (resolved) paneCacheRef.current.set(paneKey, resolved)
+      if (resolved && getWorkbenchPaneKey(resolved) === paneKey) {
+        paneCacheRef.current.set(paneKey, resolved)
+      }
       return resolved
     },
     [resolvePane]

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -13,11 +13,16 @@ import {
 import { LocalRuntimeInitializer } from './LocalRuntimeInitializer'
 
 const runtimeTokenPostMock = vi.hoisted(() => vi.fn())
+const desktopHostInvokeMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/api/http', () => ({
   createHttpClient: vi.fn(() => ({
     post: runtimeTokenPostMock,
   })),
+}))
+
+vi.mock('@/api/dsh/desktopHost', () => ({
+  invokeDesktopHost: desktopHostInvokeMock,
 }))
 
 vi.mock('@/desktop/localExecutor', () => ({
@@ -55,6 +60,8 @@ describe('LocalRuntimeInitializer', () => {
     disconnectMock.mockReset()
     ensureMock.mockReset()
     readLogMock.mockReset()
+    desktopHostInvokeMock.mockReset()
+    desktopHostInvokeMock.mockResolvedValue(undefined)
     runtimeTokenPostMock.mockReset()
     runtimeTokenPostMock.mockResolvedValue({
       auth_token: 'runtime-task-token',
@@ -508,6 +515,9 @@ describe('LocalRuntimeInitializer', () => {
 
     expect(await screen.findByTestId('local-runtime-error')).toHaveTextContent('stdio unavailable')
     expect(screen.getByText('~/.wework/logs/executor.log')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(desktopHostInvokeMock).toHaveBeenCalledWith('renderer.startupFailed')
+    )
 
     await userEvent.click(screen.getByTestId('local-runtime-retry-button'))
 

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -84,14 +84,30 @@ async function resolveLocalRuntimeState(
   fallbackError: string,
   errorText: LocalRuntimeErrorText
 ): Promise<LocalRuntimeState> {
+  const startedAt = performance.now()
+  console.info('[startup][renderer]', {
+    step: 'local-executor-initialize',
+    status: 'started',
+  })
   try {
     const status = await ensureLocalExecutorAvailable()
     const statusError = localRuntimeError(status, errorText)
     if (statusError) {
       throw new Error(statusError)
     }
+    console.info('[startup][renderer]', {
+      step: 'local-executor-initialize',
+      status: 'completed',
+      elapsedMs: Math.round(performance.now() - startedAt),
+    })
     return { phase: 'ready', error: null }
   } catch (error) {
+    console.info('[startup][renderer]', {
+      step: 'local-executor-initialize',
+      status: 'failed',
+      elapsedMs: Math.round(performance.now() - startedAt),
+      errorType: error instanceof Error ? error.name : typeof error,
+    })
     return {
       phase: 'failed',
       error: errorMessage(error, fallbackError),
@@ -275,8 +291,8 @@ export function LocalRuntimeInitializer({
     if (state.phase !== 'failed' || !isElectronRuntime() || getDesktopWindowLabel() !== 'main') {
       return
     }
-    void invokeDesktopHost<void>('renderer.startupReady').catch(error => {
-      console.error('[Wework] Failed to reveal the local runtime error', error)
+    void invokeDesktopHost<void>('renderer.startupFailed').catch(error => {
+      console.error('[Wework] Failed to report the local runtime startup error', error)
     })
   }, [state.phase])
 

--- a/wework/src/features/workbench/useWorkbenchDataRefresh.ts
+++ b/wework/src/features/workbench/useWorkbenchDataRefresh.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Dispatch } from 'react'
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 import type { ExecutorClient } from '@/api/executorAccess'
+import { getDesktopWindowLabel, isElectronRuntime } from '@/lib/runtime-environment'
 import { getPreferredStandaloneDeviceId } from '@/lib/device-selection'
 import type {
   DeviceInfo,
@@ -590,10 +592,19 @@ export function useWorkbenchDataRefresh({
 
     async function bootstrap() {
       const bootstrapRevision = ++workListRefreshRevisionRef.current
+      console.info('[startup][renderer]', {
+        step: 'device-list-load',
+        status: 'started',
+      })
       const devicesResult = await timedWorkbenchBootstrapRequest(
         'devices',
         executorClient.commands.listDevices()
       )
+      console.info('[startup][renderer]', {
+        step: 'device-list-load',
+        status: devicesResult.status === 'fulfilled' ? 'completed' : 'failed',
+        elapsedMs: Math.round(nowMs() - startedAt),
+      })
 
       if (cancelled) return
       window.clearTimeout(slowTimer)
@@ -622,11 +633,32 @@ export function useWorkbenchDataRefresh({
         standaloneDeviceId,
       })
 
+      const runtimeWorkStartedAt = nowMs()
+      console.info('[startup][renderer]', {
+        step: 'task-list-load',
+        status: 'started',
+      })
       void timedWorkbenchBootstrapRequest(
         'runtimeWork',
         executorClient.runtime.listRuntimeWork()
       ).then(runtimeWorkResult => {
         if (cancelled) return
+        console.info('[startup][renderer]', {
+          step: 'task-list-load',
+          status: runtimeWorkResult.status === 'fulfilled' ? 'completed' : 'failed',
+          elapsedMs: Math.round(nowMs() - runtimeWorkStartedAt),
+          taskCount:
+            runtimeWorkResult.status === 'fulfilled' ? runtimeWorkResult.value.totalTasks : 0,
+        })
+        if (
+          runtimeWorkResult.status === 'rejected' &&
+          isElectronRuntime() &&
+          getDesktopWindowLabel() === 'main'
+        ) {
+          void invokeDesktopHost<void>('renderer.startupFailed').catch(error => {
+            console.error('[Wework] Failed to report task-list startup failure:', error)
+          })
+        }
         const runtimeWork =
           runtimeWorkResult.status === 'fulfilled'
             ? applyRuntimeTaskOverrides(runtimeWorkResult.value, true)

--- a/wework/src/main.tsx
+++ b/wework/src/main.tsx
@@ -18,11 +18,27 @@ import { isDesktopRuntime, isElectronRuntime } from '@/lib/runtime-environment'
 import { installFrontendRecoveryBridge } from '@/lib/frontendRecovery'
 import { DshClientContextProvider } from '@/features/dsh-runtime/DshClientContextProvider'
 import { initializeDesktopLocalStoragePersistence } from '@/desktop/localStoragePersistence'
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 
 import type { Context } from '@deepseek-ai/cordis'
 
 interface WeworkAppRuntime {
   mount(container: HTMLElement, context: Context): Promise<() => void>
+}
+
+const rendererStartupStartedAt = performance.now()
+
+function logRendererStartupStep(
+  step: string,
+  status: 'started' | 'completed' | 'failed',
+  details: Record<string, unknown> = {}
+): void {
+  console.info('[startup][renderer]', {
+    step,
+    status,
+    elapsedMs: Math.round(performance.now() - rendererStartupStartedAt),
+    ...details,
+  })
 }
 
 declare global {
@@ -48,6 +64,7 @@ if (!isSystemDragPanel) {
 const performanceDiagnostics = isSystemDragPanel ? null : installPerformanceDiagnostics()
 
 async function mountApp(container: HTMLElement, context: Context | null): Promise<() => void> {
+  logRendererStartupStep('react-mount', 'started')
   const root = createRoot(container)
   root.render(
     <StrictMode>
@@ -62,11 +79,18 @@ async function mountApp(container: HTMLElement, context: Context | null): Promis
       </DshClientContextProvider>
     </StrictMode>
   )
+  logRendererStartupStep('react-mount', 'completed')
   return () => root.unmount()
 }
 
 function renderStartupFailure(container: HTMLElement, error: unknown): void {
+  logRendererStartupStep('renderer-startup', 'failed', {
+    errorType: error instanceof Error ? error.name : typeof error,
+  })
   console.error('[Wework] Failed to initialize the desktop frontend:', error)
+  void invokeDesktopHost<void>('renderer.startupFailed').catch(startupError => {
+    console.error('[Wework] Failed to report desktop startup failure:', startupError)
+  })
   createRoot(container).render(
     <main
       className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground"
@@ -90,26 +114,43 @@ function renderStartupFailure(container: HTMLElement, error: unknown): void {
   )
 }
 
-const desktopStorageReady = initializeDesktopLocalStoragePersistence().then(
-  () => null,
-  error => error
-)
+const desktopStorageReady = (async () => {
+  logRendererStartupStep('renderer-storage-initialize', 'started')
+  try {
+    await initializeDesktopLocalStoragePersistence()
+    logRendererStartupStep('renderer-storage-initialize', 'completed')
+    return null
+  } catch (error) {
+    logRendererStartupStep('renderer-storage-initialize', 'failed', {
+      errorType: error instanceof Error ? error.name : typeof error,
+    })
+    return error
+  }
+})()
 
 async function mountWework(container: HTMLElement, context: Context | null): Promise<() => void> {
+  logRendererStartupStep('wework-mount', 'started')
   const storageError = await desktopStorageReady
   if (storageError !== null) {
     renderStartupFailure(container, storageError)
     return () => {}
   }
   if (!isSystemDragPanel) {
+    logRendererStartupStep('automation-bridge-install', 'started')
     try {
       await installWeworkAutomationBridge()
+      logRendererStartupStep('automation-bridge-install', 'completed')
     } catch (error) {
+      logRendererStartupStep('automation-bridge-install', 'failed', {
+        errorType: error instanceof Error ? error.name : typeof error,
+      })
       console.error('[Wework] Failed to install the automation bridge:', error)
     }
   }
   try {
-    return await mountApp(container, context)
+    const unmount = await mountApp(container, context)
+    logRendererStartupStep('wework-mount', 'completed')
+    return unmount
   } catch (error) {
     renderStartupFailure(container, error)
     return () => {}


### PR DESCRIPTION
## Summary

- reveal the desktop workbench as soon as the initial task list is ready, without waiting for conversation history or route restoration
- recover safely from stale persisted runtime panes instead of leaving the startup splash visible
- show restart, workbench recovery, and confirmed app-state reset actions after a prolonged startup or immediately after startup failure
- preserve local tasks, plugins, Smart apps, runtime data, and workspaces during recovery
- add structured startup-stage logs with elapsed time and safe failure metadata across Electron and renderer initialization
- report local executor, task-list, storage, and renderer startup failures to the startup splash

## Verification

- Electron focused tests: 42 passed
- Wework focused tests: 232 passed
- Electron TypeScript check passed
- ESLint and Prettier checks passed
- pre-push Wework static checks, TypeScript checks, Electron checks, and unit tests passed
- `pnpm --filter wework e2e:desktop --segment native-window-startup` passed
- isolated `pnpm --filter wework ai:verify start` confirmed the workbench became visible and startup logs recorded `source: task-list` before splash close

## Recovery boundaries

- Recover workbench: clears only workspace tabs, split layouts, and prior-session restore state
- Reset app state: clears renderer state, preferences, credentials, service-worker/cache storage, and HTTP cache
- Neither action removes runtime tasks, plugins, Smart apps, executor data, or workspace directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added startup recovery options to retry, repair the workbench, or reset application state.
  - Added confirmation dialogs and clearer error messages for startup failures.
  - Improved startup progress feedback and readiness handling.
  - Added tools to clear application preferences and selectively remove stored workbench data.

- **Bug Fixes**
  - Prevented stale or mismatched workbench panes from being cached.
  - Startup failures now display recovery actions instead of silently closing the splash screen.

- **Tests**
  - Expanded coverage for recovery, storage cleanup, startup sequencing, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->