### PR TITLE
fix(wework): hide Windows console windows for subprocess spawns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,9 @@ jobs:
         working-directory: ./executor
         run: cargo fmt --check
 
+      - name: Check executor command spawns use the hidden process API
+        run: scripts/check-executor-command-spawn.sh
+
       - name: Run executor Rust tests
         working-directory: ./executor
         run: cargo test --all-features

--- a/executor/src/agents/cargo_cache.rs
+++ b/executor/src/agents/cargo_cache.rs
@@ -5,8 +5,10 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
-    process::Command,
 };
+
+#[cfg(test)]
+use std::process::Command;
 
 use sha2::{Digest, Sha256};
 
@@ -90,8 +92,7 @@ fn shared_cargo_target_dir_for_workspace(workspace: &Path, cache_root: &Path) ->
 }
 
 fn git_common_dir(workspace: &Path) -> Option<PathBuf> {
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command_sync("git");
     let output = command
         .arg("-c")
         .arg("core.bare=false")

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -2636,7 +2636,7 @@ fn spawn_codex_app_server(
     let resolved_binary = resolve_codex_binary(binary);
     let codex_home = wework_codex_home();
     prepare_wework_codex_home(&codex_home)?;
-    let mut command = Command::new(&resolved_binary);
+    let mut command = crate::process::command(&resolved_binary);
     for key in EXECUTOR_INTERNAL_ENV_KEYS {
         command.env_remove(key);
     }

--- a/executor/src/agents/git_auth.rs
+++ b/executor/src/agents/git_auth.rs
@@ -11,7 +11,7 @@ use cbc::{
     Decryptor,
 };
 use serde_json::Value;
-use tokio::{io::AsyncWriteExt, process::Command};
+use tokio::io::AsyncWriteExt;
 
 use crate::{
     logging::{log_executor_event, task_fields},
@@ -363,8 +363,7 @@ async fn authenticate_github(git_domain: &str, credentials: &GitCredentials) -> 
             ("git_domain", git_domain.to_owned()),
         ],
     );
-    let mut command = Command::new("gh");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command("gh");
     command
         .arg("auth")
         .arg("login")
@@ -485,7 +484,7 @@ async fn authenticate_gitlab(git_domain: &str, git_token: &str) -> bool {
             ("git_domain", git_domain.to_owned()),
         ],
     );
-    let mut command = Command::new("glab");
+    let mut command = crate::process::command("glab");
     command
         .arg("auth")
         .arg("login")
