### PR TITLE
fix(frontend): hide OpenClaw devices behind advanced mode

### DIFF
--- a/frontend/e2e/tests/devices/advanced-device-visibility.spec.ts
+++ b/frontend/e2e/tests/devices/advanced-device-visibility.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+
+import { buildStorageState, getJwtExpiryMs } from '../../utils/auth-state'
+import { createApiClient, type ApiClient } from '../../utils/api-client'
+import {
+  createAuthenticatedSocketClient,
+  type AuthenticatedSocketClient,
+} from '../../../../packages/chat-core/src/socket/authenticatedSocketClient'
+
+const API_BASE_URL = process.env.E2E_API_URL || 'http://localhost:8000'
+const APP_BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:3000'
+
+type BindShell = 'claudecode' | 'openclaw'
+type RegisterAck = { success?: boolean; device_id?: string; error?: string }
+
+async function registerDevice(
+  token: string,
+  deviceId: string,
+  name: string,
+  bindShell: BindShell
+): Promise<AuthenticatedSocketClient> {
+  const client = createAuthenticatedSocketClient({
+    socketBaseUrl: () => API_BASE_URL,
+    getToken: () => token,
+    namespace: '/local-executor',
+  })
+
+  await client.connect(token)
+  await expect.poll(() => client.getState().isConnected).toBe(true)
+
+  const acknowledgement = await new Promise<RegisterAck>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`Timed out registering ${deviceId}`)), 10_000)
+    client.socket.emit(
+      'device:register',
+      {
+        device_id: deviceId,
+        name,
+        device_type: 'local',
+        bind_shell: bindShell,
+        executor_version: 'e2e',
+      },
+      (response: RegisterAck) => {
+        clearTimeout(timeout)
+        resolve(response)
+      }
+    )
+  })
+
+  expect(acknowledgement).toEqual({ success: true, device_id: deviceId })
+  return client
+}
+
+async function waitForDevices(
+  apiClient: ApiClient,
+  expectedDevices: Array<{ deviceId: string; bindShell: BindShell }>
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const response = await apiClient.get<{
+        items?: Array<{ device_id: string; status: string; bind_shell?: string }>
+      }>('/api/devices')
+      expect(response.status).toBe(200)
+      const devices = response.data?.items || []
+      return expectedDevices.every(expected =>
+        devices.some(
+          device =>
+            device.device_id === expected.deviceId &&
+            device.bind_shell === expected.bindShell &&
+            device.status === 'online'
+        )
+      )
+    })
+    .toBe(true)
+}
+
+async function deleteDevice(request: APIRequestContext, token: string, deviceId: string) {
+  const response = await request.delete(
+    `${API_BASE_URL}/api/devices/${encodeURIComponent(deviceId)}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  )
+  expect([200, 404]).toContain(response.status())
+}
+
+test('gates OpenClaw behind advanced mode and keeps ordinary chat on Executor', async ({
+  browser,
+  page: authenticatedAdminPage,
+  request,
+}) => {
+  const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const userName = `e2e-device-visibility-${runId}`
+  const userPassword = 'E2E-device-visibility-123!'
+  const executorId = `e2e-executor-${runId}`
+  const openClawId = `e2e-openclaw-${runId}`
+  const executorName = `E2E Executor ${runId}`
+  const openClawName = `E2E OpenClaw ${runId}`
+  const deviceClients: AuthenticatedSocketClient[] = []
+  let browserContext: Awaited<ReturnType<typeof browser.newContext>> | null = null
+  let userId: number | null = null
+  let token: string | null = null
+  let apiClient: ApiClient | null = null
+
+  const adminStorageState = await authenticatedAdminPage.context().storageState()
+  const adminToken =
+    adminStorageState.origins
+      .flatMap(origin => origin.localStorage)
+      .find(item => item.name === 'auth_token')?.value ||
+    adminStorageState.cookies.find(cookie => cookie.name === 'auth_token')?.value
+  expect(adminToken).toBeTruthy()
+  if (!adminToken) throw new Error('Authenticated E2E admin storage did not include a token')
+  const adminClient = createApiClient(request, API_BASE_URL, adminToken)
+
+  try {
+    const createdUser = await adminClient.adminCreateUser({
+      user_name: userName,
+      password: userPassword,
+      role: 'user',
+      auth_source: 'password',
+    })
+    expect(createdUser.status).toBe(201)
+    userId = (createdUser.data as { id?: number } | null)?.id ?? null
+    expect(userId).toEqual(expect.any(Number))
+
+    apiClient = createApiClient(request)
+    const login = await apiClient.login(userName, userPassword)
+    expect(login.status).toBe(200)
+    token = login.data?.access_token || null
+    expect(token).toBeTruthy()
+    if (!token) throw new Error('Isolated E2E login did not return an access token')
+
+    deviceClients.push(await registerDevice(token, executorId, executorName, 'claudecode'))
+    deviceClients.push(await registerDevice(token, openClawId, openClawName, 'openclaw'))
+    await waitForDevices(apiClient, [
+      { deviceId: executorId, bindShell: 'claudecode' },
+      { deviceId: openClawId, bindShell: 'openclaw' },
+    ])
+
+    const updateDefault = await apiClient.put('/api/users/me', {
+      preferences: { default_execution_target: openClawId },
+    })
+    expect(updateDefault.status).toBe(200)
+
+    const tokenExpiryMs = getJwtExpiryMs(token)
+    expect(tokenExpiryMs).not.toBeNull()
+    if (!tokenExpiryMs) throw new Error('Regular E2E token does not include an expiry')
+    const storageState = buildStorageState(APP_BASE_URL, token, tokenExpiryMs)
+    storageState.origins[0]?.localStorage.push({
+      name: 'user_onboarding_completed',
+      value: 'true',
+    })
+    browserContext = await browser.newContext({ storageState })
+    const page = await browserContext.newPage()
+
+    await test.step('hide OpenClaw by default and persist the advanced-mode opt in', async () => {
+      await page.goto(`${APP_BASE_URL}/devices`)
+      await expect(page.getByText(executorName, { exact: true })).toBeVisible()
+      await expect(page.getByText(openClawName, { exact: true })).toHaveCount(0)
+
+      const advancedModeToggle = page.getByTestId('show-advanced-devices-toggle')
+      await expect(advancedModeToggle).toHaveAttribute('data-state', 'unchecked')
+      await advancedModeToggle.click()
+      await expect(advancedModeToggle).toHaveAttribute('data-state', 'checked')
+      await expect(page.getByText(openClawName, { exact: true })).toBeVisible()
+
+      await page.reload()
+      await expect(page.getByTestId('show-advanced-devices-toggle')).toHaveAttribute(
+        'data-state',
+        'checked'
+      )
+      await expect(page.getByText(openClawName, { exact: true })).toBeVisible()
+    })
+
+    await test.step('ignore an OpenClaw account default for an ordinary device chat', async () => {
+      await page.goto(`${APP_BASE_URL}/devices/chat`)
+      const targetSelect = page.getByTestId('device-chat-target-select')
+      await expect(targetSelect).toHaveValue(executorId)
+      await expect(targetSelect.locator(`option[value="${openClawId}"]`)).toHaveCount(1)
+    })
+
+    await test.step('preserve an explicit OpenClaw conversation when advanced mode is off', async () => {
+      await page.evaluate(() => localStorage.setItem('wegent_show_advanced_devices', 'false'))
+      await page.goto(`${APP_BASE_URL}/devices/chat?deviceId=${encodeURIComponent(openClawId)}`)
+      const targetSelect = page.getByTestId('device-chat-target-select')
+      await expect(targetSelect).toHaveValue(openClawId)
+      await expect(targetSelect.locator(`option[value="${openClawId}"]`)).toHaveCount(1)
+
+      await page.goto(`${APP_BASE_URL}/devices/chat`)
+      await expect(targetSelect).toHaveValue(executorId)
+      await expect(targetSelect.locator(`option[value="${openClawId}"]`)).toHaveCount(0)
+    })
+  } finally {
+    await browserContext?.close()
+    deviceClients.forEach(client => client.dispose())
+    if (token) {
+      await Promise.all([
+        deleteDevice(request, token, executorId),
+        deleteDevice(request, token, openClawId),
+      ])
+    }
+    if (userId) {
+      const deletedUser = await adminClient.adminDeleteUser(userId)
+      expect(deletedUser.status).toBe(204)
+    }
+  }
+})

--- a/frontend/src/__tests__/features/devices/DevicesPage.advanced-mode.test.tsx
+++ b/frontend/src/__tests__/features/devices/DevicesPage.advanced-mode.test.tsx
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { DeviceInfo } from '@/apis/devices'
+import DevicesPage from '@/app/(tasks)/devices/page'
+
+const devices: DeviceInfo[] = [
+  {
+    id: 1,
+    device_id: 'executor-device',
+    name: 'Executor Device',
+    status: 'online',
+    is_default: true,
+    device_type: 'local',
+    connection_mode: 'websocket',
+    slot_used: 0,
+    slot_max: 1,
+    running_tasks: [],
+    executor_version: '1.8.8',
+    latest_version: '1.8.8',
+    update_available: false,
+    bind_shell: 'claudecode',
+  },
+  {
+    id: 2,
+    device_id: 'openclaw-device',
+    name: 'OpenClaw Device',
+    status: 'online',
+    is_default: false,
+    device_type: 'local',
+    connection_mode: 'websocket',
+    slot_used: 0,
+    slot_max: 1,
+    running_tasks: [],
+    executor_version: '1.8.8',
+    latest_version: '1.8.8',
+    update_available: false,
+    bind_shell: 'openclaw',
+  },
+]
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
+}))
+
+jest.mock('@/features/layout/TopNavigation', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/features/tasks/components/sidebar', () => ({
+  TaskSidebar: () => null,
+  ResizableSidebar: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  CollapsedSidebarButtons: () => null,
+}))
+
+jest.mock('@/features/layout/GithubStarButton', () => ({ GithubStarButton: () => null }))
+jest.mock('@/features/theme/ThemeToggle', () => ({ ThemeToggle: () => null }))
+jest.mock('@/features/layout/hooks/useMediaQuery', () => ({ useIsMobile: () => false }))
+jest.mock('@/features/tasks/session/TaskSession', () => ({
+  useTaskSession: () => ({ selectTask: jest.fn() }),
+}))
+jest.mock('@/contexts/DeviceContext', () => ({
+  useDevices: () => ({
+    devices,
+    isLoading: false,
+    error: null,
+    refreshDevices: jest.fn(),
+    isDeviceUpgrading: () => false,
+    getUpgradeStatus: () => undefined,
+  }),
+}))
+jest.mock('@/apis/user', () => ({ getToken: () => 'token' }))
+jest.mock('@/lib/runtime-config', () => ({ getSocketUrl: () => 'https://example.test' }))
+jest.mock('@/features/devices/hooks', () => ({
+  useDeviceHandlers: () => ({
+    handleStartTask: jest.fn(),
+    handleSetDefault: jest.fn(),
+    handleDeleteDevice: jest.fn(),
+    handleCancelTask: jest.fn(),
+    handleUpgradeDevice: jest.fn(),
+    handleEditAlias: jest.fn(),
+  }),
+}))
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+jest.mock('@/features/devices/components', () => {
+  const actual = jest.requireActual('@/features/devices/components')
+  return {
+    ...actual,
+    DeviceCard: ({ device }: { device: DeviceInfo }) => (
+      <div data-testid={`page-device-${device.device_id}`}>{device.name}</div>
+    ),
+    DeviceSetupGuide: () => null,
+    EditDeviceAliasDialog: () => null,
+  }
+})
+
+describe('DevicesPage advanced mode', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('hides OpenClaw by default and persists the advanced-mode opt in', async () => {
+    const { unmount } = render(<DevicesPage />)
+
+    expect(screen.getByTestId('page-device-executor-device')).toBeInTheDocument()
+    expect(screen.queryByTestId('page-device-openclaw-device')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('show-advanced-devices-toggle'))
+
+    expect(screen.getByTestId('page-device-openclaw-device')).toBeInTheDocument()
+    expect(localStorage.getItem('wegent_show_advanced_devices')).toBe('true')
+
+    unmount()
+    render(<DevicesPage />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('page-device-openclaw-device')).toBeInTheDocument()
+    )
+  })
+})

--- a/frontend/src/__tests__/features/devices/utils/device-visibility.test.ts
+++ b/frontend/src/__tests__/features/devices/utils/device-visibility.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DeviceInfo } from '@/apis/devices'
+import {
+  filterDevicesByAdvancedMode,
+  isWegentExecutionDevice,
+  resolveOrdinaryDeviceChatTarget,
+} from '@/features/devices/utils/device-visibility'
+
+function createDevice(overrides: Partial<DeviceInfo>): DeviceInfo {
+  return {
+    id: 1,
+    device_id: 'device-1',
+    name: 'Device 1',
+    status: 'online',
+    is_default: false,
+    device_type: 'local',
+    connection_mode: 'websocket',
+    slot_used: 0,
+    slot_max: 1,
+    running_tasks: [],
+    executor_version: null,
+    latest_version: null,
+    update_available: false,
+    bind_shell: 'claudecode',
+    ...overrides,
+  }
+}
+
+describe('device visibility', () => {
+  it('keeps OpenClaw registered with Wegent while hiding it from ordinary choices', () => {
+    const executor = createDevice({ device_id: 'executor' })
+    const openclaw = createDevice({
+      id: 2,
+      device_id: 'openclaw',
+      bind_shell: 'openclaw',
+    })
+
+    expect(isWegentExecutionDevice(openclaw)).toBe(true)
+    expect(filterDevicesByAdvancedMode([executor, openclaw], false)).toEqual([executor])
+  })
+
+  it('shows OpenClaw after advanced mode is enabled', () => {
+    const devices = [
+      createDevice({ device_id: 'executor' }),
+      createDevice({ id: 2, device_id: 'openclaw', bind_shell: 'openclaw' }),
+    ]
+
+    expect(filterDevicesByAdvancedMode(devices, true)).toEqual(devices)
+  })
+
+  it('ignores an OpenClaw default and auto-selects the sole Executor', () => {
+    const devices = [
+      createDevice({ device_id: 'executor' }),
+      createDevice({ id: 2, device_id: 'openclaw', bind_shell: 'openclaw' }),
+    ]
+
+    expect(resolveOrdinaryDeviceChatTarget(devices, 'openclaw', 'openclaw')).toBe('executor')
+  })
+
+  it('does not arbitrarily choose between multiple Executors', () => {
+    const devices = [
+      createDevice({ device_id: 'executor-1' }),
+      createDevice({ id: 2, device_id: 'executor-2' }),
+    ]
+
+    expect(resolveOrdinaryDeviceChatTarget(devices, null, null)).toBeNull()
+    expect(resolveOrdinaryDeviceChatTarget(devices, null, 'executor-2')).toBe('executor-2')
+  })
+})

--- a/frontend/src/__tests__/features/resource-library/TeamCapabilities.test.tsx
+++ b/frontend/src/__tests__/features/resource-library/TeamCapabilities.test.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 
@@ -207,11 +207,15 @@ describe('TeamCapabilities', () => {
     fireEvent.mouseEnter(trigger)
     expect(await screen.findByTestId('team-capability-group-all')).toBeInTheDocument()
 
-    fireEvent.mouseLeave(trigger)
+    jest.useFakeTimers()
+    try {
+      fireEvent.mouseLeave(trigger)
+      act(() => jest.advanceTimersByTime(150))
 
-    await waitFor(() => expect(screen.queryByTestId('team-capability-group-all')).toBeNull(), {
-      timeout: 500,
-    })
+      expect(screen.queryByTestId('team-capability-group-all')).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it('keeps the trigger interactive while the hover menu is open', async () => {

--- a/frontend/src/__tests__/features/tasks/components/input/device-selector-tab.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/device-selector-tab.test.tsx
@@ -28,6 +28,7 @@ function createDevice(overrides: Partial<DeviceInfo>): DeviceInfo {
     executor_version: null,
     latest_version: null,
     update_available: false,
+    bind_shell: 'claudecode',
     ...overrides,
   }
 }
@@ -87,6 +88,7 @@ jest.mock('@/components/ui/tooltip', () => ({
 
 describe('DeviceSelectorTab', () => {
   beforeEach(() => {
+    localStorage.clear()
     mockSetSelectedDeviceId.mockClear()
     mockUpdatePreferences.mockClear()
     mockSelectedDeviceId = null
@@ -153,6 +155,47 @@ describe('DeviceSelectorTab', () => {
     expect(offlineDeviceCard).toBeInTheDocument()
     expect(offlineDeviceCard).toHaveAttribute('aria-disabled', 'true')
     expect(screen.queryByText('no_devices_available')).not.toBeInTheDocument()
+  })
+
+  it('hides OpenClaw devices until advanced mode is enabled', async () => {
+    mockDevices = [
+      createDevice({ device_id: 'executor-device', name: 'Executor Device' }),
+      createDevice({
+        id: 2,
+        device_id: 'openclaw-device',
+        name: 'OpenClaw Device',
+        bind_shell: 'openclaw',
+      }),
+    ]
+
+    const { unmount } = render(<DeviceSelectorTab />)
+
+    expect(screen.getByTestId('device-card-executor-device')).toBeInTheDocument()
+    expect(screen.queryByTestId('device-card-openclaw-device')).not.toBeInTheDocument()
+    expect(screen.getByText('1/1')).toBeInTheDocument()
+
+    unmount()
+    localStorage.setItem('wegent_show_advanced_devices', 'true')
+    render(<DeviceSelectorTab />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('device-card-openclaw-device')).toBeInTheDocument()
+    )
+    expect(screen.getByText('2/2')).toBeInTheDocument()
+  })
+
+  it('keeps an existing OpenClaw task target visible in read-only mode', () => {
+    mockDevices = [
+      createDevice({
+        device_id: 'openclaw-device',
+        name: 'OpenClaw Device',
+        bind_shell: 'openclaw',
+      }),
+    ]
+
+    render(<DeviceSelectorTab taskId={42} taskType="task" taskDeviceId="openclaw-device" />)
+
+    expect(screen.getByText('local_device_prefixOpenClaw Device')).toBeInTheDocument()
   })
 
   it('initializes a new task from the exact account default without fallback', async () => {

--- a/frontend/src/app/(tasks)/devices/chat/page.tsx
+++ b/frontend/src/app/(tasks)/devices/chat/page.tsx
@@ -28,6 +28,11 @@ import { Monitor, WifiOff } from 'lucide-react'
 import { TaskParamSync, DeviceParamSync } from '@/features/tasks/components/params'
 import { isOpenClawDevice } from '@/features/devices/utils/device-status'
 import { getAccountDefaultDeviceId } from '@/features/devices/utils/execution-target'
+import {
+  filterDevicesByAdvancedMode,
+  resolveOrdinaryDeviceChatTarget,
+} from '@/features/devices/utils/device-visibility'
+import { useAdvancedDeviceMode } from '@/features/devices/hooks/useAdvancedDeviceMode'
 import { useProjectContext } from '@/features/projects/contexts/projectContext'
 import { useUser } from '@/features/common/UserContext'
 
@@ -51,7 +56,8 @@ export default function DeviceChatPage() {
 
   // Check if deviceId is specified in URL
   const searchParams = useSearchParams()
-  const hasDeviceIdParam = !!(searchParams.get('deviceId') || searchParams.get('device_id'))
+  const routeDeviceId = searchParams.get('deviceId') || searchParams.get('device_id')
+  const hasDeviceIdParam = Boolean(routeDeviceId)
   const routeTaskId =
     searchParams.get('taskId') || searchParams.get('task_id') || searchParams.get('taskid')
   const isExistingTask = Boolean(routeTaskId)
@@ -66,6 +72,27 @@ export default function DeviceChatPage() {
     return projects.find(p => p.id === projectId) ?? null
   }, [projectId, projects])
   const isProjectContext = !!activeProject
+  const { showAdvancedDevices, isAdvancedDeviceModeReady } = useAdvancedDeviceMode()
+
+  const persistedTaskDeviceId =
+    selectedTaskMatchesRoute && selectedTaskDetail?.task_type === 'task'
+      ? selectedTaskDetail.device_id || null
+      : null
+  const visibleDevices = useMemo(
+    () => filterDevicesByAdvancedMode(devices, showAdvancedDevices),
+    [devices, showAdvancedDevices]
+  )
+  const conversationDevices = useMemo(() => {
+    const pinnedDeviceId = isExistingTask ? persistedTaskDeviceId : routeDeviceId
+    const pinnedDevice = pinnedDeviceId
+      ? devices.find(device => device.device_id === pinnedDeviceId)
+      : undefined
+
+    if (!pinnedDevice || visibleDevices.some(device => device.device_id === pinnedDeviceId)) {
+      return visibleDevices
+    }
+    return [...visibleDevices, pinnedDevice]
+  }, [devices, isExistingTask, persistedTaskDeviceId, routeDeviceId, visibleDevices])
 
   // Mobile sidebar state
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
@@ -85,13 +112,22 @@ export default function DeviceChatPage() {
     saveLastTab('devices')
   }, [])
 
-  // Initialize a new task from the account default without substituting a
-  // different available device. Existing tasks use their persisted target.
+  // Ordinary device conversations prefer Executor devices. Explicit device
+  // links and existing tasks keep their exact persisted target.
   useEffect(() => {
-    if (hasDeviceIdParam || isExistingTask || selectedDeviceId) return
+    if (hasDeviceIdParam || isExistingTask || !isAdvancedDeviceModeReady) return
     const defaultDeviceId = getAccountDefaultDeviceId(user?.preferences?.default_execution_target)
-    if (defaultDeviceId) setSelectedDeviceId(defaultDeviceId)
-  }, [hasDeviceIdParam, isExistingTask, selectedDeviceId, setSelectedDeviceId, user])
+    const nextDeviceId = resolveOrdinaryDeviceChatTarget(devices, selectedDeviceId, defaultDeviceId)
+    if (selectedDeviceId !== nextDeviceId) setSelectedDeviceId(nextDeviceId)
+  }, [
+    devices,
+    hasDeviceIdParam,
+    isAdvancedDeviceModeReady,
+    isExistingTask,
+    selectedDeviceId,
+    setSelectedDeviceId,
+    user,
+  ])
 
   const handleToggleCollapsed = () => {
     setIsCollapsed(prev => {
@@ -130,15 +166,15 @@ export default function DeviceChatPage() {
     setSelectedDeviceId(deviceId)
     // Clear any existing task when selecting a new device
     selectTask(null)
+    const nextParams = new URLSearchParams(searchParams.toString())
+    nextParams.set('deviceId', deviceId)
+    nextParams.delete('device_id')
+    router.replace(`/devices/chat?${nextParams.toString()}`)
   }
 
   // Get current task title for top navigation
   const currentTaskTitle = selectedTaskMatchesRoute ? selectedTaskDetail?.title : undefined
 
-  const persistedTaskDeviceId =
-    selectedTaskMatchesRoute && selectedTaskDetail?.task_type === 'task'
-      ? selectedTaskDetail.device_id || null
-      : null
   const activeDeviceId = isExistingTask ? persistedTaskDeviceId : selectedDeviceId
   const selectedDevice = devices.find(d => d.device_id === activeDeviceId)
 
@@ -192,7 +228,7 @@ export default function DeviceChatPage() {
               <option value="" disabled>
                 {t('select_device')}
               </option>
-              {devices.map(device => (
+              {conversationDevices.map(device => (
                 <option key={device.device_id} value={device.device_id}>
                   {device.name} (
                   {device.status === 'online'
@@ -227,7 +263,7 @@ export default function DeviceChatPage() {
         ) : (
           <div className="flex-1 flex items-center justify-center bg-base">
             <div className="text-center max-w-md px-6">
-              {devices.length === 0 ? (
+              {conversationDevices.length === 0 ? (
                 <>
                   <WifiOff className="w-16 h-16 text-text-muted mx-auto mb-4" />
                   <h3 className="text-lg font-semibold text-text-primary mb-2">

--- a/frontend/src/app/(tasks)/devices/chat/page.tsx
+++ b/frontend/src/app/(tasks)/devices/chat/page.tsx
@@ -220,6 +220,7 @@ export default function DeviceChatPage() {
           <div className="flex items-center gap-2 mr-2">
             <Monitor className="w-4 h-4 text-text-muted" />
             <select
+              data-testid="device-chat-target-select"
               value={activeDeviceId || ''}
               onChange={e => handleDeviceSelect(e.target.value)}
               disabled={isProjectContext || isExistingTask}

--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -34,6 +34,9 @@ import {
   EditDeviceAliasDialog,
 } from '@/features/devices/components'
 import { useDeviceHandlers } from '@/features/devices/hooks'
+import { useAdvancedDeviceMode } from '@/features/devices/hooks/useAdvancedDeviceMode'
+import { isOpenClawDevice } from '@/features/devices/utils/device-status'
+import { filterDevicesByAdvancedMode } from '@/features/devices/utils/device-visibility'
 
 // Helper function to sort devices by priority
 function sortDevices(devices: DeviceInfo[]): DeviceInfo[] {
@@ -72,9 +75,15 @@ export default function DevicesPage() {
 
   // Device action handlers (consolidated in custom hook)
   const handlers = useDeviceHandlers()
+  const { showAdvancedDevices, setShowAdvancedDevices } = useAdvancedDeviceMode()
 
   // Sort and group devices
   const sortedDevices = useMemo(() => sortDevices(devices), [devices])
+  const visibleDevices = useMemo(
+    () => filterDevicesByAdvancedMode(sortedDevices, showAdvancedDevices),
+    [showAdvancedDevices, sortedDevices]
+  )
+  const hasAdvancedDevices = useMemo(() => sortedDevices.some(isOpenClawDevice), [sortedDevices])
 
   // Mobile sidebar state
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
@@ -161,6 +170,9 @@ export default function DevicesPage() {
               hasDevices={sortedDevices.length > 0}
               onRefresh={refreshDevices}
               onAddDevice={() => setShowSetupGuide(true)}
+              hasAdvancedDevices={hasAdvancedDevices}
+              showAdvancedDevices={showAdvancedDevices}
+              onShowAdvancedDevicesChange={setShowAdvancedDevices}
             />
 
             {/* Error message */}
@@ -195,7 +207,7 @@ export default function DevicesPage() {
                 <DeviceSection
                   title={t('local_devices_section')}
                   icon={Monitor}
-                  devices={sortedDevices}
+                  devices={visibleDevices}
                   type="local"
                   emptyMessage={t('no_local_devices')}
                 >
@@ -217,7 +229,7 @@ export default function DevicesPage() {
                 <DeviceSection
                   title={t('remote_devices_section')}
                   icon={Server}
-                  devices={sortedDevices}
+                  devices={visibleDevices}
                   type="remote"
                   emptyMessage={t('no_remote_devices')}
                 >
@@ -240,7 +252,7 @@ export default function DevicesPage() {
                 <DeviceSection
                   title={t('cloud_devices_section')}
                   icon={Cloud}
-                  devices={sortedDevices}
+                  devices={visibleDevices}
                   type="cloud"
                   emptyMessage={t('cloud_devices_coming_soon')}
                 >

--- a/frontend/src/features/devices/components/DevicesPageHeader.tsx
+++ b/frontend/src/features/devices/components/DevicesPageHeader.tsx
@@ -11,6 +11,7 @@
 
 import { Monitor, RefreshCw, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/hooks/useTranslation'
 
@@ -19,6 +20,9 @@ export interface DevicesPageHeaderProps {
   hasDevices: boolean
   onRefresh: () => void
   onAddDevice: () => void
+  hasAdvancedDevices: boolean
+  showAdvancedDevices: boolean
+  onShowAdvancedDevicesChange: (show: boolean) => void
 }
 
 /**
@@ -34,11 +38,14 @@ export function DevicesPageHeader({
   hasDevices,
   onRefresh,
   onAddDevice,
+  hasAdvancedDevices,
+  showAdvancedDevices,
+  onShowAdvancedDevicesChange,
 }: DevicesPageHeaderProps) {
   const { t } = useTranslation('devices')
 
   return (
-    <div className="flex items-center justify-between mb-6">
+    <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-3">
         <Monitor className="w-6 h-6 text-primary" />
         <h2 className="text-lg font-semibold">{t('title')}</h2>
@@ -46,7 +53,22 @@ export function DevicesPageHeader({
           {t('beta')}
         </span>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {hasAdvancedDevices && (
+          <label
+            htmlFor="show-advanced-devices"
+            className="flex min-h-11 cursor-pointer items-center gap-2 rounded-md px-2 text-sm text-text-secondary hover:bg-hover sm:min-h-0"
+            title={t('advanced_mode_description')}
+          >
+            <Switch
+              id="show-advanced-devices"
+              data-testid="show-advanced-devices-toggle"
+              checked={showAdvancedDevices}
+              onCheckedChange={onShowAdvancedDevicesChange}
+            />
+            <span>{t('advanced_mode')}</span>
+          </label>
+        )}
         {/* Add Device button - only show when devices exist */}
         {hasDevices && (
           <Button

--- a/frontend/src/features/devices/hooks/index.ts
+++ b/frontend/src/features/devices/hooks/index.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './useDeviceHandlers'
+export * from './useAdvancedDeviceMode'

--- a/frontend/src/features/devices/hooks/useAdvancedDeviceMode.ts
+++ b/frontend/src/features/devices/hooks/useAdvancedDeviceMode.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { getShowAdvancedDevices, saveShowAdvancedDevices } from '@/utils/userPreferences'
+
+export function useAdvancedDeviceMode() {
+  const [showAdvancedDevices, setShowAdvancedDevicesState] = useState(false)
+  const [isAdvancedDeviceModeReady, setIsAdvancedDeviceModeReady] = useState(false)
+
+  useEffect(() => {
+    setShowAdvancedDevicesState(getShowAdvancedDevices())
+    setIsAdvancedDeviceModeReady(true)
+  }, [])
+
+  const setShowAdvancedDevices = useCallback((show: boolean) => {
+    setShowAdvancedDevicesState(show)
+    saveShowAdvancedDevices(show)
+  }, [])
+
+  return {
+    showAdvancedDevices,
+    setShowAdvancedDevices,
+    isAdvancedDeviceModeReady,
+  }
+}

--- a/frontend/src/features/devices/utils/device-visibility.ts
+++ b/frontend/src/features/devices/utils/device-visibility.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { DeviceInfo } from '@/apis/devices'
+import { isOpenClawDevice } from './device-status'
 
 /**
  * Return whether a device can be exposed as an execution target in Wegent web.
@@ -10,4 +11,29 @@ import type { DeviceInfo } from '@/apis/devices'
  */
 export function isWegentExecutionDevice(device: DeviceInfo): boolean {
   return device.device_type !== 'app'
+}
+
+/**
+ * Hide advanced runtimes from ordinary execution choices until the user opts in.
+ */
+export function filterDevicesByAdvancedMode(
+  devices: DeviceInfo[],
+  showAdvancedDevices: boolean
+): DeviceInfo[] {
+  return showAdvancedDevices ? devices : devices.filter(device => !isOpenClawDevice(device))
+}
+
+export function resolveOrdinaryDeviceChatTarget(
+  devices: DeviceInfo[],
+  selectedDeviceId: string | null,
+  defaultDeviceId: string | null
+): string | null {
+  const executorDevices = devices.filter(device => !isOpenClawDevice(device))
+  if (executorDevices.some(device => device.device_id === selectedDeviceId)) {
+    return selectedDeviceId
+  }
+  if (executorDevices.some(device => device.device_id === defaultDeviceId)) {
+    return defaultDeviceId
+  }
+  return executorDevices.length === 1 ? executorDevices[0].device_id : null
 }

--- a/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
+++ b/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
@@ -46,6 +46,8 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { paths } from '@/config/paths'
 import type { DeviceInfo } from '@/apis/devices'
 import type { TaskType } from '@/types/api'
+import { useAdvancedDeviceMode } from '@/features/devices/hooks/useAdvancedDeviceMode'
+import { filterDevicesByAdvancedMode } from '@/features/devices/utils/device-visibility'
 
 interface DeviceSelectorTabProps {
   /** Additional className */
@@ -250,6 +252,7 @@ export function DeviceSelectorTab({
   const searchParams = useSearchParams()
   const { user, updatePreferences } = useUser()
   const { devices, selectedDeviceId, setSelectedDeviceId, isLoading } = useDevices()
+  const { showAdvancedDevices, isAdvancedDeviceModeReady } = useAdvancedDeviceMode()
   const newTaskSelectionInitializedRef = useRef(false)
   const previousTaskIdRef = useRef<number | null>(taskId ?? null)
   const [isOpen, setIsOpen] = useState(false)
@@ -295,18 +298,23 @@ export function DeviceSelectorTab({
   // Get user's default execution target preference
   const defaultExecutionTarget = user?.preferences?.default_execution_target
 
+  const visibleDevices = useMemo(
+    () => filterDevicesByAdvancedMode(devices, showAdvancedDevices),
+    [devices, showAdvancedDevices]
+  )
+
   const displayDevices = useMemo(
-    () => [...devices].sort(compareDevicesByExecutionPriority),
-    [devices]
+    () => [...visibleDevices].sort(compareDevicesByExecutionPriority),
+    [visibleDevices]
   )
 
   // Count online devices
   const onlineDeviceCount = useMemo(
-    () => devices.filter(device => device.status !== 'offline').length,
-    [devices]
+    () => visibleDevices.filter(device => device.status !== 'offline').length,
+    [visibleDevices]
   )
 
-  const totalDeviceCount = devices.length
+  const totalDeviceCount = visibleDevices.length
 
   const localDevices = useMemo(() => {
     return displayDevices.filter(device => device.device_type !== 'cloud')
@@ -334,7 +342,12 @@ export function DeviceSelectorTab({
       return
     }
 
-    if (isLoading || hasExplicitDeviceParam || newTaskSelectionInitializedRef.current) {
+    if (
+      isLoading ||
+      !isAdvancedDeviceModeReady ||
+      hasExplicitDeviceParam ||
+      newTaskSelectionInitializedRef.current
+    ) {
       return
     }
 
@@ -345,22 +358,28 @@ export function DeviceSelectorTab({
     // A new draft starts from the account default. Preserve an existing
     // selection only on the first mount, where it may be an explicit launch
     // choice made by the device page before this selector mounted.
-    if (returningFromTask || !selectedDeviceId) {
+    const selectedDeviceIsVisible = visibleDevices.some(
+      device => device.device_id === selectedDeviceId
+    )
+    if (returningFromTask || !selectedDeviceId || !selectedDeviceIsVisible) {
       const defaultDeviceId = getAccountDefaultDeviceId(defaultExecutionTarget)
-      const availableDefaultDeviceId = devices.some(device => device.device_id === defaultDeviceId)
+      const availableDefaultDeviceId = visibleDevices.some(
+        device => device.device_id === defaultDeviceId
+      )
         ? defaultDeviceId
         : null
       setSelectedDeviceId(availableDefaultDeviceId)
     }
   }, [
     defaultExecutionTarget,
-    devices,
     hasExplicitDeviceParam,
+    isAdvancedDeviceModeReady,
     isExistingTask,
     isLoading,
     selectedDeviceId,
     setSelectedDeviceId,
     taskId,
+    visibleDevices,
   ])
 
   const isSelectedDeviceAvailable =

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -136,6 +136,8 @@
   "cloud_coming_soon_title": "Cloud Devices Coming Soon",
   "cloud_coming_soon_description": "Cloud device support is under active development. Stay tuned for updates!",
   "openclaw_badge": "🦞 OpenClaw",
+  "advanced_mode": "Advanced mode",
+  "advanced_mode_description": "Show OpenClaw devices",
   "got_it": "Got it",
   "actions": {
     "upgrade": "Upgrade"

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -136,6 +136,8 @@
   "cloud_coming_soon_title": "云端设备即将推出",
   "cloud_coming_soon_description": "云端设备支持正在积极开发中，敬请期待！",
   "openclaw_badge": "🦞 OpenClaw",
+  "advanced_mode": "高级模式",
+  "advanced_mode_description": "显示 OpenClaw 设备",
   "got_it": "知道了",
   "actions": {
     "upgrade": "升级"

--- a/frontend/src/utils/userPreferences.ts
+++ b/frontend/src/utils/userPreferences.ts
@@ -15,6 +15,7 @@ const STORAGE_KEYS = {
   LAST_REPO_ID: 'wegent_last_repo_id',
   LAST_REPO_NAME: 'wegent_last_repo_name',
   DEFAULT_EXECUTION_TARGET: 'wegent_default_execution_target',
+  SHOW_ADVANCED_DEVICES: 'wegent_show_advanced_devices',
 } as const
 
 /**
@@ -182,6 +183,29 @@ export function getLastRepo(): { repoId: number; repoName: string } | null {
   } catch (error) {
     console.warn('Failed to get last repo from localStorage:', error)
     return null
+  }
+}
+
+/**
+ * Persist whether advanced execution devices should be visible.
+ */
+export function saveShowAdvancedDevices(show: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEYS.SHOW_ADVANCED_DEVICES, String(show))
+  } catch (error) {
+    console.warn('Failed to save advanced device visibility to localStorage:', error)
+  }
+}
+
+/**
+ * Return whether the user opted in to advanced execution devices.
+ */
+export function getShowAdvancedDevices(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEYS.SHOW_ADVANCED_DEVICES) === 'true'
+  } catch (error) {
+    console.warn('Failed to load advanced device visibility from localStorage:', error)
+    return false
   }
 }
 


### PR DESCRIPTION
## Summary

- hide OpenClaw devices from ordinary device lists and execution selectors until a persisted Advanced mode switch is enabled
- keep ordinary device chat on Executor even when OpenClaw is the account default, while preserving explicit and existing OpenClaw conversations
- add CI-collected Playwright E2E coverage with isolated users and real Backend and Socket.IO device registration
- make the existing team menu close-timer test deterministic after the full pre-push suite exposed its wall-clock flake

## Tests

- focused Jest device suites: 3 suites, 14 tests passed
- TeamCapabilities Jest suite: 9 tests passed
- frontend TypeScript, ESLint, Prettier, and translation checks passed
- Playwright chromium collection includes advanced-device-visibility.spec.ts
- repository pre-push quality gate passed, including full frontend unit tests and executor checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Advanced Mode toggle for displaying OpenClaw devices.
  * Advanced Mode preference persists across page visits and reloads.
  * Device chats preserve explicitly selected advanced devices when Advanced Mode is turned off.
  * Ordinary chats continue selecting eligible non-OpenClaw devices automatically.
  * Added English and Chinese labels and descriptions for Advanced Mode.

* **Tests**
  * Added coverage for advanced-device visibility, chat targeting, preference persistence, and device selection behavior.
  * Improved reliability of menu interaction timing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->