### PR TITLE
fix(wework): prevent blank screen after dev reload

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -210,6 +210,28 @@ confirm that these files exist and match their repository sources. Inspecting
 only an intermediate resource directory does not prove that the distribution
 is complete.
 
+## Development hot reload
+
+`pnpm --dir wework run dev:mac` continuously builds the original Wework
+application through `wework/scripts/dev-wework-app-watch.mjs`. The watcher
+clears `dsh/app-wework/web` once at startup and must not clear it again for
+incremental builds. A running renderer may still request hashed assets from the
+previous generation, and deleting them while the next generation is being
+written can leave the window blank.
+
+Each build publishes `.wework-build-id` only after Vite finishes the bundle,
+the build result is closed, and file-viewer metadata is normalized. Core DSH
+uses this marker as the published build ID, so the page reloads only after the
+marker changes instead of treating an intermediate `index.html` write as a
+loadable generation.
+
+In development hot-reload mode, static resources under `/wework/app/` must use
+`Cache-Control: no-store`. In addition to hashed assets, this tree contains
+fixed-name `plugins/*.js` bundles. Serving those files with the production
+immutable cache can mix an old plugin bundle with a new main bundle after
+reload, creating duplicate instances of modules such as React contexts.
+Formal builds continue to use `public, max-age=31536000, immutable`.
+
 ## Local verification
 
 Release changes must run at least:

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -169,6 +169,23 @@ Codex 下载包按 `wework/codex-binaries.lock.json` 固定并校验 SHA-512。�
 打包链路时，应解包或检查真实应用产物，确认这些文件存在且与仓库中的源文件一致；
 仅检查中间资源目录不能证明最终发行物合规。
 
+## 开发模式热更新
+
+`pnpm --dir wework run dev:mac` 会通过
+`wework/scripts/dev-wework-app-watch.mjs` 持续构建原始 Wework 应用。监听器启动时
+清理一次 `dsh/app-wework/web`，后续增量构建不得再次清空该目录；正在运行的
+renderer 可能仍在请求上一代哈希资源，提前删除会在新产物写入期间造成白屏。
+
+每次构建只有在 Vite 完成 bundle、关闭构建结果并规范化文件查看器元数据后，才能
+写入 `.wework-build-id`。Core DSH 使用这个标记作为已发布构建 ID，页面只在标记
+变化后刷新，不能把 `index.html` 的中间写入状态当成可加载版本。
+
+开发热更新模式下，`/wework/app/` 下的静态资源必须返回
+`Cache-Control: no-store`。除哈希资源外，该目录还包含固定文件名的
+`plugins/*.js`；如果这些文件使用生产环境的长期 immutable 缓存，刷新后会把旧插件
+bundle 与新主 bundle 混合，导致 React Context 等模块出现两份实例。正式构建仍
+使用 `public, max-age=31536000, immutable`。
+
 ## 本地验证
 
 发布相关改动至少运行：

--- a/wework/dsh/app-wework/index-hot-reload.test.mjs
+++ b/wework/dsh/app-wework/index-hot-reload.test.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
-import { injectDevelopmentReload, weworkIndexInjection } from './index.js'
+import { injectDevelopmentReload, weworkAssetCacheControl, weworkIndexInjection } from './index.js'
 
 test('injects reload polling only into the original development application', () => {
   const html = '<html><head></head><body></body></html>'
@@ -15,25 +15,38 @@ test('injects reload polling only into the original development application', ()
   assert.match(developmentHtml, /window\.location\.reload/)
 })
 
+test('disables application asset caching while development hot reload is active', () => {
+  assert.equal(weworkAssetCacheControl({}), 'public, max-age=31536000, immutable')
+  assert.equal(weworkAssetCacheControl({ WEWORK_APP_HOT_RELOAD: '1' }), 'no-store')
+})
+
 test('reads the current application assets and build id for every page injection', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'wework-app-hot-reload-'))
   const indexPath = join(directory, 'index.html')
