### PR TITLE
fix(executor): run hook binaries directly to avoid Windows console flashes

### DIFF
--- a/executor/src/hooks/command.rs
+++ b/executor/src/hooks/command.rs
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, io, path::Path, process::Stdio, time::Duration};
+use std::{
+    collections::BTreeMap,
+    io,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
 
 use serde::Serialize;
 use tokio::{io::AsyncWriteExt, process::Command, time::sleep};
@@ -22,8 +28,8 @@ pub async fn execute_command_hook<T: Serialize>(
     input: &T,
 ) -> CommandHookOutcome {
     let script = platform_command(config);
-    let script = match resolve_command(script, plugin_dir) {
-        Ok(script) => script,
+    let resolved = match resolve_command(script, plugin_dir) {
+        Ok(resolved) => resolved,
         Err(error) => return failed_outcome(error.to_string()),
     };
     let stdin = match serde_json::to_vec(input) {
@@ -31,7 +37,10 @@ pub async fn execute_command_hook<T: Serialize>(
         Err(error) => return failed_outcome(error.to_string()),
     };
     let timeout_seconds = config.timeout.clamp(1, MAX_TIMEOUT_SECONDS);
-    let mut command = shell_command(&script);
+    let mut command = match resolved {
+        ResolvedHookCommand::Executable { program } => executable_command(program),
+        ResolvedHookCommand::Shell(script) => shell_command(&script),
+    };
     command
         .current_dir(cwd)
         .env_clear()
@@ -103,7 +112,15 @@ fn platform_target() -> String {
     format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
 }
 
-fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<String> {
+enum ResolvedHookCommand {
+    /// Spawn a resolved plugin binary directly without a shell so Windows does
+    /// not allocate a new visible console for the process or its children.
+    Executable { program: PathBuf },
+    /// Run an arbitrary command line through the platform shell.
+    Shell(String),
+}
+
+fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<ResolvedHookCommand> {
     let trimmed = command.trim();
     if trimmed.is_empty() {
         return Err(io::Error::new(
@@ -112,11 +129,14 @@ fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<String> {
         ));
     }
     let Some((program, suffix)) = split_program(trimmed) else {
-        return Ok(trimmed.to_owned());
+        return Ok(ResolvedHookCommand::Shell(trimmed.to_owned()));
     };
+    if !program.contains('/') && !program.contains('\\') {
+        return Ok(ResolvedHookCommand::Shell(trimmed.to_owned()));
+    }
     let path = Path::new(program);
-    if path.is_absolute() || (!program.contains('/') && !program.contains('\\')) {
-        return Ok(trimmed.to_owned());
+    if path.is_absolute() {
+        return Ok(ResolvedHookCommand::Shell(trimmed.to_owned()));
     }
     let candidate = plugin_dir.join(path);
     let canonical = candidate.canonicalize()?;
@@ -127,7 +147,14 @@ fn resolve_command(command: &str, plugin_dir: &Path) -> io::Result<String> {
             "relative hook command escapes plugin directory",
         ));
     }
-    Ok(format!("{}{}", shell_quote(&canonical), suffix))
+    if suffix.trim().is_empty() {
+        return Ok(ResolvedHookCommand::Executable { program: canonical });
+    }
+    Ok(ResolvedHookCommand::Shell(format!(
+        "{}{}",
+        shell_quote(&canonical),
+        suffix
+    )))
 }
 
 fn split_program(command: &str) -> Option<(&str, &str)> {
@@ -148,11 +175,26 @@ fn shell_quote(path: &Path) -> String {
     format!("\"{}\"", path.to_string_lossy().replace('"', "\\\""))
 }
 
+fn executable_command(program: PathBuf) -> Command {
+    let program = program.to_string_lossy().into_owned();
+    let (program, prefix_args) = crate::process::spawn_program_parts(&program);
+    let mut command = Command::new(program);
+    command.args(prefix_args);
+    crate::process::hide_windows_console(&mut command);
+    command
+}
+
 fn shell_command(script: &str) -> Command {
     #[cfg(windows)]
     {
         let mut command = Command::new("cmd");
-        command.args(["/S", "/C", script]);
+        command.args(["/S", "/C"]);
+        // cmd /S strips the first and last quote of the command line, so
+        // wrapping the script in quotes preserves inner quoting such as
+        // resolved plugin binary paths that contain spaces. Passing the script
+        // as a raw argument also prevents Rust from escaping those inner
+        // quotes into backslash forms that cmd does not understand.
+        command.raw_arg(format!("\"{}\"", script));
         crate::process::hide_windows_console(&mut command);
         command
     }
@@ -285,5 +327,34 @@ mod tests {
             .insert(platform_target(), "target-command".to_owned());
 
         assert_eq!(platform_command(&hook), "target-command");
+    }
+
+    #[test]
+    fn resolves_relative_plugin_binaries_without_a_shell() {
+        let directory = tempdir().unwrap();
+        let tool = directory.path().join("bin/tool");
+        fs::create_dir_all(tool.parent().unwrap()).unwrap();
+        fs::write(&tool, "placeholder").unwrap();
+
+        let resolved = resolve_command("./bin/tool", directory.path()).unwrap();
+        match resolved {
+            ResolvedHookCommand::Executable { program } => {
+                assert!(program.starts_with(directory.path().canonicalize().unwrap()));
+            }
+            ResolvedHookCommand::Shell(_) => {
+                panic!("expected the plugin binary to resolve for direct execution")
+            }
+        }
+    }
+
+    #[test]
+    fn keeps_commands_with_arguments_in_the_shell() {
+        let directory = tempdir().unwrap();
+        let tool = directory.path().join("bin/tool");
+        fs::create_dir_all(tool.parent().unwrap()).unwrap();
+        fs::write(&tool, "placeholder").unwrap();
+
+        let resolved = resolve_command("./bin/tool --flag", directory.path()).unwrap();
+        assert!(matches!(resolved, ResolvedHookCommand::Shell(_)));
     }
 }


### PR DESCRIPTION
## Problem

On Windows, Wework local tasks flash a blank console window on every code edit (apply_patch), titled with the codex-code-statistics hook binary path.

## Root cause

Bundled hook commands that resolve to a single plugin binary were executed through a PowerShell wrapper. The hook binary, spawned as a grandchild, did not inherit the hidden console, so every apply_patch hook allocated a new visible console window.

## Change

`executor/src/hooks/command.rs`:

- Commands that resolve to a single plugin binary (e.g. `./bin/windows-x86_64/codex-code-statistics.exe`) are now spawned directly with `CREATE_NO_WINDOW` instead of through a shell, so no visible console is allocated for the hook or its children.
- Commands that still need a shell run through `cmd /C` (Windows) / `sh -c` (Unix) with hidden console; the Windows shell argument is passed as a raw argument so quoted plugin paths survive.

The change is self-contained: it relies only on the existing `hide_windows_console` / `spawn_program_parts` helpers.

## Verification

- `cargo check --all-targets`, executor hooks unit tests, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` pass.
- Windows real-machine verification is pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Plugin hook commands that resolve to standalone binaries now execute directly, preventing an unwanted console window on Windows.
  * Commands containing arguments or requiring shell interpretation continue to run through the shell.
  * Improved handling of quoted and whitespace-prefixed commands across supported platforms.
  * Windows shell-based hook commands now handle script quoting more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->