### PR TITLE
fix(git): compare fork changes with parent remote

### DIFF
--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -28,8 +28,10 @@ class LocalDeviceCommandDefinition:
 GIT_BRANCH_DIFF_SHORTSTAT_COMMAND = (
     'bash -c \'base=""; '
     "for candidate in "
+    '"$(git symbolic-ref --quiet --short refs/remotes/upstream/HEAD 2>/dev/null)" '
+    "upstream/main upstream/master "
     '"$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)" '
-    "origin/main main origin/master master; do "
+    "origin/main origin/master main master; do "
     '[ -n "$candidate" ] || continue; '
     'if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then '
     'base="$candidate"; break; '
@@ -58,8 +60,10 @@ GIT_BRANCH_DIFF_COMMAND = (
     "bash -c "
     '\'base=""; '
     "for candidate in "
+    '"$(git symbolic-ref --quiet --short refs/remotes/upstream/HEAD 2>/dev/null)" '
+    "upstream/main upstream/master "
     '"$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)" '
-    "origin/main main origin/master master; do "
+    "origin/main origin/master main master; do "
     '[ -n "$candidate" ] || continue; '
     'if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then '
     'base="$candidate"; break; '

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import json
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -1006,6 +1007,76 @@ def test_local_device_command_registry_default_includes_workspace_file_commands(
     assert read_definition is not None
     assert read_definition.post_processor == "json"
     assert "MAX_BYTES = 262144" in read_definition.command
+
+
+def test_branch_diff_prefers_fork_parent_default_branch(tmp_path):
+    """Fork branches should compare with their parent base instead of stale origin."""
+    from app.services.device.command_registry import resolve_local_device_command
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(repo, "init", "-q")
+    _run_git(repo, "config", "user.email", "tests@example.com")
+    _run_git(repo, "config", "user.name", "Tests")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _run_git(repo, "add", "--all")
+    _run_git(repo, "commit", "-qm", "initial")
+    _run_git(repo, "branch", "-M", "main")
+    stale_origin_main = _run_git(repo, "rev-parse", "HEAD").decode().strip()
+
+    _run_git(repo, "remote", "add", "origin", "https://example.com/fork.git")
+    _run_git(repo, "update-ref", "refs/remotes/origin/main", stale_origin_main)
+    _run_git(
+        repo,
+        "symbolic-ref",
+        "refs/remotes/origin/HEAD",
+        "refs/remotes/origin/main",
+    )
+
+    canonical_lines = "".join(f"canonical-{index}\n" for index in range(300))
+    (repo / "canonical.txt").write_text(canonical_lines, encoding="utf-8")
+    _run_git(repo, "add", "--all")
+    _run_git(repo, "commit", "-qm", "canonical update")
+    canonical_main = _run_git(repo, "rev-parse", "HEAD").decode().strip()
+
+    _run_git(repo, "remote", "add", "upstream", "https://example.com/parent.git")
+    _run_git(repo, "update-ref", "refs/remotes/upstream/main", canonical_main)
+    _run_git(
+        repo,
+        "symbolic-ref",
+        "refs/remotes/upstream/HEAD",
+        "refs/remotes/upstream/main",
+    )
+
+    _run_git(repo, "checkout", "-qb", "feature/fork-base")
+    (repo / "feature.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    _run_git(repo, "add", "--all")
+    _run_git(repo, "commit", "-qm", "feature change")
+
+    shortstat_definition = resolve_local_device_command("git_branch_diff_shortstat", {})
+    diff_definition = resolve_local_device_command("git_branch_diff", {})
+    assert shortstat_definition is not None
+    assert diff_definition is not None
+
+    shortstat = subprocess.run(
+        shlex.split(shortstat_definition.command),
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    diff = subprocess.run(
+        shlex.split(diff_definition.command),
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    assert "1 file changed" in shortstat
+    assert "3 insertions(+)" in shortstat
+    assert "canonical.txt" not in diff
+    assert "feature.txt" in diff
 
 
 def test_remote_command_policy_separates_read_only_and_mutating_keys():

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -1009,7 +1009,7 @@ def test_local_device_command_registry_default_includes_workspace_file_commands(
     assert "MAX_BYTES = 262144" in read_definition.command
 
 
-def test_branch_diff_prefers_fork_parent_default_branch(tmp_path):
+def test_branch_diff_prefers_fork_parent_default_branch(tmp_path: Path) -> None:
     """Fork branches should compare with their parent base instead of stale origin."""
     from app.services.device.command_registry import resolve_local_device_command
 

--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -245,9 +245,9 @@ print(json.dumps({
     "detectionError": None,
 }))
 "#;
-const GIT_BRANCH_DIFF_SHORTSTAT_SCRIPT: &str = r#"base=""; for candidate in "$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)" origin/main main origin/master master; do [ -n "$candidate" ] || continue; if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then base="$candidate"; break; fi; done; [ -n "$base" ] || { git diff --shortstat HEAD --; exit 0; }; merge_base=$(git merge-base "$base" HEAD 2>/dev/null || true); [ -n "$merge_base" ] || { git diff --shortstat HEAD --; exit 0; }; git diff --shortstat "$merge_base" --"#;
+const GIT_BRANCH_DIFF_SHORTSTAT_SCRIPT: &str = r#"base=""; for candidate in "$(git symbolic-ref --quiet --short refs/remotes/upstream/HEAD 2>/dev/null)" upstream/main upstream/master "$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)" origin/main origin/master main master; do [ -n "$candidate" ] || continue; if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then base="$candidate"; break; fi; done; [ -n "$base" ] || { git diff --shortstat HEAD --; exit 0; }; merge_base=$(git merge-base "$base" HEAD 2>/dev/null || true); [ -n "$merge_base" ] || { git diff --shortstat HEAD --; exit 0; }; git diff --shortstat "$merge_base" --"#;
 const GIT_WORKSPACE_DIFF_SCRIPT: &str = r#"if git rev-parse --verify --quiet HEAD >/dev/null; then git diff --binary HEAD --; else git diff --binary --; fi; git ls-files --others --exclude-standard -z | while IFS= read -r -d "" file; do git diff --binary --no-index -- /dev/null "$file" || true; done"#;
-const GIT_BRANCH_DIFF_SCRIPT: &str = r#"base=""; for candidate in "$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)" origin/main main origin/master master; do [ -n "$candidate" ] || continue; if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then base="$candidate"; break; fi; done; if [ -n "$base" ]; then merge_base=$(git merge-base "$base" HEAD 2>/dev/null || true); fi; if [ -n "$merge_base" ]; then git diff --binary "$merge_base" --; elif git rev-parse --verify --quiet HEAD >/dev/null; then git diff --binary HEAD --; else git diff --binary --; fi; git ls-files --others --exclude-standard -z | while IFS= read -r -d "" file; do git diff --binary --no-index -- /dev/null "$file" || true; done"#;
+const GIT_BRANCH_DIFF_SCRIPT: &str = r#"base=""; for candidate in "$(git symbolic-ref --quiet --short refs/remotes/upstream/HEAD 2>/dev/null)" upstream/main upstream/master "$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)" origin/main origin/master main master; do [ -n "$candidate" ] || continue; if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then base="$candidate"; break; fi; done; if [ -n "$base" ]; then merge_base=$(git merge-base "$base" HEAD 2>/dev/null || true); fi; if [ -n "$merge_base" ]; then git diff --binary "$merge_base" --; elif git rev-parse --verify --quiet HEAD >/dev/null; then git diff --binary HEAD --; else git diff --binary --; fi; git ls-files --others --exclude-standard -z | while IFS= read -r -d "" file; do git diff --binary --no-index -- /dev/null "$file" || true; done"#;
 const TURN_FILE_CHANGES_SCRIPT: &str = r#"
 import gzip
 import hashlib
@@ -3843,6 +3843,25 @@ mod tests {
             assert_eq!(command.argv.first(), Some(&"bash"));
             assert_eq!(command.argv.get(1), Some(&"-c"));
             assert!(!command.argv.contains(&"-l"));
+        }
+    }
+
+    #[test]
+    fn git_branch_diff_prefers_fork_parent_remote() {
+        for command_key in ["git_branch_diff", "git_branch_diff_shortstat"] {
+            let script = local_app_command(command_key)
+                .expect("command must be registered")
+                .argv[2];
+            let upstream = script
+                .find("upstream/HEAD")
+                .expect("upstream default branch should be considered");
+            let origin = script
+                .find("origin/HEAD")
+                .expect("origin default branch should be considered");
+            assert!(
+                upstream < origin,
+                "fork parent remote should be checked before origin"
+            );
         }
     }
 

--- a/executor/src/version.rs
+++ b/executor/src/version.rs
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Cargo tracks option_env! values in build fingerprints. Development launchers
+// set this per worktree so a shared target directory cannot reuse another
+// worktree's executor binary.
+const _DEV_BUILD_ID: Option<&str> = option_env!("WEGENT_EXECUTOR_DEV_BUILD_ID");
+
 pub fn get_version() -> String {
     std::env::var("WEGENT_EXECUTOR_VERSION")
         .ok()

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -12,6 +12,8 @@ ISOLATED_EXECUTOR_HOME=""
 MANAGED_SOURCE_EXECUTOR="false"
 MANAGED_DWS_BINARY="false"
 MANAGED_HARNESS_RUNTIME="false"
+MANAGED_SOURCE_EXECUTOR_BINARY=""
+EXECUTOR_BINARY_TEMP=""
 WEWORK_APP_WATCH_PID=""
 WEWORK_APP_WATCH_READY_FILE=""
 
@@ -143,6 +145,9 @@ cleanup() {
   if [ -n "$WEWORK_APP_WATCH_READY_FILE" ]; then
     rm -f "$WEWORK_APP_WATCH_READY_FILE"
   fi
+  if [ -n "$EXECUTOR_BINARY_TEMP" ]; then
+    rm -f "$EXECUTOR_BINARY_TEMP"
+  fi
 }
 
 trap cleanup EXIT
@@ -179,9 +184,11 @@ else
   export WEWORK_EXECUTOR_PATH="$SCRIPT_DIR/dev-executor-sidecar.sh"
   MANAGED_SOURCE_EXECUTOR="true"
   configure_wegent_cargo_target_dir "$PROJECT_DIR" "executor-dev"
-  export WEGENT_EXECUTOR_BINARY="$(
+  MANAGED_SOURCE_EXECUTOR_BINARY="$(
     cargo_target_binary_path "$PROJECT_DIR/executor" debug wegent-executor
   )"
+  export WEGENT_EXECUTOR_BINARY="$WEWORK_DIR/node_modules/.cache/wework-executor-dev/wegent-executor"
+  export WEGENT_EXECUTOR_DEV_BUILD_ID="$WEWORK_DEV_INSTANCE_ID"
 fi
 export WEWORK_DEV_CACHE_ROOT="${WEWORK_DEV_CACHE_ROOT:-$HOME/Library/Caches/wegent/wework-dev}"
 export WEWORK_HARNESS_RUNTIME_ASSET_CACHE_ROOT="${WEWORK_HARNESS_RUNTIME_ASSET_CACHE_ROOT:-$WEWORK_DEV_CACHE_ROOT/harness-runtime}"
@@ -259,6 +266,12 @@ fi
 
 if [ "$MANAGED_SOURCE_EXECUTOR" = "true" ]; then
   cargo build --manifest-path "$PROJECT_DIR/executor/Cargo.toml" --bin wegent-executor
+  mkdir -p "$(dirname "$WEGENT_EXECUTOR_BINARY")"
+  EXECUTOR_BINARY_TEMP="$WEGENT_EXECUTOR_BINARY.tmp.$$"
+  cp "$MANAGED_SOURCE_EXECUTOR_BINARY" "$EXECUTOR_BINARY_TEMP"
+  chmod 0755 "$EXECUTOR_BINARY_TEMP"
+  mv -f "$EXECUTOR_BINARY_TEMP" "$WEGENT_EXECUTOR_BINARY"
+  EXECUTOR_BINARY_TEMP=""
 fi
 if [ ! -x "$WEWORK_EXECUTOR_PATH" ]; then
   echo "Error: Executor command is not executable: $WEWORK_EXECUTOR_PATH" >&2

--- a/wework/scripts/dev-mac-app.test.mjs
+++ b/wework/scripts/dev-mac-app.test.mjs
@@ -14,6 +14,10 @@ describe('dev-mac-app', () => {
     expect(source).toContain('WEWORK_HARNESS_RUNTIME_ASSET_CACHE_ROOT')
     expect(source).toContain('$WEWORK_DIR/node_modules/.cache/harness-runtime-dev')
     expect(source).toContain('WEWORK_DEV_EXECUTOR_PATH')
+    expect(source).toContain('WEGENT_EXECUTOR_DEV_BUILD_ID="$WEWORK_DEV_INSTANCE_ID"')
+    expect(source).toContain('$WEWORK_DIR/node_modules/.cache/wework-executor-dev/wegent-executor')
+    expect(source).toContain('cp "$MANAGED_SOURCE_EXECUTOR_BINARY" "$EXECUTOR_BINARY_TEMP"')
+    expect(source).toContain('mv -f "$EXECUTOR_BINARY_TEMP" "$WEGENT_EXECUTOR_BINARY"')
     expect(source).toContain('node "$SCRIPT_DIR/prepare-dev-dependencies.mjs"')
     expect(source).toContain('node "$SCRIPT_DIR/prepare-dev-component-resources.mjs"')
     expect(source).toContain('WEWORK_CORE_PLUGIN_ROOT=')
@@ -31,12 +35,21 @@ describe('dev-mac-app', () => {
     const electronNodeReset = source.indexOf('unset ELECTRON_RUN_AS_NODE')
     const inheritedNodePathReset = source.indexOf('unset WEWORK_NODE_PATH')
     const inheritedNodeKindReset = source.indexOf('unset WEWORK_NODE_RUNTIME_KIND')
+    const executorBuild = source.indexOf(
+      'cargo build --manifest-path "$PROJECT_DIR/executor/Cargo.toml"'
+    )
+    const executorCopy = source.indexOf(
+      'cp "$MANAGED_SOURCE_EXECUTOR_BINARY" "$EXECUTOR_BINARY_TEMP"'
+    )
     const electronBuild = source.indexOf('pnpm --dir electron run build')
     const electronLaunch = source.indexOf('"$ELECTRON_BINARY" "$WEWORK_DIR/electron"')
     expect(electronNodeReset).toBeGreaterThan(-1)
     expect(inheritedNodePathReset).toBeGreaterThan(electronNodeReset)
     expect(inheritedNodeKindReset).toBeGreaterThan(inheritedNodePathReset)
     expect(inheritedNodeKindReset).toBeLessThan(electronBuild)
+    expect(executorBuild).toBeGreaterThan(-1)
+    expect(executorCopy).toBeGreaterThan(executorBuild)
+    expect(executorCopy).toBeLessThan(electronLaunch)
     expect(electronBuild).toBeLessThan(electronLaunch)
   })
 })


### PR DESCRIPTION
## Summary

- prefer the fork parent remote (`upstream`) when selecting the branch diff base
- keep `origin` and local default branches as fallbacks for regular repositories
- apply the same base selection to backend-dispatched and local executor Git commands
- add regression coverage for a stale fork default branch that would otherwise inflate the diff
- keep the shared Cargo dependency cache while copying the built development Executor to a worktree-local binary, preventing another worktree from replacing the running implementation

## Tests

- `cd backend && uv run pytest tests/services/test_local_device_command_service.py -k branch_diff_prefers_fork_parent_default_branch`
- `CARGO_TARGET_DIR="$HOME/.cache/wegent/cargo-target/executor-dev" WEGENT_EXECUTOR_DEV_BUILD_ID=a554365d5c76 cargo test --manifest-path executor/Cargo.toml git_branch_diff_prefers_fork_parent_remote --lib`
- `pnpm --filter wework test scripts/dev-mac-app.test.mjs`
- `pnpm --filter wework exec prettier --check scripts/dev-mac-app.test.mjs`
- `pnpm --filter wework exec eslint scripts/dev-mac-app.test.mjs`
- `cargo fmt --manifest-path executor/Cargo.toml -- --check`
- `bash -n wework/scripts/dev-mac-app.sh`
- isolated real-Electron verification against this fork: review panel reported `+132/-5` for the six PR files instead of the stale `origin/main` result `+56310/-5467`

Internal task: WORK-375
