### PR TITLE
feat: workflow video generation params

### DIFF
--- a/backend/app/api/endpoints/openapi_responses.py
+++ b/backend/app/api/endpoints/openapi_responses.py
@@ -273,6 +273,19 @@ def _execution_model_type(execution_request: Any) -> str:
     return str(model_config.get("modelType") or "").lower()
 
 
+def _validate_generation_options_model(
+    request_body: ResponseCreateInput,
+    execution_request: Any,
+) -> None:
+    """Reject OpenAPI generation options for non-generation execution models."""
+    if _generation_options(request_body) is None:
+        return
+    if _execution_model_type(execution_request) not in {"image", "video"}:
+        raise ValueError(
+            "Generation options are only supported for image or video models"
+        )
+
+
 def _should_run_in_background(
     *,
     requested_background: bool,
@@ -677,6 +690,7 @@ async def _create_non_streaming_response_unified(
             generation_params=_generation_options(request_body),
             attachment_ids=linked_attachment_ids,
         )
+        _validate_generation_options_model(request_body, execution_request)
     except ExternalRefValidationError as e:
         logger.warning("Failed to build execution request: %s", e)
         await _persist_terminal_failure(
@@ -1029,6 +1043,7 @@ async def _create_streaming_response_unified(
             generation_params=_generation_options(request_body),
             attachment_ids=linked_attachment_ids,
         )
+        _validate_generation_options_model(request_body, execution_request)
     except ExternalRefValidationError as e:
         logger.warning("Failed to build execution request: %s", e)
         await _persist_terminal_failure(

--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -130,11 +130,14 @@ def _apply_generation_params(
     model_config: Dict[str, Any],
     generate_params: Any,
 ) -> None:
-    """Validate generation options against the selected model type and apply them."""
+    """Apply generation options when the execution model directly generates media."""
     if generate_params is None:
         return
 
     model_type = str(model_config.get("modelType") or "").strip().lower()
+    if model_type not in {"image", "video"}:
+        return
+
     if model_type == "image":
         unsupported = [
             name
@@ -150,10 +153,6 @@ def _apply_generation_params(
         if _generation_param(generate_params, "size") is not None:
             raise ValueError("Video generation does not support option: size")
         apply_video_generation_params(model_config, generate_params)
-    else:
-        raise ValueError(
-            "Generation options are only supported for image or video models"
-        )
 
     logger.info(
         "[build_execution_request] Generation params applied: "

--- a/backend/tests/api/test_openapi_responses.py
+++ b/backend/tests/api/test_openapi_responses.py
@@ -95,6 +95,23 @@ def test_result_blocks_become_created_then_updated_streaming_chunks():
     assert known_blocks["image-1"]["image_attachment_ids"] == [51]
 
 
+def test_generation_options_reject_non_generation_openapi_model():
+    from app.api.endpoints.openapi_responses import (
+        _validate_generation_options_model,
+    )
+    from app.schemas.openapi_response import ResponseCreateInput
+
+    request_body = ResponseCreateInput(
+        model="default#test-team",
+        input="create a video",
+        wegent_options={"generation": {"duration": 5}},
+    )
+    execution_request = SimpleNamespace(model_config={"modelType": "llm"})
+
+    with pytest.raises(ValueError, match="only supported for image or video"):
+        _validate_generation_options_model(request_body, execution_request)
+
+
 @pytest.fixture
 def test_team(test_db: Session, test_user: User) -> Kind:
     """Create a test Team Kind."""

--- a/backend/tests/services/chat/test_trigger_unified.py
+++ b/backend/tests/services/chat/test_trigger_unified.py
@@ -75,14 +75,17 @@ def test_apply_generation_params_rejects_image_options_for_video() -> None:
         )
 
 
-def test_apply_generation_params_rejects_non_generation_model() -> None:
+def test_apply_generation_params_ignores_non_generation_model() -> None:
     from app.services.chat.trigger import unified as trigger_unified
 
-    with pytest.raises(ValueError, match="only supported for image or video"):
-        trigger_unified._apply_generation_params(
-            {"modelType": "llm"},
-            SimpleNamespace(size="1024x1024"),
-        )
+    model_config = {"modelType": "llm"}
+
+    trigger_unified._apply_generation_params(
+        model_config,
+        SimpleNamespace(size="1024x1024"),
+    )
+
+    assert model_config == {"modelType": "llm"}
 
 
 def test_apply_user_runtime_config_adds_codex_status(monkeypatch):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generation options are now rejected with a clear error when used with unsupported language models.
  * Image and video generation settings are safely ignored when the selected model cannot generate media.
  * Improved handling of both streaming and non-streaming requests to prevent invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->