@@ -495,7 +494,6 @@ async fn authenticate_gitlab(git_domain: &str, git_token: &str) -> bool {
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
-    crate::process::hide_windows_console(&mut command);
     let Ok(mut child) = command.spawn() else {
         return false;
     };
@@ -538,8 +536,7 @@ pub(crate) async fn configure_repo_proxy(git_domain: &str) {
         return;
     };
     for (key, value) in proxy_values {
-        let mut command = Command::new("git");
-        crate::process::hide_windows_console(&mut command);
+        let mut command = crate::process::command("git");
         let _ = command
             .arg("config")
             .arg("--global")

--- a/executor/src/agents/git_workspace.rs
+++ b/executor/src/agents/git_workspace.rs
@@ -15,7 +15,7 @@ use std::os::unix::process::CommandExt;
 use serde_json::Value;
 use tokio::{
     io::{AsyncRead, AsyncReadExt},
-    process::{Child, Command},
+    process::Child,
     task::JoinHandle,
     time::timeout,
 };
@@ -219,8 +219,7 @@ async fn clone_repo(
         ));
     }
 
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command("git");
     command.arg("clone");
     let branch = branch_name(request);
     if let Some(branch) = branch.as_deref() {
@@ -310,8 +309,7 @@ async fn clone_repo(
 }
 
 async fn validate_existing_git_repository(project_path: &Path) -> Result<(), String> {
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command("git");
     command
         .arg("-C")
         .arg(project_path)
@@ -538,8 +536,7 @@ async fn setup_git_config(request: &ExecutionRequest, project_path: &Path) {
         return;
     };
     for (key, value) in [("user.name", git_login), ("user.email", git_email)] {
-        let mut command = Command::new("git");
-        crate::process::hide_windows_console(&mut command);
+        let mut command = crate::process::command("git");
         let _ = command
             .arg("-C")
             .arg(project_path)

--- a/executor/src/agents/image_validator.rs
+++ b/executor/src/agents/image_validator.rs
@@ -6,7 +6,7 @@ use std::{future::Future, pin::Pin, process::Stdio, time::Duration};
 
 use serde::Serialize;
 use serde_json::Value;
-use tokio::{process::Command, time};
+use tokio::time;
 
 use crate::{
     protocol::ExecutionRequest,
@@ -81,8 +81,7 @@ async fn validate_image(request: ExecutionRequest) -> Result<ValidationResult, S
 }
 
 async fn run_check(check: ValidationCheck) -> CheckResult {
-    let mut command = Command::new("sh");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command("sh");
     command
         .args(["-c", check.command])
         .stdout(Stdio::piped())

--- a/executor/src/hooks/command.rs
+++ b/executor/src/hooks/command.rs
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, io, path::Path, process::Stdio, time::Duration};
+use std::{
+    collections::BTreeMap,
+    io,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
 
 use serde::Serialize;
 use tokio::{io::AsyncWriteExt, process::Command, time::sleep};
@@ -22,8 +28,8 @@ pub async fn execute_command_hook<T: Serialize>(
     input: &T,
 ) -> CommandHookOutcome {
     let script = platform_command(config);
-    let script = match resolve_command(script, plugin_dir) {
-        Ok(script) => script,
+    let resolved = match resolve_command(script, plugin_dir) {
+        Ok(resolved) => resolved,
         Err(error) => return failed_outcome(error.to_string()),
     };
     let stdin = match serde_json::to_vec(input) {
@@ -31,7 +37,10 @@ pub async fn execute_command_hook<T: Serialize>(
         Err(error) => return failed_outcome(error.to_string()),
     };
     let timeout_seconds = config.timeout.clamp(1, MAX_TIMEOUT_SECONDS);
-    let mut command = shell_command(&script);
+    let mut command = match resolved {
+        ResolvedHookCommand::Executable { program } => executable_command(program),
+        ResolvedHookCommand::Shell(script) => shell_command(&script),
+    };
     command
         .current_dir(cwd)
         .env_clear()
@@ -103,7 +112,15 @@ fn platform_target() -> String {
     format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
 }
 
-fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<String> {
+enum ResolvedHookCommand {
+    /// Spawn a resolved plugin binary directly without a shell so Windows does
+    /// not allocate a new visible console for the process or its children.
+    Executable { program: PathBuf },
+    /// Run an arbitrary command line through the platform shell.
+    Shell(String),
+}
+
+fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<ResolvedHookCommand> {
     let trimmed = command.trim();
     if trimmed.is_empty() {
         return Err(io::Error::new(
@@ -112,11 +129,14 @@ fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<String> {
         ));
     }
     let Some((program, suffix)) = split_program(trimmed) else {
-        return Ok(trimmed.to_owned());
+        return Ok(ResolvedHookCommand::Shell(trimmed.to_owned()));
     };
+    if !program.contains('/') && !program.contains('\\') {
+        return Ok(ResolvedHookCommand::Shell(trimmed.to_owned()));
+    }
     let path = Path::new(program);
-    if path.is_absolute() || (!program.contains('/') && !program.contains('\\')) {
-        return Ok(trimmed.to_owned());
+    if path.is_absolute() {
+        return Ok(ResolvedHookCommand::Shell(trimmed.to_owned()));
     }
     let candidate = plugin_dir.join(path);
     let canonical = candidate.canonicalize()?;
@@ -127,7 +147,14 @@ fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<String> {
             "relative hook command escapes plugin directory",
         ));
     }
-    Ok(format!("{}{}", shell_quote(&canonical), suffix))
+    if suffix.trim().is_empty() {
+        return Ok(ResolvedHookCommand::Executable { program: canonical });
+    }
+    Ok(ResolvedHookCommand::Shell(format!(
+        "{}{}",
+        shell_quote(&canonical),
+        suffix
+    )))
 }
 
 fn split_program(command: &str) -> Option<(&str, &str)> {
@@ -148,11 +175,26 @@ fn shell_quote(path: &Path) -> String {
     format!("\"{}\"", path.to_string_lossy().replace('"', "\\\""))
 }
 
+fn executable_command(program: PathBuf) -> Command {
+    let program = program.to_string_lossy().into_owned();
+    let (program, prefix_args) = crate::process::spawn_program_parts(&program);
+    let mut command = Command::new(program);
+    command.args(prefix_args);
+    crate::process::hide_windows_console(&mut command);
+    command
+}
+
 fn shell_command(script: &str) -> Command {
     #[cfg(windows)]
     {
         let mut command = Command::new("cmd");
-        command.args(["/S", "/C", script]);
+        command.args(["/S", "/C"]);
+        // cmd /S strips the first and last quote of the command line, so
+        // wrapping the script in quotes preserves inner quoting such as
+        // resolved plugin binary paths that contain spaces. Passing the script
+        // as a raw argument also prevents Rust from escaping those inner
+        // quotes into backslash forms that cmd does not understand.
+        command.raw_arg(format!("\"{}\"", script));
         crate::process::hide_windows_console(&mut command);
         command
     }
@@ -285,5 +327,34 @@ mod tests {
             .insert(platform_target(), "target-command".to_owned());
 
         assert_eq!(platform_command(&hook), "target-command");
+    }
+
+    #[test]
+    fn resolves_relative_plugin_binaries_without_a_shell() {
+        let directory = tempdir().unwrap();
+        let tool = directory.path().join("bin/tool");
+        fs::create_dir_all(tool.parent().unwrap()).unwrap();
+        fs::write(&tool, "placeholder").unwrap();
+
+        let resolved = resolve_command("./bin/tool", directory.path()).unwrap();
+        match resolved {
+            ResolvedHookCommand::Executable { program } => {
+                assert!(program.starts_with(directory.path().canonicalize().unwrap()));
+            }
+            ResolvedHookCommand::Shell(_) => {
+                panic!("expected the plugin binary to resolve for direct execution")
+            }
+        }
+    }
+
+    #[test]
+    fn keeps_commands_with_arguments_in_the_shell() {
+        let directory = tempdir().unwrap();
+        let tool = directory.path().join("bin/tool");
+        fs::create_dir_all(tool.parent().unwrap()).unwrap();
+        fs::write(&tool, "placeholder").unwrap();
+
+        let resolved = resolve_command("./bin/tool --flag", directory.path()).unwrap();
+        assert!(matches!(resolved, ResolvedHookCommand::Shell(_)));
     }
 }

--- a/executor/src/hooks/command.rs
+++ b/executor/src/hooks/command.rs
@@ -39,7 +39,7 @@ pub async fn execute_command_hook<T: Serialize>(
     let timeout_seconds = config.timeout.clamp(1, MAX_TIMEOUT_SECONDS);
     let mut command = match resolved {
         ResolvedHookCommand::Executable { program } => executable_command(program),
-        ResolvedHookCommand::Shell(script) => shell_command(&script),
+        ResolvedHookCommand::Shell(script) => crate::process::shell(&script),
     };
     command
         .current_dir(cwd)
@@ -178,32 +178,9 @@ fn shell_quote(path: &Path) -> String {
 fn executable_command(program: PathBuf) -> Command {
     let program = program.to_string_lossy().into_owned();
     let (program, prefix_args) = crate::process::spawn_program_parts(&program);
-    let mut command = Command::new(program);
+    let mut command = crate::process::command(program);
     command.args(prefix_args);
-    crate::process::hide_windows_console(&mut command);
     command
-}
-
-fn shell_command(script: &str) -> Command {
-    #[cfg(windows)]
-    {
-        let mut command = Command::new("cmd");
-        command.args(["/S", "/C"]);
-        // cmd /S strips the first and last quote of the command line, so
-        // wrapping the script in quotes preserves inner quoting such as
-        // resolved plugin binary paths that contain spaces. Passing the script
-        // as a raw argument also prevents Rust from escaping those inner
-        // quotes into backslash forms that cmd does not understand.
-        command.raw_arg(format!("\"{}\"", script));
-        crate::process::hide_windows_console(&mut command);
-        command
-    }
-    #[cfg(not(windows))]
-    {
-        let mut command = Command::new("sh");
-        command.args(["-c", script]);
-        command
-    }
 }
 
 fn filtered_environment() -> BTreeMap<String, String> {

--- a/executor/src/hooks/pre_execute.rs
+++ b/executor/src/hooks/pre_execute.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::BTreeMap, path::PathBuf, sync::OnceLock, time::Duration};
 
-use tokio::{process::Command, time::timeout};
+use tokio::time::timeout;
 
 const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
 
@@ -55,8 +55,7 @@ impl PreExecuteHook {
             return HookExit::success();
         };
 
-        let mut command = Command::new("bash");
-        crate::process::hide_windows_console(&mut command);
+        let mut command = crate::process::command("bash");
         command.arg(script).arg(&context.task_dir);
         command.env("WEGENT_TASK_DIR", &context.task_dir);
         if let Some(task_id) = context.task_id {

--- a/executor/src/local/backend/extension.rs
+++ b/executor/src/local/backend/extension.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use serde_json::{json, Value};
-use tokio::{process::Command, time::timeout};
+use tokio::time::timeout;
 
 const EXTENSION_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -112,8 +112,7 @@ async fn run_script(
     payload: &Value,
 ) -> Result<String, String> {
     let payload_json = serde_json::to_string(payload).unwrap_or_else(|_| "{}".to_owned());
-    let mut command = Command::new("bash");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command("bash");
     command
         .arg(script)
         .arg(action)

--- a/executor/src/local/command.rs
+++ b/executor/src/local/command.rs
@@ -244,29 +244,13 @@ pub fn build_env(extra_env: &HashMap<String, String>) -> HashMap<String, String>
 fn process_command(request: &CommandRequest) -> Command {
     if !request.argv.is_empty() {
         let (program, prefix_args) = crate::process::spawn_program_parts(&request.argv[0]);
-        let mut command = Command::new(program);
-        crate::process::hide_windows_console(&mut command);
+        let mut command = crate::process::command(program);
         command.args(prefix_args);
         command.args(&request.argv[1..]);
         return command;
     }
 
-    shell_command(&request.command)
-}
-
-#[cfg(windows)]
-fn shell_command(command_line: &str) -> Command {
-    let mut command = Command::new("cmd");
-    command.args(["/C", command_line]);
-    crate::process::hide_windows_console(&mut command);
-    command
-}
-
-#[cfg(not(windows))]
-fn shell_command(command_line: &str) -> Command {
-    let mut command = Command::new("sh");
-    command.args(["-c", command_line]);
-    command
+    crate::process::shell(&request.command)
 }
 
 fn decode_and_truncate(data: &[u8], max_bytes: usize) -> (String, bool) {

--- a/executor/src/local/git_commit_message.rs
+++ b/executor/src/local/git_commit_message.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use serde_json::json;
-use tokio::{io::AsyncWriteExt, process::Command, time};
+use tokio::{io::AsyncWriteExt, time};
 
 use crate::{
     agents::{resolve_codex_binary, resolve_codex_binary_path},
@@ -105,8 +105,7 @@ async fn run_git(
     env: &HashMap<String, String>,
     max_bytes: usize,
 ) -> Result<(String, bool), String> {
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command("git");
     command.args(args);
     command.env_clear();
     command.envs(env);
@@ -144,8 +143,7 @@ async fn run_codex(
     cwd: Option<&str>,
     env: &HashMap<String, String>,
 ) -> Result<String, String> {
-    let mut command = Command::new(binary);
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command(binary);
     command.args(codex_args(output_path));
     command.env_clear();
     command.envs(env);

--- a/executor/src/local/harnesses.rs
+++ b/executor/src/local/harnesses.rs
@@ -12,7 +12,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
-use tokio::{process::Command, time::timeout};
+use tokio::time::timeout;
 
 use crate::{path_compat::strip_windows_verbatim_prefix, process_environment};
 
@@ -421,8 +421,7 @@ fn is_executable_file(path: &Path) -> bool {
 }
 
 async fn read_command_version(path: &Path, args: &[&str]) -> Option<String> {
-    let mut command = Command::new(path);
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command(path);
     command
         .args(args)
         .kill_on_drop(true)

--- a/executor/src/local/harnesses.rs
+++ b/executor/src/local/harnesses.rs
@@ -422,6 +422,7 @@ fn is_executable_file(path: &Path) -> bool {
 
 async fn read_command_version(path: &Path, args: &[&str]) -> Option<String> {
     let mut command = Command::new(path);
+    crate::process::hide_windows_console(&mut command);
     command
         .args(args)
         .kill_on_drop(true)

--- a/executor/src/process/mod.rs
+++ b/executor/src/process/mod.rs
@@ -47,8 +47,12 @@ use crate::{
     },
 };
 
+mod spawn;
+
 #[cfg(windows)]
 mod windows_batch;
+
+pub use spawn::{command, command_sync, shell};
 
 const DEFAULT_STREAM_TEXT_CHUNK_CHARS: usize = 256;
 const DEFAULT_STREAM_REASONING_CHUNK_CHARS: usize = 4_096;
@@ -855,16 +859,12 @@ impl Drop for ProcessTreeGuard {
 
 #[cfg(windows)]
 fn kill_windows_process_tree(pid: u32) {
-    use std::os::windows::process::CommandExt;
-
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     let pid = pid.to_string();
-    let status = std::process::Command::new("taskkill")
+    let status = crate::process::command_sync("taskkill")
         .args(["/PID", pid.as_str(), "/T", "/F"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .creation_flags(CREATE_NO_WINDOW)
         .status();
     if let Err(error) = status {
         log_executor_event(
@@ -876,7 +876,6 @@ fn kill_windows_process_tree(pid: u32) {
 
 async fn run_command_output(spec: CommandSpec, timeout_seconds: u64) -> CommandOutcome {
     let mut command = command_from_spec(&spec);
-    hide_windows_console(&mut command);
     if let Some(cwd) = spec.cwd.as_ref() {
         if let Err(error) = fs::create_dir_all(cwd) {
             return CommandOutcome::Failure {
@@ -928,7 +927,6 @@ where
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    hide_windows_console(&mut command);
     if let Some(cwd) = spec.cwd.as_ref() {
         if let Err(error) = fs::create_dir_all(cwd) {
             return CommandOutcome::Failure {
@@ -987,7 +985,7 @@ fn command_from_spec(spec: &CommandSpec) -> Command {
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect::<Vec<_>>();
     let (program, prefix_args) = spawn_program_parts(&spec.program);
-    let mut command = Command::new(program);
+    let mut command = crate::process::command(program);
     command
         .args(prefix_args)
         .args(&spec.args)

--- a/executor/src/process/spawn.rs
+++ b/executor/src/process/spawn.rs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use tokio::process::Command;
+
+use super::hide_windows_console;
+
+/// Build a subprocess command with Windows console windows hidden by default.
+///
+/// Every executor subprocess should be created through this function (or
+/// [`shell`]) instead of raw `Command::new` so Windows builds cannot
+/// reintroduce visible console windows. On non-Windows platforms this is
+/// equivalent to `Command::new`.
+pub fn command(program: impl AsRef<Path>) -> Command {
+    let mut command = Command::new(program.as_ref());
+    hide_windows_console(&mut command);
+    command
+}
+
+/// Synchronous counterpart of [`command`] for code that cannot await.
+pub fn command_sync(program: impl AsRef<Path>) -> std::process::Command {
+    let mut command = std::process::Command::new(program.as_ref());
+    hide_windows_console(&mut command);
+    command
+}
+
+/// Build a command that runs `command_line` through the platform shell.
+///
+/// On Unix this is `sh -c`. On Windows it is `cmd /S /C` with the script
+/// passed as a single raw argument, so inner quoting survives and the whole
+/// shell tree runs under one hidden console.
+pub fn shell(command_line: &str) -> Command {
+    #[cfg(windows)]
+    {
+        let mut command = Command::new("cmd");
+        command.args(["/S", "/C"]);
+        command.raw_arg(format!("\"{}\"", command_line));
+        hide_windows_console(&mut command);
+        command
+    }
+    #[cfg(not(windows))]
+    {
+        let mut command = Command::new("sh");
+        command.args(["-c", command_line]);
+        command
+    }
+}

--- a/executor/src/process_environment.rs
+++ b/executor/src/process_environment.rs
@@ -7,11 +7,14 @@ use std::{collections::HashMap, env, path::PathBuf};
 #[cfg(unix)]
 use std::{
     io::{Read, Seek, SeekFrom},
-    process::{Command, ExitStatus, Stdio},
+    process::{ExitStatus, Stdio},
     sync::OnceLock,
     thread,
     time::{Duration, Instant},
 };
+
+#[cfg(test)]
+use std::process::Command;
 
 #[cfg(unix)]
 use regex::Regex;
@@ -217,7 +220,7 @@ fn capture_shell_environment(
         "printf '%s' '{0}'; command env; printf '%s' '{0}'; exit",
         SHELL_ENV_DELIMITER
     );
-    let mut child = Command::new(shell)
+    let mut child = crate::process::command_sync(shell)
         .args(["-ilc", &script])
         .env("CODEX_SHELL", "1")
         .env(SHELL_ENV_MARKER, "1")

--- a/executor/src/runtime_work/codex_global_state.rs
+++ b/executor/src/runtime_work/codex_global_state.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 #[cfg(target_os = "macos")]
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -1855,7 +1855,7 @@ fn normalize_path_or_raw(value: &str) -> String {
 
 #[cfg(target_os = "macos")]
 fn codex_app_is_running() -> bool {
-    Command::new("ps")
+    crate::process::command_sync("ps")
         .args(codex_app_running_probe_args())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())

--- a/executor/src/runtime_work/local_connector_auth.rs
+++ b/executor/src/runtime_work/local_connector_auth.rs
@@ -715,16 +715,14 @@ async fn run_plugin_command(
 
 fn plugin_command(program: &Path, rest: &[String]) -> Command {
     if looks_like_shell_script(program) {
-        let mut cmd = Command::new("sh");
-        crate::process::hide_windows_console(&mut cmd);
+        let mut cmd = crate::process::command("sh");
         cmd.arg(program);
         for arg in rest {
             cmd.arg(arg);
         }
         cmd
     } else if program.extension().and_then(|ext| ext.to_str()) == Some("ps1") {
-        let mut cmd = Command::new("pwsh");
-        crate::process::hide_windows_console(&mut cmd);
+        let mut cmd = crate::process::command("pwsh");
         cmd.args([
             "-NoProfile",
             "-NonInteractive",
@@ -738,8 +736,7 @@ fn plugin_command(program: &Path, rest: &[String]) -> Command {
         }
         cmd
     } else {
-        let mut cmd = Command::new(program);
-        crate::process::hide_windows_console(&mut cmd);
+        let mut cmd = crate::process::command(program);
         for arg in rest {
             cmd.arg(arg);
         }

--- a/executor/src/runtime_work/local_connector_auth.rs
+++ b/executor/src/runtime_work/local_connector_auth.rs
@@ -716,6 +716,7 @@ async fn run_plugin_command(
 fn plugin_command(program: &Path, rest: &[String]) -> Command {
     if looks_like_shell_script(program) {
         let mut cmd = Command::new("sh");
+        crate::process::hide_windows_console(&mut cmd);
         cmd.arg(program);
         for arg in rest {
             cmd.arg(arg);
@@ -723,6 +724,7 @@ fn plugin_command(program: &Path, rest: &[String]) -> Command {
         cmd
     } else if program.extension().and_then(|ext| ext.to_str()) == Some("ps1") {
         let mut cmd = Command::new("pwsh");
+        crate::process::hide_windows_console(&mut cmd);
         cmd.args([
             "-NoProfile",
             "-NonInteractive",
@@ -737,6 +739,7 @@ fn plugin_command(program: &Path, rest: &[String]) -> Command {
         cmd
     } else {
         let mut cmd = Command::new(program);
+        crate::process::hide_windows_console(&mut cmd);
         for arg in rest {
             cmd.arg(arg);
         }

--- a/executor/src/runtime_work/worktrees.rs
+++ b/executor/src/runtime_work/worktrees.rs
@@ -8,13 +8,15 @@ use std::{
     fs::OpenOptions,
     io::Write,
     path::{Path, PathBuf},
-    process::Command,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex, Weak,
     },
     time::{SystemTime, UNIX_EPOCH},
 };
+
+#[cfg(test)]
+use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -1144,13 +1146,12 @@ fn add_git_worktree(source: &Path, target: &Path, git_ref: Option<&str>) -> Resu
 fn remove_git_worktree(path: &Path) -> Result<(), String> {
     let value = path.to_str().ok_or("Invalid worktree path")?;
     let common_dir = git_common_dir(path)?;
-    let mut command = Command::new("git");
+    let mut command = crate::process::command_sync("git");
     command
         .arg("--git-dir")
         .arg(common_dir)
         .args(["worktree", "remove", "--force", value]);
     command.env_remove("GIT_DIR").env_remove("GIT_WORK_TREE");
-    crate::process::hide_windows_console(&mut command);
     let output = command.output().map_err(|error| error.to_string())?;
     command_result(output).map(|_| ())
 }
@@ -1184,32 +1185,29 @@ fn restore_git_worktree(git_common_dir: &Path, path: &Path, reference: &str) -> 
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| error.to_string())?;
     }
-    let mut command = Command::new("git");
+    let mut command = crate::process::command_sync("git");
     command
         .arg("--git-dir")
         .arg(git_common_dir)
         .args(["worktree", "add", "--detach"])
         .arg(path)
         .arg(reference);
-    crate::process::hide_windows_console(&mut command);
     let output = command.output().map_err(|error| error.to_string())?;
     command_result(output).map(|_| ())
 }
 
 fn delete_snapshot_ref(git_common_dir: &Path, reference: &str) -> Result<(), String> {
-    let mut command = Command::new("git");
+    let mut command = crate::process::command_sync("git");
     command
         .arg("--git-dir")
         .arg(git_common_dir)
         .args(["update-ref", "-d", reference]);
-    crate::process::hide_windows_console(&mut command);
     let output = command.output().map_err(|error| error.to_string())?;
     command_result(output).map(|_| ())
 }
 
 fn git_output(path: &Path, args: &[&str], envs: Option<&[(&str, &str)]>) -> Result<String, String> {
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command_sync("git");
     command
         .arg("-c")
         .arg("core.bare=false")
@@ -1524,8 +1522,7 @@ fn git_ref_exists(repo_root: &Path, git_ref: &str) -> Result<bool, String> {
         return Ok(false);
     }
     let commit = format!("{git_ref}^{{commit}}");
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command_sync("git");
     command
         .arg("-c")
         .arg("core.bare=false")

--- a/executor/src/server/mod.rs
+++ b/executor/src/server/mod.rs
@@ -32,7 +32,7 @@ use axum::{
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tokio::{process::Command, sync::Semaphore, time::timeout};
+use tokio::{sync::Semaphore, time::timeout};
 
 use crate::{
     agents::runtime_capabilities,
@@ -664,8 +664,7 @@ async fn zip_directory(path: &Path) -> Result<Vec<u8>, HttpError> {
         detail: "Directory name not found".to_owned(),
     })?;
 
-    let mut command = Command::new("zip");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command("zip");
     command
         .arg("-r")
         .arg("-q")
@@ -1456,8 +1455,7 @@ async fn run_envd_process(request: &ProcessStartRequest) -> ProcessOutput {
         .collect::<Vec<_>>();
     let process_environment = process_environment::process_env(&requested_environment);
     let (program, prefix_args) = crate::process::spawn_program_parts(&request.process.cmd);
-    let mut command = Command::new(program);
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command(program);
     command
         .args(prefix_args)
         .args(&request.process.args)

--- a/executor/src/services/turn_file_changes.rs
+++ b/executor/src/services/turn_file_changes.rs
@@ -583,8 +583,7 @@ fn line_stats(
 fn numstat_by_path(workspace: &Path, patch: &[u8]) -> BTreeMap<String, (i64, i64, bool)> {
     let patch_path = unique_temp_dir("wegent-turn-numstat").join("changes.patch");
     let _ = fs::write(&patch_path, patch);
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command_sync("git");
     clear_local_git_env(&mut command);
     let result = command
         .arg("apply")
@@ -826,8 +825,7 @@ fn git_output_vec(
     env: Option<&BTreeMap<String, String>>,
     input: Option<&[u8]>,
 ) -> Result<Vec<u8>, String> {
-    let mut command = Command::new("git");
-    crate::process::hide_windows_console(&mut command);
+    let mut command = crate::process::command_sync("git");
     clear_local_git_env(&mut command);
     command.arg("-C").arg(workspace).args(args);
     if let Some(env) = env {

--- a/executor/src/services/updater/process_manager.rs
+++ b/executor/src/services/updater/process_manager.rs
@@ -5,7 +5,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::Stdio,
     sync::Arc,
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -152,8 +152,7 @@ impl ProcessManager {
         let Some(program) = plan.command.first() else {
             return false;
         };
-        let mut command = Command::new(program);
-        crate::process::hide_windows_console(&mut command);
+        let mut command = crate::process::command(program);
         command.args(plan.command.iter().skip(1));
         command.stdin(Stdio::null());
 

--- a/executor/src/task_runtime/aitable_provider.rs
+++ b/executor/src/task_runtime/aitable_provider.rs
@@ -641,8 +641,7 @@ impl AITableProvider {
     fn command(&self, args: &[&str]) -> Result<Command, TaskRuntimeError> {
         std::fs::create_dir_all(&self.dws_config_dir)
             .map_err(|error| TaskRuntimeError::ProviderRequest(error.to_string()))?;
-        let mut command = Command::new(&self.dws_binary);
-        crate::process::hide_windows_console(&mut command);
+        let mut command = crate::process::command(&self.dws_binary);
         command
             .args(args)
             .args(["--format", "json"])

--- a/scripts/check-executor-command-spawn.sh
+++ b/scripts/check-executor-command-spawn.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ensures every executor subprocess goes through
+# crate::process::{command, command_sync, shell} so Windows console windows
+# stay hidden by default. Ad-hoc Command::new sites tend to forget
+# CREATE_NO_WINDOW and reintroduce console flashes on Windows.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXECUTOR_SRC="$REPO_ROOT/executor/src"
+
+find "$EXECUTOR_SRC" -name '*.rs' -print0 | xargs -0 awk '
+  BEGIN { in_test = 0; depth = 0; bad = 0 }
+  FILENAME ~ /wegent-executor-dev\.rs$/ { nextfile }
+  FILENAME ~ /tests\.rs$/ { nextfile }
+  /^#\[cfg\(/ && /test/ { in_test = 1; next }
+  in_test {
+    depth += gsub(/\{/, "x") - gsub(/\}/, "x")
+    if (depth <= 0) { in_test = 0; depth = 0 }
+    next
+  }
+  /Command::new\(/ && FILENAME !~ /process\/spawn\.rs$/ {
+    print FILENAME ":" FNR ": use crate::process::command()/command_sync()/shell() instead of Command::new()"
+    bad = 1
+  }
+  END { exit bad }
+'

--- a/wework/electron/src/host/local-workspace-openers.ts
+++ b/wework/electron/src/host/local-workspace-openers.ts
@@ -1,10 +1,8 @@
-import { execFile, spawn } from 'node:child_process'
 import { access, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, extname, join } from 'node:path'
-import { promisify } from 'node:util'
 
-const execFileAsync = promisify(execFile)
+import { execFileAsync, spawnProcess, spawnVisible } from '../runtime/process.js'
 
 export interface LocalWorkspaceOpenerAvailability {
   id: string
@@ -411,24 +409,32 @@ async function launchWindowsOpener(
   workspacePath: string
 ): Promise<void> {
   if (openerId === 'cmd') {
-    await launchDetached('cmd.exe', ['/C', 'start', '', command, '/K', `cd /d "${workspacePath}"`])
+    await launchDetached(
+      'cmd.exe',
+      ['/C', 'start', '', command, '/K', `cd /d "${workspacePath}"`],
+      { visible: true }
+    )
     return
   }
   if (openerId === 'powershell') {
     const escapedPath = workspacePath.replaceAll("'", "''")
-    await launchDetached('cmd.exe', [
-      '/C',
-      'start',
-      '',
-      command,
-      '-NoExit',
-      '-Command',
-      `Set-Location -LiteralPath '${escapedPath}'`,
-    ])
+    await launchDetached(
+      'cmd.exe',
+      [
+        '/C',
+        'start',
+        '',
+        command,
+        '-NoExit',
+        '-Command',
+        `Set-Location -LiteralPath '${escapedPath}'`,
+      ],
+      { visible: true }
+    )
     return
   }
   if (openerId === 'terminal') {
-    await launchDetached(command, ['-d', workspacePath])
+    await launchDetached(command, ['-d', workspacePath], { visible: true })
     return
   }
   if (['.cmd', '.bat'].includes(extname(command).toLowerCase())) {
@@ -438,9 +444,14 @@ async function launchWindowsOpener(
   await launchDetached(command, [workspacePath])
 }
 
-async function launchDetached(command: string, args: string[]): Promise<void> {
+async function launchDetached(
+  command: string,
+  args: string[],
+  options: { visible?: boolean } = {}
+): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, {
+    const spawnFn = options.visible ? spawnVisible : spawnProcess
+    const child = spawnFn(command, args, {
       detached: true,
       stdio: 'ignore',
     })

--- a/wework/electron/src/host/local-workspace-openers.ts
+++ b/wework/electron/src/host/local-workspace-openers.ts
@@ -390,7 +390,9 @@ async function resolveWindowsExecutable(
 
   for (const command of opener.commands) {
     try {
-      const { stdout } = await execFileAsync('where.exe', [command])
+      const { stdout } = await execFileAsync('where.exe', [command], {
+        windowsHide: true,
+      })
       const resolved = stdout
         .split(/\r?\n/)
         .map(path => path.trim())
@@ -519,12 +521,11 @@ foreach ($dir in $folders) {
 }
 `
   try {
-    const { stdout } = await execFileAsync('pwsh.exe', [
-      '-NoProfile',
-      '-NonInteractive',
-      '-Command',
-      script,
-    ])
+    const { stdout } = await execFileAsync(
+      'pwsh.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      { windowsHide: true }
+    )
     return new Map(
       stdout.split(/\r?\n/).flatMap(line => {
         const separator = line.indexOf('\t')

--- a/wework/electron/src/host/process-diagnostics.ts
+++ b/wework/electron/src/host/process-diagnostics.ts
@@ -1,7 +1,4 @@
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
-
-const execFileAsync = promisify(execFile)
+import { execFileAsync } from '../runtime/process.js'
 
 export interface ProcessDiagnosticsProcess {
   pid: number

--- a/wework/electron/src/host/workbench-plugin-manager.ts
+++ b/wework/electron/src/host/workbench-plugin-manager.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto'
-import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import type { ChildProcessByStdio } from 'node:child_process'
 import type { Readable, Writable } from 'node:stream'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { createInterface, type Interface as ReadlineInterface } from 'node:readline'
+import { spawnProcess } from '../runtime/process.js'
 import { readdir, readFile, realpath, stat } from 'node:fs/promises'
 
 const MANIFEST_PATH = '.wework-plugin/plugin.json'
@@ -107,7 +108,7 @@ export class WorkbenchPluginManager {
     const desktop = plugin.manifest.desktop
     const command = plugin.desktopPath
     if (!desktop || !command) throw new Error('Plugin does not declare a desktop sidecar')
-    const child = spawn(command, desktop.args, {
+    const child = spawnProcess(command, desktop.args, {
       cwd: plugin.root,
       detached: process.platform !== 'win32',
       env: {
@@ -236,7 +237,7 @@ async function terminateProcessTree(sidecar: RunningSidecar): Promise<void> {
   const pid = sidecar.child.pid
   if (!pid || sidecar.child.exitCode !== null) return
   if (process.platform === 'win32') {
-    const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+    const killer = spawnProcess('taskkill', ['/PID', String(pid), '/T', '/F'], {
       stdio: 'ignore',
       windowsHide: true,
     })

--- a/wework/electron/src/host/workbench-plugin-manager.ts
+++ b/wework/electron/src/host/workbench-plugin-manager.ts
@@ -118,7 +118,7 @@ export class WorkbenchPluginManager {
       },
       stdio: ['pipe', 'pipe', 'ignore'],
       windowsHide: true,
-    })
+    }) as PluginChild
     await waitForSpawn(child, pluginId)
     const readline = createInterface({ input: child.stdout, crlfDelay: Infinity })
     this.sidecars.set(pluginId, {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -18,13 +18,11 @@ import {
   type WebContents,
 } from 'electron'
 import electronUpdater from 'electron-updater'
-import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { release } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { promisify } from 'node:util'
 import {
   captureWebContentsDataUrl,
   createElectronCapabilityRouter,
@@ -49,6 +47,7 @@ import { restoreComputerUseAfterStartup } from './host/computer-use-startup.js'
 import { materializeBundledRuntimes } from './runtime/bundled-runtime-materializer.js'
 import { waitForRendererSelector } from './host/renderer-readiness.js'
 import { desktopWindowFrameOptions } from './host/window-layout.js'
+import { execFileAsync } from './runtime/process.js'
 import { createSingleFlight, presentWindow } from './host/window-presentation.js'
 import { DesktopRuntime } from './runtime/desktop-runtime.js'
 import { FeedbackBundleManager } from './host/feedback-bundle-manager.js'
@@ -104,7 +103,6 @@ const startupSplashPreloadPath = resolve(packageRoot, 'dist/startup-splash-prelo
 const browserAnnotationPreloadPath = resolve(packageRoot, 'dist/browser-annotation-preload.cjs')
 const developmentResourcesRoot = resolve(packageRoot, '..', 'resources')
 const { autoUpdater } = electronUpdater
-const execFileAsync = promisify(execFile)
 const keepE2EWindowInBackground = keepDesktopE2EInBackground(process.env, process.platform)
 const updateBaseUrl =
   process.env.WEWORK_UPDATE_BASE_URL?.trim() ||

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -1554,6 +1554,7 @@ async function readNodeVersion(path: string): Promise<string> {
   const { stdout } = await execFileAsync(path, ['--version'], {
     env: environment,
     timeout: 5000,
+    windowsHide: true,
   })
   const output = stdout.trim()
   const match = /^v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/.exec(output)

--- a/wework/electron/src/runtime/core-dsh-plugin-manager.ts
+++ b/wework/electron/src/runtime/core-dsh-plugin-manager.ts
@@ -1,4 +1,5 @@
 import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { join } from 'node:path'
 import { runtimeNodeArgs } from './electron-node-runtime.js'
 import { spawnProcess } from './process.js'
@@ -505,7 +506,7 @@ function runCommand(
       shell: false,
       windowsHide: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-    })
+    }) as ChildProcessWithoutNullStreams
     let stdout = ''
     let stderr = ''
     const timeout = setTimeout(() => {

--- a/wework/electron/src/runtime/core-dsh-plugin-manager.ts
+++ b/wework/electron/src/runtime/core-dsh-plugin-manager.ts
@@ -1,7 +1,7 @@
-import { spawn } from 'node:child_process'
 import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { runtimeNodeArgs } from './electron-node-runtime.js'
+import { spawnProcess } from './process.js'
 
 const PROFILE_NAME = 'wework-core'
 const STATE_FILE = '.wework-core-plugins.json'
@@ -499,7 +499,7 @@ function runCommand(
   options: { cwd: string; env: NodeJS.ProcessEnv }
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawnProcess(command, args, {
       cwd: options.cwd,
       env: options.env,
       shell: false,

--- a/wework/electron/src/runtime/desktop-device-name.ts
+++ b/wework/electron/src/runtime/desktop-device-name.ts
@@ -1,8 +1,6 @@
-import { execFile } from 'node:child_process'
 import { hostname } from 'node:os'
-import { promisify } from 'node:util'
 
-const execFileAsync = promisify(execFile)
+import { execFileAsync } from './process.js'
 
 interface DesktopDeviceNameOptions {
   environment: NodeJS.ProcessEnv

--- a/wework/electron/src/runtime/process.ts
+++ b/wework/electron/src/runtime/process.ts
@@ -5,7 +5,10 @@
 import {
   execFile,
   spawn,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
   type ExecFileOptions,
+  type SpawnOptions,
   type SpawnOptionsWithoutStdio,
 } from 'node:child_process'
 import { promisify } from 'node:util'
@@ -18,8 +21,18 @@ import { promisify } from 'node:util'
  */
 export function spawnProcess(
   command: string,
+  args: readonly string[],
+  options: SpawnOptionsWithoutStdio
+): ChildProcessWithoutNullStreams
+export function spawnProcess(
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions
+): ChildProcess
+export function spawnProcess(
+  command: string,
   args: readonly string[] = [],
-  options: SpawnOptionsWithoutStdio = {}
+  options: SpawnOptions = {}
 ) {
   return spawn(command, args, { ...options, windowsHide: true })
 }
@@ -28,7 +41,7 @@ export function spawnProcess(
 export function spawnVisible(
   command: string,
   args: readonly string[] = [],
-  options: SpawnOptionsWithoutStdio = {}
+  options: SpawnOptions = {}
 ) {
   return spawn(command, args, options)
 }

--- a/wework/electron/src/runtime/process.ts
+++ b/wework/electron/src/runtime/process.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  execFile,
+  spawn,
+  type ExecFileOptions,
+  type SpawnOptionsWithoutStdio,
+} from 'node:child_process'
+import { promisify } from 'node:util'
+
+/**
+ * Spawn a subprocess with Windows console windows hidden by default. Every
+ * background subprocess should go through this helper so Windows builds
+ * cannot reintroduce console flashes. Use {@link spawnVisible} when showing a
+ * terminal window is intentional.
+ */
+export function spawnProcess(
+  command: string,
+  args: readonly string[] = [],
+  options: SpawnOptionsWithoutStdio = {}
+) {
+  return spawn(command, args, { ...options, windowsHide: true })
+}
+
+/** Spawn a subprocess and keep its terminal window visible on Windows. */
+export function spawnVisible(
+  command: string,
+  args: readonly string[] = [],
+  options: SpawnOptionsWithoutStdio = {}
+) {
+  return spawn(command, args, options)
+}
+
+const execFileAsyncImpl = promisify(execFile)
+
+/** `execFile` promisified with Windows console windows hidden by default. */
+export function execFileAsync(
+  file: string,
+  args: readonly string[],
+  options: ExecFileOptions = {}
+): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsyncImpl(file, args, { ...options, windowsHide: true }) as Promise<{
+    stdout: string
+    stderr: string
+  }>
+}

--- a/wework/electron/src/runtime/runtime-supervisor.ts
+++ b/wework/electron/src/runtime/runtime-supervisor.ts
@@ -1,10 +1,7 @@
-import {
-  spawn,
-  type ChildProcessWithoutNullStreams,
-  type SpawnOptionsWithoutStdio,
-} from 'node:child_process'
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from 'node:child_process'
 import { EventEmitter, once } from 'node:events'
 import { RotatingLog, type RotatingLogOptions } from './rotating-log.js'
+import { spawnProcess } from './process.js'
 import { resolveSpawnCommand } from './spawn-command.js'
 
 export type RuntimeSupervisorState =
@@ -99,7 +96,7 @@ export class RuntimeSupervisor extends EventEmitter<RuntimeSupervisorEvents> {
       stdio.push('pipe')
     }
     const resolved = resolveSpawnCommand(this.options.command, this.options.args ?? [])
-    const child = spawn(resolved.command, resolved.args, {
+    const child = spawnProcess(resolved.command, resolved.args, {
       cwd: this.options.cwd,
       env: this.options.env,
       detached: process.platform !== 'win32',
@@ -330,7 +327,7 @@ function signalProcessTree(child: ChildProcessWithoutNullStreams, signal: NodeJS
     if (process.platform === 'win32') {
       const args = ['/pid', String(child.pid), '/t']
       if (signal === 'SIGKILL') args.push('/f')
-      const killer = spawn('taskkill', args, { windowsHide: true, stdio: 'ignore' })
+      const killer = spawnProcess('taskkill', args, { stdio: 'ignore' })
       killer.unref()
       return
     }

--- a/wework/electron/src/runtime/workbench-dsh-runtime.ts
+++ b/wework/electron/src/runtime/workbench-dsh-runtime.ts
@@ -1,4 +1,5 @@
 import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { basename, delimiter, dirname, isAbsolute, join, resolve, sep } from 'node:path'
 import semver from 'semver'
 import { runtimeNodeArgs } from './electron-node-runtime.js'
@@ -431,7 +432,7 @@ function runCommand(
       ...options,
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
-    })
+    }) as ChildProcessWithoutNullStreams
     let stdout = ''
     let stderr = ''
     child.stdout.setEncoding('utf8')

--- a/wework/electron/src/runtime/workbench-dsh-runtime.ts
+++ b/wework/electron/src/runtime/workbench-dsh-runtime.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process'
 import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, delimiter, dirname, isAbsolute, join, resolve, sep } from 'node:path'
 import semver from 'semver'
@@ -9,6 +8,7 @@ import {
   type BundledDshRuntime,
   type CommandRunner,
 } from './core-dsh-runtime.js'
+import { spawnProcess } from './process.js'
 
 export const WORKBENCH_DSH_VERSION = '0.1.0-rc.8'
 
@@ -427,7 +427,7 @@ function runCommand(
   options: { cwd: string; env: NodeJS.ProcessEnv }
 ): Promise<void> {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, {
+    const child = spawnProcess(command, args, {
       ...options,
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,

--- a/wework/eslint.config.js
+++ b/wework/eslint.config.js
@@ -30,4 +30,23 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    files: ['electron/src/**/*.{ts,tsx}'],
+    ignores: ['electron/src/runtime/process.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'node:child_process',
+              allowTypeImports: true,
+              message:
+                'Use runtime/process.ts (spawnProcess / spawnVisible / execFileAsync) so Windows console windows stay hidden.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ])

--- a/wework/eslint.config.js
+++ b/wework/eslint.config.js
@@ -32,7 +32,7 @@ export default defineConfig([
   },
   {
     files: ['electron/src/**/*.{ts,tsx}'],
-    ignores: ['electron/src/runtime/process.ts'],
+    ignores: ['electron/src/runtime/process.ts', 'electron/src/**/*.test.{ts,tsx}'],
     rules: {
       'no-restricted-imports': [
         'error',


### PR DESCRIPTION
## Problem

On Windows, Wework local tasks flash a blank console window on every code edit (apply_patch), titled with the codex-code-statistics hook binary path; Wework also flashes once on startup.

## Root cause

- Bundled hook commands were executed through a PowerShell wrapper. The hook binary, spawned as a grandchild, did not inherit the hidden console, so each apply_patch hook allocated a new visible console window.
- Several startup and helper spawn sites did not set `CREATE_NO_WINDOW` / `windowsHide`.

## Changes

1. `fix(executor): run hook binaries directly...` — executor hooks now spawn resolved plugin binaries directly with `CREATE_NO_WINDOW` instead of wrapping them in a shell; shell fallbacks run through `cmd /C` with correct raw-argument quoting.
2. `refactor(executor): route all subprocess spawns through a hidden process API` — add `crate::process::{command, command_sync, shell}` factories that hide console windows by default, migrate every executor subprocess spawn to them, and add a CI check that forbids raw `Command::new` outside the factory.
3. `refactor(wework): route Electron subprocess spawns...` — add `runtime/process.ts` (`spawnProcess` / `spawnVisible` / `execFileAsync`, `windowsHide` by default), migrate `child_process` callers, and restrict direct `node:child_process` imports via ESLint. User-invoked terminal openers stay visible via `spawnVisible`.
4. `fix(wework): hide Windows console windows for remaining spawn sites` — cover Node version probing, workspace opener discovery, and local harness/connector commands.
5. Two follow-up fixes: `spawnProcess` overloads matching node `child_process` types, and exempting test files from the import restriction (tests legitimately spawn processes).

## Verification

- `cargo check --all-targets`, executor lib tests (hooks suite), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check` pass.
- `tsc`, `eslint`, `prettier`, and the new `scripts/check-executor-command-spawn.sh` pass.
- Rebased onto latest `main`; the only overlapping file (`wework/electron/src/main.ts`) merged cleanly.
- Windows real-machine verification is still pending.

## Notes

The internal codex-code-statistics hook plugin (internal-only) receives a separate, internal-only change; the executor/electron fixes here will reach the internal repo via the periodic open-source sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unwanted console windows from appearing during background process operations on Windows.
  * Improved command execution consistency across executor and desktop workflows.
  * Preserved intentional visibility for commands launched directly in a terminal.

* **Tests**
  * Added automated checks to ensure subprocesses use the supported execution pathways.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->