+  const buildIdPath = join(directory, '.wework-build-id')
 
   try {
     await writeFile(
       indexPath,
       '<html><head><script type="module" src="/assets/first.js"></script></head></html>'
     )
+    await writeFile(buildIdPath, 'build-1\n')
     const firstInjection = weworkIndexInjection({ WEWORK_APP_HOT_RELOAD: '1' }, indexPath)
 
     await writeFile(
       indexPath,
       '<html><head><script type="module" src="/assets/second-build.js"></script></head></html>'
     )
+    const unpublishedInjection = weworkIndexInjection({ WEWORK_APP_HOT_RELOAD: '1' }, indexPath)
+    await writeFile(buildIdPath, 'build-2\n')
     const secondInjection = weworkIndexInjection({ WEWORK_APP_HOT_RELOAD: '1' }, indexPath)
 
     assert.match(firstInjection[0].html, /first\.js/)
+    assert.match(firstInjection[2].html, /"build-1"/)
+    assert.match(unpublishedInjection[0].html, /second-build\.js/)
+    assert.match(unpublishedInjection[2].html, /"build-1"/)
     assert.match(secondInjection[0].html, /second-build\.js/)
+    assert.match(secondInjection[2].html, /"build-2"/)
     assert.notEqual(firstInjection[2].html, secondInjection[2].html)
   } finally {
     await rm(directory, { recursive: true, force: true })

--- a/wework/dsh/app-wework/index.js
+++ b/wework/dsh/app-wework/index.js
@@ -12,11 +12,13 @@ export const APP_BASE_PATH = '/wework/app'
 const API_PROXY_PATH = '/wework/api'
 const SOCKET_PROXY_PATH = '/wework/socket.io'
 const DEEP_LINK_PARAMETER = '__wework_route'
+const HOT_RELOAD_BUILD_ID_FILE = '.wework-build-id'
 const configuredWebRoot = process.env.WEWORK_APP_WEB_ROOT?.trim()
 const webRoot = configuredWebRoot
   ? resolve(configuredWebRoot)
   : resolve(dirname(fileURLToPath(import.meta.url)), 'web')
 const indexPath = join(webRoot, 'index.html')
+const hotReloadBuildIdPath = join(webRoot, HOT_RELOAD_BUILD_ID_FILE)
 
 const MIME_TYPES = {
   '.css': 'text/css; charset=utf-8',
@@ -111,7 +113,7 @@ export async function serveWeworkApp(req, res) {
     if (req.method === 'HEAD' && process.env.WEWORK_APP_HOT_RELOAD === '1') {
       res.writeHead(200, {
         'cache-control': 'no-store',
-        'x-wework-app-build-id': fileBuildId(indexPath),
+        'x-wework-app-build-id': hotReloadBuildId(hotReloadBuildIdPath, indexPath),
       })
       res.end()
       return
@@ -127,7 +129,7 @@ export async function serveWeworkApp(req, res) {
   const metadata = await stat(asset)
   res.writeHead(200, {
     'content-type': MIME_TYPES[extname(asset)] ?? 'application/octet-stream',
-    'cache-control': 'public, max-age=31536000, immutable',
+    'cache-control': weworkAssetCacheControl(process.env),
     'content-length': metadata.size,
   })
   if (req.method === 'HEAD') {
@@ -159,7 +161,11 @@ export function injectDevelopmentReload(html, environment, buildId) {
 
 export function weworkIndexInjection(environment = process.env, appIndexPath = indexPath) {
   const assets = weworkIndexAssets(readFileSync(appIndexPath, 'utf8'))
-  const developmentReload = injectDevelopmentReload('', environment, fileBuildId(appIndexPath))
+  const developmentReload = injectDevelopmentReload(
+    '',
+    environment,
+    hotReloadBuildId(join(dirname(appIndexPath), HOT_RELOAD_BUILD_ID_FILE), appIndexPath)
+  )
   const injection = [
     {
       kind: 'html',
@@ -185,6 +191,22 @@ export function weworkIndexInjection(environment = process.env, appIndexPath = i
 function fileBuildId(path) {
   const metadata = statSync(path, { bigint: true })
   return `${metadata.mtimeNs}:${metadata.size}`
+}
+
+function hotReloadBuildId(buildIdPath, appIndexPath) {
+  try {
+    const buildId = readFileSync(buildIdPath, 'utf8').trim()
+    if (buildId) return buildId
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+  return fileBuildId(appIndexPath)
+}
+
+export function weworkAssetCacheControl(environment = process.env) {
+  return environment.WEWORK_APP_HOT_RELOAD === '1'
+    ? 'no-store'
+    : 'public, max-age=31536000, immutable'
 }
 
 export function injectRuntimeConfig(html, environment = process.env, windowLabel = 'main') {

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -81,7 +81,9 @@ describe('desktop resource migration', () => {
       'vite build --base /wework/app/ --outDir dsh/app-wework/web --emptyOutDir'
     )
     expect(devAppWatcher).toContain('outDir: appWebRoot')
-    expect(devAppWatcher).toContain('emptyOutDir: true')
+    expect(devAppWatcher).toContain('await rm(appWebRoot, { recursive: true, force: true })')
+    expect(devAppWatcher).toContain('emptyOutDir: false')
+    expect(devAppWatcher).toContain("path.join(appWebRoot, '.wework-build-id')")
     expect(devAppWatcher).not.toContain('WEWORK_DSH_APP_OUT_DIR')
     expect(viteConfig).not.toContain('WEWORK_DSH_APP_OUT_DIR')
     expect(devMacScript).not.toContain('node electron/node_modules/electron/install.js')

--- a/wework/scripts/dev-wework-app-watch.mjs
+++ b/wework/scripts/dev-wework-app-watch.mjs
@@ -6,11 +6,13 @@ import { normalizeFileViewerAssetManifest } from './lib/harness-runtime-metadata
 
 const weworkRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const appWebRoot = path.join(weworkRoot, 'dsh', 'app-wework', 'web')
+const buildIdFile = path.join(appWebRoot, '.wework-build-id')
 const readyFile = process.env.WEWORK_APP_WATCH_READY_FILE?.trim()
 
 if (!readyFile) throw new Error('WEWORK_APP_WATCH_READY_FILE is required')
 
 await rm(readyFile, { force: true })
+await rm(appWebRoot, { recursive: true, force: true })
 
 process.env.VITE_APP_BASE_PATH = '/wework/app/'
 process.chdir(weworkRoot)
@@ -21,7 +23,10 @@ const watcher = await build({
   logLevel: 'warn',
   build: {
     outDir: appWebRoot,
-    emptyOutDir: true,
+    // Keep the previous hashed assets available until the completed build id
+    // is published. The running renderer may still request them while Vite is
+    // writing the next generation.
+    emptyOutDir: false,
     watch: {},
   },
 })
@@ -47,6 +52,7 @@ watcher.on('event', event => {
         await result?.close()
         await normalizeBuildMetadata(appWebRoot)
         completedBuilds += 1
+        await writeFile(buildIdFile, `${Date.now()}-${completedBuilds}\n`)
         await writeFile(readyFile, `${completedBuilds}\n`)
         console.log(`[wework-app-watch] built original Wework app (${completedBuilds})`)
       })


### PR DESCRIPTION
## Summary

- publish a completed Wework app build ID only after Vite and metadata finalization finish
- retain the previous hashed assets during incremental watcher builds
- disable static asset caching in development hot-reload mode so fixed-name DSH plugin bundles cannot mix with a newer main bundle
- document the development hot-reload publication and caching invariants in Chinese and English

## Root cause

The DSH app server served every application asset with a one-year immutable cache, including fixed-name `plugins/*.js` bundles. After a development reload, Chromium could reuse an old plugin bundle while loading a new main bundle. This created duplicate module instances, including `WorkbenchContext`, and React failed with `useWorkbench must be used within WorkbenchProvider`, leaving only the empty DSH root.

The watcher could also remove active hashed assets during an incremental build and the page used `index.html` metadata as a build signal before the complete generation was published.

## Verification

- `node --test dsh/app-wework/index-hot-reload.test.mjs`
- `pnpm test scripts/desktop-resource-migration.test.mjs`
- Prettier and ESLint checks for all changed Wework files
- pre-push Wework static checks and unit tests
- real Electron source-mode verification with `WEWORK_APP_HOT_RELOAD=1` and the source app web root
  - control client ID changed after reload
  - `workspace-tab-strip` remained visible for 5 seconds
  - workbench reported `isBootstrapping=false` and `error=null`
  - all 220 assets referenced by the rebuilt index existed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added macOS development hot reload support with reliable build completion detection.
  - Development builds now refresh only after a complete build is published.
  - Hot-reload assets disable caching to prevent stale resources; production builds retain long-term caching.

- **Documentation**
  - Added English and Chinese guidance for development watch mode, reload behavior, and caching.

- **Bug Fixes**
  - Prevented blank windows and mixed asset versions during incremental development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->