### PR TITLE
fix(wework): clean desktop E2E runtime artifacts

### DIFF
--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -281,7 +281,11 @@ already-built real binaries. A supplied application must be built with the
 desktop E2E Vite environment variables. The lifecycle scenarios share one
 application launch to control CI duration. Test artifacts, captured model
 requests, and failure diagnostics are stored in
-`wework/test-results/desktop-e2e/`.
+`wework/test-results/desktop-e2e/`. Each scenario retains logs, screenshots,
+requests, and UI state while removing copied application bundles, Executor
+homes, extracted runtimes, and rebuildable Electron caches. The runner also
+compacts inactive result directories left by interrupted runs so repeated local
+execution does not continuously consume disk space.
 
 The local runner writes complete stdout and stderr from the prerequisite
 Electron and Executor build to

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -246,7 +246,9 @@ Electron 应用及其内置 Executor，再启动所选场景。可选的 `WEWORK
 和 `WEWORK_E2E_APP_BIN` 必须成对设置，用于复用已经构建的真实 Executor 和真实
 Electron 应用；传入的应用必须使用桌面 E2E 的 Vite 环境变量构建。各生命周期场景
 复用一次应用启动以控制 CI 时长；测试过程、捕获的模型请求和失败诊断会保存在
-`wework/test-results/desktop-e2e/`。
+`wework/test-results/desktop-e2e/`。场景结束后会保留日志、截图、请求和 UI 状态，
+同时删除复制的应用包、Executor Home、解压 Runtime 和 Electron 可重建缓存；runner
+启动时也会清理之前异常中断留下的非活动结果目录，避免本地磁盘随运行次数持续增长。
 
 本地 runner 会把前置 Electron 和 Executor 构建的完整 stdout、stderr 写入
 `wework/test-results/desktop-e2e/desktop-build-<pid>.log`，终端只显示构建阶段、

--- a/wework/e2e/desktop/modules/shared.mjs
+++ b/wework/e2e/desktop/modules/shared.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { DESKTOP_CHECKPOINTS, PLUGIN_SEGMENTS } from '../checkpoints.mjs'
 import { processIsAlive, stopProcess, stopProcessGroup } from '../process-lifecycle.mjs'
+import { resolveDesktopE2EResultRoot } from '../result-retention.mjs'
 import { loadDesktopScenario } from '../scenario-loader.mjs'
 import { waitForSnapshot } from './conversation-layout.mjs'
 import { sendPrompt } from './conversation-navigation.mjs'
@@ -524,9 +525,7 @@ const repoDir = resolve(weworkDir, '..')
 const toolDetailsMcpServerPath = join(weworkDir, 'e2e', 'utils', 'tool-details-mcp-server.mjs')
 const mcpElicitationServerPath = join(weworkDir, 'e2e', 'utils', 'mcp-elicitation-server.mjs')
 const runId = `${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}`
-const resultRoot = process.env.WEWORK_E2E_RESULT_ROOT?.trim()
-  ? resolve(process.env.WEWORK_E2E_RESULT_ROOT.trim())
-  : join(weworkDir, 'test-results', 'desktop-e2e')
+const resultRoot = resolveDesktopE2EResultRoot(weworkDir)
 const resultDir = join(resultRoot, runId)
 
 const OFFICIAL_PLUGIN_REPOSITORY = 'https://github.com/openai/plugins.git'

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -888,7 +888,7 @@ async function main() {
   validateDesktopSegmentOptions()
   const runsProjectPluginE2E = DESKTOP_SEGMENT === 'project-ai-settings'
   await mkdir(resultDir, { recursive: true })
-  await markDesktopE2EResultActive(resultDir)
+  await markDesktopE2EResultActive(resultDir, { ownerProcessId: process.pid })
   console.log(`[desktop-e2e] result directory: ${resultDir}`)
   const workspacePath = join(resultDir, 'workspace')
   const secondaryProjectPath = join(resultDir, 'secondary-project-root')
@@ -1179,6 +1179,10 @@ async function main() {
         env: appEnvironment,
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: process.platform !== 'win32',
+      })
+      await markDesktopE2EResultActive(resultDir, {
+        applicationProcessId: child.pid,
+        ownerProcessId: process.pid,
       })
       await Promise.all([
         appendProcessOutput(child.stdout, appLogPath),
@@ -4053,48 +4057,64 @@ last_updated = "2026-07-30T00:00:00Z"`
     )
     throw error
   } finally {
-    let teardownError
-    try {
-      await cloudEnvironment?.stop()
-      await blockingNetworkProxy?.stop()
-      await stopDesktopAppProcess(app)
-      await control.close()
-      await desktopScenario?.cleanup?.()
-      await rm(codexSqliteHome, {
+    const teardownFailures = []
+    const runTeardownStep = async (label, action) => {
+      try {
+        await action()
+      } catch (error) {
+        teardownFailures.push({ error, label })
+      }
+    }
+    await runTeardownStep('cloud environment', async () => cloudEnvironment?.stop())
+    await runTeardownStep('blocking network proxy', async () => blockingNetworkProxy?.stop())
+    await runTeardownStep('desktop application', async () => stopDesktopAppProcess(app))
+    await runTeardownStep('desktop controller', async () => control.close())
+    await runTeardownStep('desktop scenario', async () => desktopScenario?.cleanup?.())
+    await runTeardownStep('Codex SQLite home', async () =>
+      rm(codexSqliteHome, {
         recursive: true,
         force: true,
         maxRetries: process.platform === 'win32' ? 20 : 0,
         retryDelay: 100,
       })
+    )
+    await runTeardownStep('macOS Launch Services registration', async () => {
       if (appBundlePath && process.platform === 'darwin') {
         spawnSync(MACOS_LAUNCH_SERVICES_REGISTER, ['-u', appBundlePath])
       }
-    } catch (error) {
-      teardownError = error
-    }
+    })
     let cleanupError
-    try {
-      const removed = await compactDesktopE2EResult(resultDir)
-      if (removed > 0) {
-        console.log(`[desktop-e2e] removed ${removed} transient runtime artifacts`)
+    if (teardownFailures.length === 0) {
+      try {
+        const removed = await compactDesktopE2EResult(resultDir)
+        if (removed > 0) {
+          console.log(`[desktop-e2e] removed ${removed} transient runtime artifacts`)
+        }
+      } catch (error) {
+        cleanupError = error
       }
-    } catch (error) {
-      cleanupError = error
-    }
-    try {
-      await clearDesktopE2EResultActive(resultDir)
-    } catch (error) {
-      cleanupError ??= error
+      try {
+        await clearDesktopE2EResultActive(resultDir)
+      } catch (error) {
+        cleanupError ??= error
+      }
     }
     if (testFailed) {
-      if (teardownError) {
-        console.error(`[desktop-e2e] process teardown failed: ${String(teardownError)}`)
+      for (const failure of teardownFailures) {
+        console.error(`[desktop-e2e] ${failure.label} teardown failed: ${String(failure.error)}`)
       }
       if (cleanupError) {
         console.error(`[desktop-e2e] result cleanup failed: ${String(cleanupError)}`)
       }
     } else {
-      if (teardownError) throw teardownError
+      if (teardownFailures.length > 0) {
+        throw new AggregateError(
+          teardownFailures.map(failure => failure.error),
+          `Desktop E2E teardown failed: ${teardownFailures
+            .map(failure => failure.label)
+            .join(', ')}`
+        )
+      }
       if (cleanupError) throw cleanupError
     }
   }

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -65,6 +65,12 @@ import { DesktopE2EServer } from './desktop-server.mjs'
 import { resolveElectronLaunchArguments } from './electron-launch-arguments.mjs'
 
 import {
+  clearDesktopE2EResultActive,
+  compactDesktopE2EResult,
+  markDesktopE2EResultActive,
+} from '../result-retention.mjs'
+
+import {
   verifyActiveGoalIdleUnreadLifecycle,
   verifyBusyTurnGoalHandoff,
   verifyGoalRestartRecoveryLifecycle,
@@ -882,6 +888,7 @@ async function main() {
   validateDesktopSegmentOptions()
   const runsProjectPluginE2E = DESKTOP_SEGMENT === 'project-ai-settings'
   await mkdir(resultDir, { recursive: true })
+  await markDesktopE2EResultActive(resultDir)
   console.log(`[desktop-e2e] result directory: ${resultDir}`)
   const workspacePath = join(resultDir, 'workspace')
   const secondaryProjectPath = join(resultDir, 'secondary-project-root')
@@ -989,6 +996,7 @@ async function main() {
   let cloudEnvironment
   let phase = 'startup'
   let desktopScenarioVerified = false
+  let testFailed = false
   try {
     await control.start()
     if (RUNS_PLUGIN_E2E) {
@@ -3979,6 +3987,7 @@ last_updated = "2026-07-30T00:00:00Z"`
     )
     console.log(`Wework desktop task-flow E2E passed. Diagnostics: ${resultDir}`)
   } catch (error) {
+    testFailed = true
     await writeFile(
       join(resultDir, 'model-requests.json'),
       `${JSON.stringify(control.modelRequests, null, 2)}\n`,
@@ -4044,19 +4053,49 @@ last_updated = "2026-07-30T00:00:00Z"`
     )
     throw error
   } finally {
-    await cloudEnvironment?.stop()
-    await blockingNetworkProxy?.stop()
-    await stopDesktopAppProcess(app)
-    await control.close()
-    await desktopScenario?.cleanup?.()
-    await rm(codexSqliteHome, {
-      recursive: true,
-      force: true,
-      maxRetries: process.platform === 'win32' ? 20 : 0,
-      retryDelay: 100,
-    })
-    if (appBundlePath && process.platform === 'darwin') {
-      spawnSync(MACOS_LAUNCH_SERVICES_REGISTER, ['-u', appBundlePath])
+    let teardownError
+    try {
+      await cloudEnvironment?.stop()
+      await blockingNetworkProxy?.stop()
+      await stopDesktopAppProcess(app)
+      await control.close()
+      await desktopScenario?.cleanup?.()
+      await rm(codexSqliteHome, {
+        recursive: true,
+        force: true,
+        maxRetries: process.platform === 'win32' ? 20 : 0,
+        retryDelay: 100,
+      })
+      if (appBundlePath && process.platform === 'darwin') {
+        spawnSync(MACOS_LAUNCH_SERVICES_REGISTER, ['-u', appBundlePath])
+      }
+    } catch (error) {
+      teardownError = error
+    }
+    let cleanupError
+    try {
+      const removed = await compactDesktopE2EResult(resultDir)
+      if (removed > 0) {
+        console.log(`[desktop-e2e] removed ${removed} transient runtime artifacts`)
+      }
+    } catch (error) {
+      cleanupError = error
+    }
+    try {
+      await clearDesktopE2EResultActive(resultDir)
+    } catch (error) {
+      cleanupError ??= error
+    }
+    if (testFailed) {
+      if (teardownError) {
+        console.error(`[desktop-e2e] process teardown failed: ${String(teardownError)}`)
+      }
+      if (cleanupError) {
+        console.error(`[desktop-e2e] result cleanup failed: ${String(cleanupError)}`)
+      }
+    } else {
+      if (teardownError) throw teardownError
+      if (cleanupError) throw cleanupError
     }
   }
 }

--- a/wework/e2e/desktop/process-lifecycle.mjs
+++ b/wework/e2e/desktop/process-lifecycle.mjs
@@ -108,7 +108,7 @@ export function processIsAlive(processId) {
   return true
 }
 
-function isProcessGroupRunning(processGroupId) {
+export function processGroupIsAlive(processGroupId) {
   try {
     process.kill(-processGroupId, 0)
     if (process.platform === 'linux') {
@@ -127,10 +127,10 @@ function isProcessGroupRunning(processGroupId) {
 async function waitForProcessGroupExit(processGroupId, timeoutMs) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < timeoutMs) {
-    if (!isProcessGroupRunning(processGroupId)) return true
+    if (!processGroupIsAlive(processGroupId)) return true
     await new Promise(resolvePromise => setTimeout(resolvePromise, PROCESS_GROUP_POLL_INTERVAL_MS))
   }
-  return !isProcessGroupRunning(processGroupId)
+  return !processGroupIsAlive(processGroupId)
 }
 
 export async function stopProcess(child) {

--- a/wework/e2e/desktop/result-retention.mjs
+++ b/wework/e2e/desktop/result-retention.mjs
@@ -2,7 +2,11 @@ import { spawn } from 'node:child_process'
 import { readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
 
+import { processGroupIsAlive, processIsAlive } from './process-lifecycle.mjs'
+
 const ACTIVE_MARKER = '.active'
+const POSIX_REMOVE_ATTEMPTS = 20
+const POSIX_REMOVE_RETRY_DELAY_MS = 100
 const CACHE_DIRECTORY_NAMES = new Set([
   'Cache',
   'Code Cache',
@@ -20,6 +24,7 @@ const TRANSIENT_TOP_LEVEL_ENTRIES = new Set([
   'wegent-executor.exe',
 ])
 const MACOS_APP_BUNDLE_PATTERN = /^WeWork-Electron-E2E-\d+\.app$/
+const RESULT_DIRECTORY_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-(\d+)$/
 
 function removeOptions() {
   return {
@@ -44,14 +49,98 @@ async function removePath(path) {
     await rm(path, removeOptions())
     return
   }
-  await new Promise((resolvePromise, reject) => {
-    const child = spawn('/bin/rm', ['-rf', path], { stdio: 'ignore' })
-    child.once('error', reject)
-    child.once('close', code => {
-      if (code === 0) resolvePromise()
-      else reject(new Error(`/bin/rm exited with code ${code ?? 'unknown'} for ${path}`))
-    })
-  })
+
+  let lastError
+  for (let attempt = 1; attempt <= POSIX_REMOVE_ATTEMPTS; attempt += 1) {
+    try {
+      await new Promise((resolvePromise, reject) => {
+        const child = spawn('/bin/rm', ['-rf', path], {
+          stdio: ['ignore', 'ignore', 'pipe'],
+        })
+        let stderr = ''
+        child.stderr.setEncoding('utf8')
+        child.stderr.on('data', chunk => {
+          stderr += chunk
+        })
+        child.once('error', reject)
+        child.once('close', code => {
+          if (code === 0) {
+            resolvePromise()
+            return
+          }
+          reject(
+            new Error(`/bin/rm exited with code ${code ?? 'unknown'} for ${path}: ${stderr.trim()}`)
+          )
+        })
+      })
+      return
+    } catch (error) {
+      lastError = error
+      if (attempt < POSIX_REMOVE_ATTEMPTS) {
+        await new Promise(resolvePromise => setTimeout(resolvePromise, POSIX_REMOVE_RETRY_DELAY_MS))
+      }
+    }
+  }
+  throw lastError
+}
+
+function positiveProcessId(value) {
+  return Number.isInteger(value) && value > 0 ? value : undefined
+}
+
+function normalizeActivity(activity, fallbackOwnerProcessId = process.pid) {
+  if (typeof activity === 'number') {
+    return { ownerProcessId: positiveProcessId(activity) ?? fallbackOwnerProcessId }
+  }
+  const applicationProcessId = positiveProcessId(activity?.applicationProcessId)
+  const ownerProcessId = positiveProcessId(activity?.ownerProcessId) ?? fallbackOwnerProcessId
+  return { applicationProcessId, ownerProcessId }
+}
+
+function parseActivity(value) {
+  try {
+    const parsed = JSON.parse(value)
+    if (!parsed || typeof parsed !== 'object') return null
+    const activity = normalizeActivity(parsed, null)
+    return activity.applicationProcessId || activity.ownerProcessId ? activity : null
+  } catch {
+    const ownerProcessId = Number.parseInt(value.trim(), 10)
+    return Number.isInteger(ownerProcessId) && ownerProcessId > 0 ? { ownerProcessId } : null
+  }
+}
+
+function applicationProcessIsAlive(processId) {
+  if (process.platform === 'win32') return processIsAlive(processId)
+  return processGroupIsAlive(processId)
+}
+
+function isRecognizedResultDirectory(resultDirectory) {
+  return RESULT_DIRECTORY_PATTERN.test(basename(resultDirectory))
+}
+
+function ownerProcessIdFromResultDirectory(resultDirectory) {
+  const match = basename(resultDirectory).match(RESULT_DIRECTORY_PATTERN)
+  return match ? Number.parseInt(match[1], 10) : null
+}
+
+async function activeProcesses(resultDirectory) {
+  try {
+    const activity = parseActivity(await readFile(join(resultDirectory, ACTIVE_MARKER), 'utf8'))
+    if (activity) return activity
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+  return {
+    ownerProcessId: ownerProcessIdFromResultDirectory(resultDirectory),
+  }
+}
+
+function activityIsAlive(
+  activity,
+  { isApplicationAlive = applicationProcessIsAlive, isOwnerAlive = processIsAlive } = {}
+) {
+  if (activity.ownerProcessId && isOwnerAlive(activity.ownerProcessId)) return true
+  return Boolean(activity.applicationProcessId && isApplicationAlive(activity.applicationProcessId))
 }
 
 async function removeNamedDirectories(root, names) {
@@ -107,8 +196,15 @@ export function resolveDesktopE2EResultRoot(weworkDirectory, environment = proce
     : join(resolve(weworkDirectory), 'test-results', 'desktop-e2e')
 }
 
-export async function markDesktopE2EResultActive(resultDirectory, processId = process.pid) {
-  await writeFile(join(resultDirectory, ACTIVE_MARKER), `${processId}\n`, 'utf8')
+export async function markDesktopE2EResultActive(
+  resultDirectory,
+  activity = { ownerProcessId: process.pid }
+) {
+  await writeFile(
+    join(resultDirectory, ACTIVE_MARKER),
+    `${JSON.stringify(normalizeActivity(activity))}\n`,
+    'utf8'
+  )
 }
 
 export async function clearDesktopE2EResultActive(resultDirectory) {
@@ -131,44 +227,21 @@ export async function compactDesktopE2EResult(resultDirectory) {
   return removed
 }
 
-function processIdFromResultDirectory(resultDirectory) {
-  const match = basename(resultDirectory).match(/-(\d+)$/)
-  return match ? Number.parseInt(match[1], 10) : null
-}
-
-async function activeProcessId(resultDirectory) {
-  try {
-    const value = (await readFile(join(resultDirectory, ACTIVE_MARKER), 'utf8')).trim()
-    const processId = Number.parseInt(value, 10)
-    if (Number.isInteger(processId) && processId > 0) return processId
-  } catch (error) {
-    if (error?.code !== 'ENOENT') throw error
-  }
-  return processIdFromResultDirectory(resultDirectory)
-}
-
-function processIsAlive(processId) {
-  try {
-    process.kill(processId, 0)
-    return true
-  } catch (error) {
-    if (error?.code === 'ESRCH') return false
-    if (error?.code === 'EPERM') return true
-    throw error
-  }
-}
-
 export async function compactInactiveDesktopE2EResults(
   resultRoot,
-  { isProcessAlive = processIsAlive } = {}
+  {
+    isApplicationAlive = applicationProcessIsAlive,
+    isProcessAlive: isOwnerAlive = processIsAlive,
+  } = {}
 ) {
   let compacted = 0
   let removed = 0
   for (const entry of await directoryEntries(resultRoot)) {
     if (!entry.isDirectory()) continue
     const resultDirectory = join(resultRoot, entry.name)
-    const processId = await activeProcessId(resultDirectory)
-    if (processId && isProcessAlive(processId)) continue
+    if (!isRecognizedResultDirectory(resultDirectory)) continue
+    const activity = await activeProcesses(resultDirectory)
+    if (activityIsAlive(activity, { isApplicationAlive, isOwnerAlive })) continue
     const removedFromResult = await compactDesktopE2EResult(resultDirectory)
     await clearDesktopE2EResultActive(resultDirectory)
     if (removedFromResult > 0) compacted += 1

--- a/wework/e2e/desktop/result-retention.mjs
+++ b/wework/e2e/desktop/result-retention.mjs
@@ -1,0 +1,178 @@
+import { spawn } from 'node:child_process'
+import { readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+
+const ACTIVE_MARKER = '.active'
+const CACHE_DIRECTORY_NAMES = new Set([
+  'Cache',
+  'Code Cache',
+  'DawnGraphiteCache',
+  'DawnWebGPUCache',
+  'GPUCache',
+  'GrShaderCache',
+  'ShaderCache',
+])
+const TRANSIENT_TOP_LEVEL_ENTRIES = new Set([
+  'executor-home',
+  'harness-runtime',
+  'node-runtime',
+  'wegent-executor',
+  'wegent-executor.exe',
+])
+const MACOS_APP_BUNDLE_PATTERN = /^WeWork-Electron-E2E-\d+\.app$/
+
+function removeOptions() {
+  return {
+    force: true,
+    maxRetries: 20,
+    recursive: true,
+    retryDelay: 100,
+  }
+}
+
+async function directoryEntries(path) {
+  try {
+    return await readdir(path, { withFileTypes: true })
+  } catch (error) {
+    if (error?.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+async function removePath(path) {
+  if (process.platform === 'win32') {
+    await rm(path, removeOptions())
+    return
+  }
+  await new Promise((resolvePromise, reject) => {
+    const child = spawn('/bin/rm', ['-rf', path], { stdio: 'ignore' })
+    child.once('error', reject)
+    child.once('close', code => {
+      if (code === 0) resolvePromise()
+      else reject(new Error(`/bin/rm exited with code ${code ?? 'unknown'} for ${path}`))
+    })
+  })
+}
+
+async function removeNamedDirectories(root, names) {
+  let removed = 0
+  for (const entry of await directoryEntries(root)) {
+    if (!entry.isDirectory()) continue
+    const path = join(root, entry.name)
+    if (names.has(entry.name)) {
+      await removePath(path)
+      removed += 1
+      continue
+    }
+    removed += await removeNamedDirectories(path, names)
+  }
+  return removed
+}
+
+async function removeHarnessAppProfiles(userDataDirectory) {
+  const instancesRoot = join(userDataDirectory, 'harness-apps', 'instances')
+  let removed = 0
+  for (const entry of await directoryEntries(instancesRoot)) {
+    if (!entry.isDirectory()) continue
+    const profiles = join(instancesRoot, entry.name, 'profiles')
+    const entries = await directoryEntries(profiles)
+    if (entries.length === 0) continue
+    await removePath(profiles)
+    removed += 1
+  }
+  return removed
+}
+
+async function compactElectronUserData(userDataDirectory) {
+  let removed = 0
+  const exactDirectories = [
+    join(userDataDirectory, 'managed-runtimes'),
+    join(userDataDirectory, 'dsh-core', 'profiles'),
+  ]
+  for (const directory of exactDirectories) {
+    const entries = await directoryEntries(directory)
+    if (entries.length === 0) continue
+    await removePath(directory)
+    removed += 1
+  }
+  removed += await removeHarnessAppProfiles(userDataDirectory)
+  removed += await removeNamedDirectories(userDataDirectory, CACHE_DIRECTORY_NAMES)
+  return removed
+}
+
+export function resolveDesktopE2EResultRoot(weworkDirectory, environment = process.env) {
+  const configured = environment.WEWORK_E2E_RESULT_ROOT?.trim()
+  return configured
+    ? resolve(configured)
+    : join(resolve(weworkDirectory), 'test-results', 'desktop-e2e')
+}
+
+export async function markDesktopE2EResultActive(resultDirectory, processId = process.pid) {
+  await writeFile(join(resultDirectory, ACTIVE_MARKER), `${processId}\n`, 'utf8')
+}
+
+export async function clearDesktopE2EResultActive(resultDirectory) {
+  await rm(join(resultDirectory, ACTIVE_MARKER), { force: true })
+}
+
+export async function compactDesktopE2EResult(resultDirectory) {
+  let removed = 0
+  for (const entry of await directoryEntries(resultDirectory)) {
+    if (
+      !TRANSIENT_TOP_LEVEL_ENTRIES.has(entry.name) &&
+      !MACOS_APP_BUNDLE_PATTERN.test(entry.name)
+    ) {
+      continue
+    }
+    await removePath(join(resultDirectory, entry.name))
+    removed += 1
+  }
+  removed += await compactElectronUserData(join(resultDirectory, 'electron-user-data'))
+  return removed
+}
+
+function processIdFromResultDirectory(resultDirectory) {
+  const match = basename(resultDirectory).match(/-(\d+)$/)
+  return match ? Number.parseInt(match[1], 10) : null
+}
+
+async function activeProcessId(resultDirectory) {
+  try {
+    const value = (await readFile(join(resultDirectory, ACTIVE_MARKER), 'utf8')).trim()
+    const processId = Number.parseInt(value, 10)
+    if (Number.isInteger(processId) && processId > 0) return processId
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+  return processIdFromResultDirectory(resultDirectory)
+}
+
+function processIsAlive(processId) {
+  try {
+    process.kill(processId, 0)
+    return true
+  } catch (error) {
+    if (error?.code === 'ESRCH') return false
+    if (error?.code === 'EPERM') return true
+    throw error
+  }
+}
+
+export async function compactInactiveDesktopE2EResults(
+  resultRoot,
+  { isProcessAlive = processIsAlive } = {}
+) {
+  let compacted = 0
+  let removed = 0
+  for (const entry of await directoryEntries(resultRoot)) {
+    if (!entry.isDirectory()) continue
+    const resultDirectory = join(resultRoot, entry.name)
+    const processId = await activeProcessId(resultDirectory)
+    if (processId && isProcessAlive(processId)) continue
+    const removedFromResult = await compactDesktopE2EResult(resultDirectory)
+    await clearDesktopE2EResultActive(resultDirectory)
+    if (removedFromResult > 0) compacted += 1
+    removed += removedFromResult
+  }
+  return { compacted, removed }
+}

--- a/wework/e2e/desktop/run-checkpoints.mjs
+++ b/wework/e2e/desktop/run-checkpoints.mjs
@@ -5,6 +5,10 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { DESKTOP_CHECKPOINTS } from './checkpoints.mjs'
+import {
+  compactInactiveDesktopE2EResults,
+  resolveDesktopE2EResultRoot,
+} from './result-retention.mjs'
 import { prepareDesktopE2EBuild } from '../../scripts/lib/desktop-e2e-build.mjs'
 import { runCommandToLog } from '../../scripts/lib/command-log.mjs'
 
@@ -505,6 +509,13 @@ async function runCheckpoints(checkpoints) {
 
 async function runAllCheckpoints() {
   await runCheckpoints(DEFAULT_DESKTOP_CHECKPOINTS)
+}
+
+const previousResults = await compactInactiveDesktopE2EResults(
+  resolveDesktopE2EResultRoot(weworkDir)
+)
+if (previousResults.compacted > 0) {
+  console.log(`[desktop-e2e] compacted ${previousResults.compacted} previous result directories`)
 }
 
 if (requestedArgs.length > 0) {

--- a/wework/scripts/desktop-e2e-result-retention.test.mjs
+++ b/wework/scripts/desktop-e2e-result-retention.test.mjs
@@ -1,0 +1,111 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, test } from 'vitest'
+
+import {
+  compactDesktopE2EResult,
+  compactInactiveDesktopE2EResults,
+  markDesktopE2EResultActive,
+  resolveDesktopE2EResultRoot,
+} from '../e2e/desktop/result-retention.mjs'
+
+const roots = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+})
+
+async function temporaryRoot() {
+  const root = await mkdtemp(join(tmpdir(), 'wework-desktop-e2e-retention-'))
+  roots.push(root)
+  return root
+}
+
+async function createDirectoryWithFile(path) {
+  await mkdir(path, { recursive: true })
+  await writeFile(join(path, 'payload'), 'transient\n')
+}
+
+async function expectExists(path) {
+  await expect(access(path)).resolves.toBeUndefined()
+}
+
+async function expectMissing(path) {
+  await expect(access(path)).rejects.toMatchObject({ code: 'ENOENT' })
+}
+
+describe('desktop E2E result retention', () => {
+  test('resolves the configured or default result root', () => {
+    expect(resolveDesktopE2EResultRoot('/repo/wework', {})).toBe(
+      join('/repo/wework', 'test-results', 'desktop-e2e')
+    )
+    expect(
+      resolveDesktopE2EResultRoot('/repo/wework', {
+        WEWORK_E2E_RESULT_ROOT: '/tmp/custom-results',
+      })
+    ).toBe('/tmp/custom-results')
+  })
+
+  test('removes rebuildable runtime payloads while preserving diagnostic evidence', async () => {
+    const resultDirectory = join(await temporaryRoot(), '2026-09-02T00-00-00-000Z-123')
+    const transientDirectories = [
+      'WeWork-Electron-E2E-123.app',
+      'executor-home',
+      'harness-runtime',
+      'node-runtime',
+      'electron-user-data/Cache',
+      'electron-user-data/dsh-core/profiles',
+      'electron-user-data/harness-apps/instances/app-1/profiles',
+      'electron-user-data/managed-runtimes',
+    ]
+    await Promise.all(
+      transientDirectories.map(path => createDirectoryWithFile(join(resultDirectory, path)))
+    )
+    await writeFile(join(resultDirectory, 'wegent-executor'), 'binary\n')
+    await writeFile(join(resultDirectory, 'app.log'), 'diagnostic\n')
+    await createDirectoryWithFile(join(resultDirectory, 'electron-user-data', 'Local Storage'))
+
+    const removed = await compactDesktopE2EResult(resultDirectory)
+
+    expect(removed).toBeGreaterThan(0)
+    for (const path of transientDirectories) {
+      await expectMissing(join(resultDirectory, path))
+    }
+    await expectMissing(join(resultDirectory, 'wegent-executor'))
+    await expectExists(join(resultDirectory, 'app.log'))
+    await expectExists(join(resultDirectory, 'electron-user-data', 'Local Storage', 'payload'))
+  })
+
+  test('compacts inactive results without touching a live desktop run', async () => {
+    const resultRoot = await temporaryRoot()
+    const inactive = join(resultRoot, '2026-09-01T00-00-00-000Z-111')
+    const active = join(resultRoot, '2026-09-02T00-00-00-000Z-222')
+    await createDirectoryWithFile(join(inactive, 'executor-home'))
+    await createDirectoryWithFile(join(active, 'executor-home'))
+    await markDesktopE2EResultActive(active, 222)
+
+    const result = await compactInactiveDesktopE2EResults(resultRoot, {
+      isProcessAlive: processId => processId === 222,
+    })
+
+    expect(result).toEqual({ compacted: 1, removed: 1 })
+    await expectMissing(join(inactive, 'executor-home'))
+    await expectExists(join(active, 'executor-home', 'payload'))
+    await expectExists(join(active, '.active'))
+  })
+
+  test('recognizes a live result before its active marker is written', async () => {
+    const resultRoot = await temporaryRoot()
+    const active = join(resultRoot, '2026-09-02T00-00-00-000Z-333')
+    await createDirectoryWithFile(join(active, 'executor-home'))
+
+    const result = await compactInactiveDesktopE2EResults(resultRoot, {
+      isProcessAlive: processId => processId === 333,
+    })
+
+    expect(result).toEqual({ compacted: 0, removed: 0 })
+    await expectExists(join(active, 'executor-home', 'payload'))
+  })
+})

--- a/wework/scripts/desktop-e2e-result-retention.test.mjs
+++ b/wework/scripts/desktop-e2e-result-retention.test.mjs
@@ -1,6 +1,6 @@
 import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, test } from 'vitest'
 
@@ -39,13 +39,13 @@ async function expectMissing(path) {
 describe('desktop E2E result retention', () => {
   test('resolves the configured or default result root', () => {
     expect(resolveDesktopE2EResultRoot('/repo/wework', {})).toBe(
-      join('/repo/wework', 'test-results', 'desktop-e2e')
+      join(resolve('/repo/wework'), 'test-results', 'desktop-e2e')
     )
     expect(
       resolveDesktopE2EResultRoot('/repo/wework', {
         WEWORK_E2E_RESULT_ROOT: '/tmp/custom-results',
       })
-    ).toBe('/tmp/custom-results')
+    ).toBe(resolve('/tmp/custom-results'))
   })
 
   test('removes rebuildable runtime payloads while preserving diagnostic evidence', async () => {
@@ -84,7 +84,7 @@ describe('desktop E2E result retention', () => {
     const active = join(resultRoot, '2026-09-02T00-00-00-000Z-222')
     await createDirectoryWithFile(join(inactive, 'executor-home'))
     await createDirectoryWithFile(join(active, 'executor-home'))
-    await markDesktopE2EResultActive(active, 222)
+    await markDesktopE2EResultActive(active, { ownerProcessId: 222 })
 
     const result = await compactInactiveDesktopE2EResults(resultRoot, {
       isProcessAlive: processId => processId === 222,
@@ -107,5 +107,36 @@ describe('desktop E2E result retention', () => {
 
     expect(result).toEqual({ compacted: 0, removed: 0 })
     await expectExists(join(active, 'executor-home', 'payload'))
+  })
+
+  test('keeps results while their detached application process group is alive', async () => {
+    const resultRoot = await temporaryRoot()
+    const active = join(resultRoot, '2026-09-02T00-00-00-000Z-444')
+    await createDirectoryWithFile(join(active, 'executor-home'))
+    await markDesktopE2EResultActive(active, {
+      applicationProcessId: 555,
+      ownerProcessId: 444,
+    })
+
+    const result = await compactInactiveDesktopE2EResults(resultRoot, {
+      isApplicationAlive: processId => processId === 555,
+      isProcessAlive: () => false,
+    })
+
+    expect(result).toEqual({ compacted: 0, removed: 0 })
+    await expectExists(join(active, 'executor-home', 'payload'))
+  })
+
+  test('ignores unrelated directories with numeric suffixes', async () => {
+    const resultRoot = await temporaryRoot()
+    const unrelated = join(resultRoot, 'unrelated-666')
+    await createDirectoryWithFile(join(unrelated, 'executor-home'))
+
+    const result = await compactInactiveDesktopE2EResults(resultRoot, {
+      isProcessAlive: () => false,
+    })
+
+    expect(result).toEqual({ compacted: 0, removed: 0 })
+    await expectExists(join(unrelated, 'executor-home', 'payload'))
   })
 })


### PR DESCRIPTION
## Summary

- remove copied app bundles, Executor homes, extracted runtimes, staged executors, and rebuildable Electron caches after each desktop E2E scenario
- compact inactive result directories left by interrupted runs while protecting live runs with PID-based activity detection
- preserve diagnostic logs, screenshots, requests, and UI state; document the retention behavior and add focused tests

Related: WORK-387

## Verification

- `pnpm --filter wework test src/e2e/desktop-process-lifecycle.test.ts scripts/desktop-e2e-result-retention.test.mjs` (12 tests passed)
- `pnpm --filter wework exec eslint ...`
- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework e2e:desktop -- --segment native-window-startup`
  - real Electron checkpoint passed
  - removed 11 transient runtime artifacts
  - retained result directory size: 820KB with `app.log` and `executor.log`
- repository pre-push quality gate passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop E2E test results now retain diagnostic evidence such as logs, screenshots, captured requests, and UI state while removing rebuildable temporary artifacts.
  * Interrupted or inactive test runs are automatically compacted to help prevent ongoing disk usage growth.
  * Active test results remain protected from cleanup during execution.

* **Documentation**
  * Updated English and Chinese guides to describe result storage, retained diagnostics, and automatic cleanup behavior.

* **Tests**
  * Added coverage for result retention, cleanup, active-run protection, and configurable result locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->