### PR TITLE
fix(wework): align macOS terminal navigation keys

### DIFF
--- a/wework/e2e/desktop/scenarios/local-terminal.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/local-terminal.scenario.mjs
@@ -460,12 +460,68 @@ async function startHarness({
   }
 }
 
+async function verifyMacKeybindings(control, timeoutMs) {
+  if (process.platform !== 'darwin') return
+
+  const terminalSelector =
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="workspace-terminal-window"] ` +
+    '[data-testid="embedded-local-terminal"]'
+  const terminalTextareaSelector = `${terminalSelector} .xterm-helper-textarea`
+  const terminalLineSelector = `${terminalSelector} .xterm-accessibility-tree [role="listitem"]`
+
+  await control.command('waitFor', terminalLineSelector, { timeoutMs })
+  await control.command('terminalInput', terminalSelector, { value: 'bindkey -e\r' })
+
+  await control.command('terminalInput', terminalSelector, { value: 'echo option-left omega' })
+  await control.command('press', terminalTextareaSelector, { key: 'Alt+ArrowLeft' })
+  await control.command('terminalInput', terminalSelector, { value: 'X\r' })
+  await control.command('waitFor', terminalLineSelector, {
+    text: 'option-left Xomega',
+    timeoutMs,
+  })
+
+  await control.command('terminalInput', terminalSelector, { value: 'echo option-right omega' })
+  await control.command('terminalInput', terminalSelector, { value: '\x01' })
+  await control.command('press', terminalTextareaSelector, { key: 'Alt+ArrowRight' })
+  await control.command('terminalInput', terminalSelector, { value: 'X\r' })
+  await control.command('waitFor', terminalLineSelector, {
+    text: 'Xoption-right omega',
+    timeoutMs,
+  })
+
+  await control.command('terminalInput', terminalSelector, { value: 'X=WRONG\r' })
+  await control.command('terminalInput', terminalSelector, { value: 'echo noop' })
+  await control.command('press', terminalTextareaSelector, { key: 'Meta+ArrowLeft' })
+  await control.command('terminalInput', terminalSelector, { value: 'X=RIGHT;\r' })
+  await control.command('terminalInput', terminalSelector, {
+    value: 'echo "<command-left:$X>"\r',
+  })
+  await control.command('waitFor', terminalLineSelector, {
+    text: '<command-left:RIGHT>',
+    timeoutMs,
+  })
+
+  await control.command('terminalInput', terminalSelector, { value: 'X=WRONG\r' })
+  await control.command('terminalInput', terminalSelector, { value: 'echo' })
+  await control.command('terminalInput', terminalSelector, { value: '\x01' })
+  await control.command('press', terminalTextareaSelector, { key: 'Meta+ArrowRight' })
+  await control.command('terminalInput', terminalSelector, { value: ';X=RIGHT\r' })
+  await control.command('terminalInput', terminalSelector, {
+    value: 'echo "<command-right:$X>"\r',
+  })
+  await control.command('waitFor', terminalLineSelector, {
+    text: '<command-right:RIGHT>',
+    timeoutMs,
+  })
+}
+
 async function verifyHarnessWorkbenchChrome({
   control,
   title,
   timeoutMs,
   captureWorkbench,
   screenshot,
+  verifyMacKeybindings: shouldVerifyMacKeybindings = false,
 }) {
   const titleSelector = '[data-testid="workbench-pane-task-title"]'
   const rightPanelToggleSelector = '[data-testid="toggle-right-workspace-panel-button"]'
@@ -539,6 +595,9 @@ async function verifyHarnessWorkbenchChrome({
     bottomPanelMetrics.scrollHeight > 0,
     `${title} opened a bottom workspace panel without content`
   )
+  if (shouldVerifyMacKeybindings) {
+    await verifyMacKeybindings(control, timeoutMs)
+  }
   await captureWorkbench(control, screenshot)
 
   await control.command('click', bottomPanelToggleSelector)
@@ -660,6 +719,7 @@ export async function createDesktopScenario({ captureScreenshot, uiTimeoutMs, wo
         timeoutMs: uiTimeoutMs,
         captureWorkbench: capturePage,
         screenshot: 'local-harness-08-opencode-workbench-panels.png',
+        verifyMacKeybindings: true,
       })
       await waitForRequests(
         harnessModelRequests,

--- a/wework/scripts/ai-verify.mjs
+++ b/wework/scripts/ai-verify.mjs
@@ -52,6 +52,7 @@ export const AI_VERIFY_ACTIONS = Object.freeze({
   'remove-storage': 'removeLocalStorageItem',
   origin: 'getLocationOrigin',
   'restart-core-dsh': 'restartCoreDsh',
+  'terminal-input': 'terminalInput',
   'terminal-snapshot': 'readLocalTerminalSnapshot',
   reload: 'reloadApp',
   'close-to-tray': 'closeMainWindowToTray',

--- a/wework/scripts/ai-verify.test.mjs
+++ b/wework/scripts/ai-verify.test.mjs
@@ -45,6 +45,7 @@ describe('AI_VERIFY_ACTIONS', () => {
       'remove-storage': 'removeLocalStorageItem',
       origin: 'getLocationOrigin',
       'restart-core-dsh': 'restartCoreDsh',
+      'terminal-input': 'terminalInput',
       'terminal-snapshot': 'readLocalTerminalSnapshot',
       reload: 'reloadApp',
       'close-to-tray': 'closeMainWindowToTray',

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -13,6 +13,7 @@ import { appendRuntimeTerminalContext } from '@/lib/runtime-terminal-context'
 import { focusTerminalUnlessComposerFocusRequested } from '@/lib/workbenchComposerFocus'
 import { defaultAppearance, useOptionalAppearance } from '@/features/appearance'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
+import { installXtermMacKeybindings } from './xtermMacKeybindings'
 import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermSelectionGuard } from './xtermSelectionGuard'
 import { installXtermTextDrag } from './xtermTextDrag'
@@ -159,11 +160,12 @@ export function EmbeddedLocalTerminal({
       noteData: () => undefined,
       dispose: () => undefined,
     }
-    const dataDisposable = terminal.onData(data => {
+    const writeTerminalInput = (data: string) => {
       if (!terminalInputReady) return
       inputFallback.noteData(data)
       void writeLocalTerminal(sessionId, data)
-    })
+    }
+    const dataDisposable = terminal.onData(writeTerminalInput)
     const titleDisposable = terminal.onTitleChange(title => {
       onTitleChangeRef.current?.(title)
     })
@@ -177,12 +179,9 @@ export function EmbeddedLocalTerminal({
     const textDrag = installXtermTextDrag({ container, terminal })
     inputFallback = installXtermInputFallback({
       terminal,
-      writeData: data => {
-        if (!terminalInputReady) return
-        inputFallback.noteData(data)
-        void writeLocalTerminal(sessionId, data)
-      },
+      writeData: writeTerminalInput,
     })
+    installXtermMacKeybindings({ terminal, writeData: writeTerminalInput })
     terminalRef.current = terminal
     fitAddonRef.current = fitAddon
     applyTerminalTheme(terminal, container, getTerminalTheme(), showWorkbenchBackground)

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.test.tsx
@@ -20,6 +20,7 @@ const testState = vi.hoisted(() => ({
     getSelection: ReturnType<typeof vi.fn>
     getSelectionPosition: ReturnType<typeof vi.fn>
     hasSelection: ReturnType<typeof vi.fn>
+    attachCustomKeyEventHandler: ReturnType<typeof vi.fn>
     onData: ReturnType<typeof vi.fn>
     onResize: ReturnType<typeof vi.fn>
     onScroll: ReturnType<typeof vi.fn>
@@ -85,6 +86,7 @@ vi.mock('@xterm/xterm', () => ({
       getSelection: vi.fn(() => ''),
       getSelectionPosition: vi.fn(() => undefined),
       hasSelection: vi.fn(() => false),
+      attachCustomKeyEventHandler: vi.fn(),
       onData: vi.fn((handler: (data: string) => void) => {
         dataHandlers.push(handler)
         return { dispose: vi.fn() }

--- a/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/RemoteTerminal.tsx
@@ -17,6 +17,7 @@ import { focusTerminalUnlessComposerFocusRequested } from '@/lib/workbenchCompos
 import { defaultAppearance, useOptionalAppearance } from '@/features/appearance'
 import { createXtermWebLinksAddon } from './xtermLinks'
 import { installXtermInputFallback, type XtermInputFallbackController } from './xtermInputFallback'
+import { installXtermMacKeybindings } from './xtermMacKeybindings'
 import { installXtermSelectionGuard } from './xtermSelectionGuard'
 import { installXtermTextDrag } from './xtermTextDrag'
 import {
@@ -193,14 +194,15 @@ export function RemoteTerminal({
       noteData: () => undefined,
       dispose: () => undefined,
     }
-    const dataDisposable = terminal.onData(data => {
+    const writeTerminalInput = (data: string) => {
       inputFallback.noteData(data)
       void client.write(data).catch(error => {
         if (!disposed) {
           console.error('Failed to write to remote terminal:', error)
         }
       })
-    })
+    }
+    const dataDisposable = terminal.onData(writeTerminalInput)
     const unsubscribeOutput = client.onOutput(payload => {
       if (!disposed && payload.session_id === sessionId) {
         writeTerminalOutput(payload.data)
@@ -222,15 +224,9 @@ export function RemoteTerminal({
     const textDrag = installXtermTextDrag({ container, terminal })
     inputFallback = installXtermInputFallback({
       terminal,
-      writeData: data => {
-        inputFallback.noteData(data)
-        void client.write(data).catch(error => {
-          if (!disposed) {
-            console.error('Failed to write fallback input to remote terminal:', error)
-          }
-        })
-      },
+      writeData: writeTerminalInput,
     })
+    installXtermMacKeybindings({ terminal, writeData: writeTerminalInput })
     terminalRef.current = terminal
     fitAddonRef.current = fitAddon
     clientRef.current = client

--- a/wework/src/components/layout/workspace-panels/xtermMacKeybindings.test.ts
+++ b/wework/src/components/layout/workspace-panels/xtermMacKeybindings.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { installXtermMacKeybindings } from './xtermMacKeybindings'
+
+type CustomKeyEventHandler = (event: KeyboardEvent) => boolean
+
+function installForPlatform(platform: string, userAgent: string) {
+  vi.stubGlobal('navigator', { platform, userAgent })
+  let handler: CustomKeyEventHandler | null = null
+  const terminal = {
+    attachCustomKeyEventHandler: vi.fn((nextHandler: CustomKeyEventHandler) => {
+      handler = nextHandler
+    }),
+  }
+  const writeData = vi.fn()
+
+  installXtermMacKeybindings({ terminal, writeData })
+
+  return { handler, terminal, writeData }
+}
+
+function createKeyEvent(
+  key: string,
+  overrides: Partial<KeyboardEvent> = {}
+): KeyboardEvent & {
+  preventDefault: ReturnType<typeof vi.fn>
+  stopPropagation: ReturnType<typeof vi.fn>
+} {
+  return {
+    type: 'keydown',
+    key,
+    altKey: true,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...overrides,
+  } as unknown as KeyboardEvent & {
+    preventDefault: ReturnType<typeof vi.fn>
+    stopPropagation: ReturnType<typeof vi.fn>
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('installXtermMacKeybindings', () => {
+  test.each([
+    ['ArrowLeft', '\x1bb'],
+    ['ArrowRight', '\x1bf'],
+  ])('maps macOS Option+%s to shell word navigation', (key, expectedData) => {
+    const { handler, writeData } = installForPlatform(
+      'MacIntel',
+      'Macintosh; Intel Mac OS X 10_15_7'
+    )
+    const event = createKeyEvent(key)
+
+    expect(handler?.(event)).toBe(false)
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+    expect(writeData).toHaveBeenCalledWith(expectedData)
+  })
+
+  test.each([
+    ['ArrowLeft', '\x01'],
+    ['ArrowUp', '\x01'],
+    ['ArrowRight', '\x05'],
+    ['ArrowDown', '\x05'],
+    ['Backspace', '\x15'],
+    ['Delete', '\x0b'],
+  ])('maps macOS Command+%s to ChatGPT terminal navigation', (key, expectedData) => {
+    const { handler, writeData } = installForPlatform(
+      'MacIntel',
+      'Macintosh; Intel Mac OS X 10_15_7'
+    )
+    const event = createKeyEvent(key, { altKey: false, metaKey: true })
+
+    expect(handler?.(event)).toBe(false)
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+    expect(writeData).toHaveBeenCalledWith(expectedData)
+  })
+
+  test.each([
+    ['keyup', { type: 'keyup' }],
+    ['unmodified arrow', { altKey: false }],
+    ['Control+Option', { ctrlKey: true }],
+    ['Command+Option', { metaKey: true }],
+    ['Shift+Option', { shiftKey: true }],
+    ['unrelated key', { key: 'ArrowUp' }],
+    ['unrelated Command key', { altKey: false, metaKey: true, key: 'Enter' }],
+  ])('leaves %s to xterm', (_label, overrides) => {
+    const { handler, writeData } = installForPlatform(
+      'MacIntel',
+      'Macintosh; Intel Mac OS X 10_15_7'
+    )
+    const event = createKeyEvent('ArrowLeft', overrides)
+
+    expect(handler?.(event)).toBe(true)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(event.stopPropagation).not.toHaveBeenCalled()
+    expect(writeData).not.toHaveBeenCalled()
+  })
+
+  test('does not install the override outside macOS', () => {
+    const { handler, terminal } = installForPlatform('Win32', 'Windows NT 10.0; Win64; x64')
+
+    expect(handler).toBeNull()
+    expect(terminal.attachCustomKeyEventHandler).not.toHaveBeenCalled()
+  })
+})

--- a/wework/src/components/layout/workspace-panels/xtermMacKeybindings.ts
+++ b/wework/src/components/layout/workspace-panels/xtermMacKeybindings.ts
@@ -1,0 +1,48 @@
+import type { Terminal } from '@xterm/xterm'
+
+type XtermMacKeybindingsOptions = {
+  terminal: Pick<Terminal, 'attachCustomKeyEventHandler'>
+  writeData: (data: string) => void
+}
+
+function isMacOsPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return (
+    (navigator.platform ?? '').startsWith('Mac') || (navigator.userAgent ?? '').includes('Mac OS X')
+  )
+}
+
+function getMacKeybindingData(event: KeyboardEvent): string | null {
+  if (event.altKey === event.metaKey) return null
+
+  if (event.altKey) {
+    return event.key === 'ArrowLeft' ? '\x1bb' : event.key === 'ArrowRight' ? '\x1bf' : null
+  }
+
+  if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') return '\x01'
+  if (event.key === 'ArrowRight' || event.key === 'ArrowDown') return '\x05'
+  if (event.key === 'Backspace') return '\x15'
+  if (event.key === 'Delete') return '\x0b'
+  return null
+}
+
+export function installXtermMacKeybindings({
+  terminal,
+  writeData,
+}: XtermMacKeybindingsOptions): void {
+  if (!isMacOsPlatform()) return
+
+  terminal.attachCustomKeyEventHandler(event => {
+    if (event.type !== 'keydown' || event.ctrlKey || event.shiftKey) {
+      return true
+    }
+
+    const data = getMacKeybindingData(event)
+    if (!data) return true
+
+    event.preventDefault()
+    event.stopPropagation()
+    writeData(data)
+    return false
+  })
+}


### PR DESCRIPTION
## Summary

- map macOS Option+Left/Right to shell word navigation instead of leaking `D`/`C`
- align Command+arrow and Command+delete shortcuts with the ChatGPT terminal behavior
- share the key handler across local and remote terminals and keep Windows on xterm defaults
- add unit and desktop Electron regression coverage

## Key mappings

- Option+Left / Option+Right: `Esc+B` / `Esc+F`
- Command+Left / Command+Up: `Ctrl+A`
- Command+Right / Command+Down: `Ctrl+E`
- Command+Backspace: `Ctrl+U`
- Command+Delete: `Ctrl+K`

## Verification

- `pnpm --filter wework test` focused terminal suite: 119 tests passed
- pre-push focused Wework ESLint, TypeScript, and unit tests passed
- `pnpm --filter wework lint` passed
- `pnpm --filter wework typecheck` passed
- `pnpm --filter wework e2e:desktop:local-terminal` passed in isolated Electron

## Notes

- Windows behavior remains delegated to xterm and the active shell, matching the platform-specific implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added macOS terminal keyboard shortcuts for word and line navigation, including Option- and Command-based arrow, deletion, and editing commands.
  - Terminal shortcuts now work consistently across local and remote terminal sessions.

- **Bug Fixes**
  - Improved terminal input handling so keyboard commands use the same reliable input path and readiness behavior.

- **Tests**
  - Added automated coverage validating macOS shortcuts and confirming standard behavior remains unchanged on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->