### PR TITLE
chore(wework): upgrade bundled Codex to 0.152.1

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -193,6 +193,14 @@ with SHA-512. Prepared desktop resources live under `wework/resources/`.
 icons, and runtime descriptors into the application resources. Do not maintain
 a second desktop resource tree or manifest.
 
+The current pin is Codex `0.152.1`. Codex `0.152` disables
+`tools.update_plan.enabled` by default, while Wework consumes the corresponding
+plan events to render plan blocks, so the Executor must enable the tool
+explicitly when launching Codex. Desktop E2E verifies the lockfile binary by
+default; only the dedicated `WEWORK_E2E_CODEX_BIN` may override it. It must not
+inherit the generic `CODEX_BIN`, which could otherwise select an older binary
+from an installed application instead of the repository version under test.
+
 Desktop distributions must also include the project and bundled-sidecar
 licenses and attribution notices:
 

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -157,6 +157,12 @@ Codex 下载包按 `wework/codex-binaries.lock.json` 固定并校验 SHA-512。�
 `wework/electron/scripts/prepare-package-assets.mjs` 会把 sidecar、插件、图标和运行时
 描述复制到应用资源目录。不要重新建立第二份桌面资源目录或资源清单。
 
+当前固定版本为 Codex `0.152.1`。Codex `0.152` 开始默认关闭
+`tools.update_plan.enabled`，但 Wework 会消费对应的计划事件并渲染计划块，因此
+Executor 启动 Codex 时必须显式启用该工具。桌面 E2E 默认验证锁文件中的二进制；
+只有专用的 `WEWORK_E2E_CODEX_BIN` 可以覆盖它，不能继承通用 `CODEX_BIN`，否则
+本机已安装应用中的旧版本可能绕过待验证的仓库版本。
+
 桌面发行物还必须携带项目及 bundled sidecar 的许可证和归属信息：
 
 - 应用资源根目录的 `LICENSE` 是 Wegent 的 Apache-2.0 许可证；

--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -64,6 +64,7 @@ const CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE: &str =
     "suppress_unstable_features_warning=true";
 const CODEX_DISABLE_TOOL_CALL_MCP_ELICITATION_OVERRIDE: &str =
     "features.tool_call_mcp_elicitation=false";
+const CODEX_ENABLE_UPDATE_PLAN_OVERRIDE: &str = "tools.update_plan.enabled=true";
 const DEFAULT_EXECUTOR_SERVER_PORT: u16 = 10001;
 const DEFAULT_VISION_SIDECAR_TIMEOUT_MS: u64 = 45_000;
 const DEFAULT_VISION_SIDECAR_MAX_DESCRIPTIONS: usize = 8;
@@ -3208,6 +3209,7 @@ fn codex_streaming_patch_config_overrides() -> Vec<String> {
 fn codex_runtime_default_config_overrides() -> Vec<String> {
     let mut overrides = codex_streaming_patch_config_overrides();
     overrides.push(CODEX_DISABLE_TOOL_CALL_MCP_ELICITATION_OVERRIDE.to_owned());
+    overrides.push(CODEX_ENABLE_UPDATE_PLAN_OVERRIDE.to_owned());
     overrides
 }
 

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -260,6 +260,9 @@ fn persistent_app_server_uses_codex_deferred_mcp_tools() {
     assert!(config
         .config_overrides
         .contains(&CODEX_DISABLE_TOOL_CALL_MCP_ELICITATION_OVERRIDE.to_owned()));
+    assert!(config
+        .config_overrides
+        .contains(&CODEX_ENABLE_UPDATE_PLAN_OVERRIDE.to_owned()));
 }
 
 #[test]
@@ -811,6 +814,9 @@ fn codex_launch_config_enables_streaming_patch_updates() {
     assert!(launch_config
         .config_overrides
         .contains(&CODEX_DISABLE_TOOL_CALL_MCP_ELICITATION_OVERRIDE.to_owned()));
+    assert!(launch_config
+        .config_overrides
+        .contains(&CODEX_ENABLE_UPDATE_PLAN_OVERRIDE.to_owned()));
 }
 
 #[test]

--- a/executor/tests/codex_app_server_contract.rs
+++ b/executor/tests/codex_app_server_contract.rs
@@ -482,6 +482,7 @@ async fn codex_app_server_receives_normalized_developer_path() {
     let _lock = env_lock().await;
     let _path = EnvGuard::set("PATH", "/usr/bin:/bin");
     let _extra_paths = EnvGuard::set("WEGENT_EXTRA_PATHS", "/custom/bin:/opt/homebrew/bin");
+    let _runtime_bin = EnvGuard::remove("WEWORK_RUNTIME_BIN");
     let log_path = std::env::temp_dir().join(format!(
         "wegent-executor-codex-path-rpc-{}.jsonl",
         std::process::id()
@@ -794,12 +795,14 @@ async fn codex_app_server_engine_does_not_timeout_running_turn() {
 
 async fn codex_app_server_idle_restart_preserves_in_flight_requests() {
     let _lock = env_lock().await;
-    let fake_codex = write_fake_codex_with_pending_request();
+    let request_marker = unique_dir("codex-pending-request").join("received");
+    let fake_codex = write_fake_codex_with_pending_request(&request_marker);
     let client = CodexAppServerClient::new(fake_codex.display().to_string());
     let request_client = client.clone();
     let pending_request =
         tokio::spawn(async move { request_client.request("plugin/list", json!({})).await });
 
+    wait_for_path(&request_marker, "pending app-server request should reach Codex").await;
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {
             if matches!(client.restart_if_no_pending_requests().await, Err(1)) {
@@ -821,12 +824,14 @@ async fn codex_app_server_idle_restart_preserves_in_flight_requests() {
 
 async fn codex_app_server_proxy_restart_settles_in_flight_requests() {
     let _lock = env_lock().await;
-    let fake_codex = write_fake_codex_with_pending_request();
+    let request_marker = unique_dir("codex-proxy-pending-request").join("received");
+    let fake_codex = write_fake_codex_with_pending_request(&request_marker);
     let client = CodexAppServerClient::new(fake_codex.display().to_string());
     let request_client = client.clone();
     let pending_request =
         tokio::spawn(async move { request_client.request("plugin/list", json!({})).await });
 
+    wait_for_path(&request_marker, "pending app-server request should reach Codex").await;
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {
             if matches!(client.restart_if_no_pending_requests().await, Err(1)) {
@@ -1277,15 +1282,13 @@ done
     path
 }
 
-fn write_fake_codex_with_pending_request() -> PathBuf {
+fn write_fake_codex_with_pending_request(request_marker: &Path) -> PathBuf {
     let path = std::env::temp_dir().join(format!(
         "fake-codex-pending-request-{}-{}",
         std::process::id(),
         unique_suffix()
     ));
-    fs::write(
-        &path,
-        r#"#!/bin/sh
+    let content = r#"#!/bin/sh
 while IFS= read -r line; do
   request_id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
   case "$line" in
@@ -1295,13 +1298,14 @@ while IFS= read -r line; do
     *'"method":"initialized"'*)
       ;;
     *'"method":"plugin/list"'*)
+      touch '__REQUEST_MARKER__'
       sleep 30
       ;;
   esac
 done
-"#,
-    )
-    .unwrap();
+"#
+    .replace("__REQUEST_MARKER__", &request_marker.display().to_string());
+    fs::write(&path, content).unwrap();
     #[cfg(unix)]
     {
         let mut permissions = fs::metadata(&path).unwrap().permissions();
@@ -1694,6 +1698,16 @@ fn read_json_lines(path: &Path) -> Vec<Value> {
         .collect::<Vec<_>>()
 }
 
+async fn wait_for_path(path: &Path, message: &str) {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while !path.exists() {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect(message);
+}
+
 fn assert_config_arg(args: &[Value], expected: &str) {
     assert!(
         args.windows(2)
@@ -1736,6 +1750,12 @@ impl EnvGuard {
     fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var(key).ok();
         std::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::remove_var(key);
         Self { key, previous }
     }
 }

--- a/executor/tests/codex_app_server_contract.rs
+++ b/executor/tests/codex_app_server_contract.rs
@@ -795,7 +795,7 @@ async fn codex_app_server_engine_does_not_timeout_running_turn() {
 
 async fn codex_app_server_idle_restart_preserves_in_flight_requests() {
     let _lock = env_lock().await;
-    let request_marker = unique_dir("codex-pending-request").join("received");
+    let request_marker = unique_dir("codex-pending-request'quoted").join("received");
     let fake_codex = write_fake_codex_with_pending_request(&request_marker);
     let client = CodexAppServerClient::new(fake_codex.display().to_string());
     let request_client = client.clone();
@@ -1298,13 +1298,13 @@ while IFS= read -r line; do
     *'"method":"initialized"'*)
       ;;
     *'"method":"plugin/list"'*)
-      touch '__REQUEST_MARKER__'
+      touch __REQUEST_MARKER__
       sleep 30
       ;;
   esac
 done
 "#
-    .replace("__REQUEST_MARKER__", &request_marker.display().to_string());
+    .replace("__REQUEST_MARKER__", &shell_quote(request_marker));
     fs::write(&path, content).unwrap();
     #[cfg(unix)]
     {
@@ -1313,6 +1313,10 @@ done
         fs::set_permissions(&path, permissions).unwrap();
     }
     path
+}
+
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
 }
 
 fn write_fake_codex_logging_start(log_path: &Path, env_keys: &[&str]) -> PathBuf {

--- a/wework/codex-binaries.lock.json
+++ b/wework/codex-binaries.lock.json
@@ -1,40 +1,40 @@
 {
-  "codexVersion": "0.149.0",
+  "codexVersion": "0.152.1",
   "registry": "https://registry.npmjs.org",
   "targets": {
     "aarch64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.149.0-darwin-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-darwin-arm64.tgz",
-      "integrity": "sha512-GsZJbzBWiD48RETrO8VHGAQNgfSrUVxItXZFeD87wswatPi0+lKuQo8Dx4nMYmOZhZrVtwr3al/feRrZxnDV8Q==",
+      "version": "0.152.1-darwin-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-darwin-arm64.tgz",
+      "integrity": "sha512-H8i0uZHILM0Z2Ep+MryCF5rGXmXjmXTzXf5ZK6bobKtZc2yfomi42ZrQWuYQ5P02H0oLG7B5jLaSWZQ+VFgjbA==",
       "binaryPath": "vendor/aarch64-apple-darwin/bin/codex"
     },
     "x86_64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.149.0-darwin-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-darwin-x64.tgz",
-      "integrity": "sha512-H+mMgW3Nhc5QzGWEklCoFqACuOc0cVpgPkPQRw0LShoK7P5664T6BRnyl1yzT6orKPKv49cXry7DIWWZ19SanQ==",
+      "version": "0.152.1-darwin-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-darwin-x64.tgz",
+      "integrity": "sha512-M2qW7YkRx+JeSFoZQsrjgA5yNglowuNAFOwRJoIjlgeP8bsyOqPtbSolu3w4Us7IyCH8f/yuKtlt/v/MdDqbfA==",
       "binaryPath": "vendor/x86_64-apple-darwin/bin/codex"
     },
     "x86_64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.149.0-linux-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-linux-x64.tgz",
-      "integrity": "sha512-uZXaN9JPxu0/jjnqqJeTd4kRYPnjVZK3MiVndfG1mHhEaoDKL7ScWHfPqvAEOjwsSDEmQSlMfUkmvYp/CHciYw==",
+      "version": "0.152.1-linux-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-linux-x64.tgz",
+      "integrity": "sha512-ar59rr3CX5j4MLMnRcHqcE0eHZPsZlmXlz37ZS2yP3BsV5pNhO+wFXTOzXFdaYmg2cALX7a3Eqv+vB2jQlXnjQ==",
       "binaryPath": "vendor/x86_64-unknown-linux-musl/bin/codex"
     },
     "aarch64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.149.0-linux-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-linux-arm64.tgz",
-      "integrity": "sha512-fAXPpvIob+11RNZJS9CVVTsKb+V4Hw3woGFPj42D7fU2wBJUKI2jfAc4fLJNtrpwRecLeW601mtkMHOSIbWuuA==",
+      "version": "0.152.1-linux-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-linux-arm64.tgz",
+      "integrity": "sha512-qZXqf7fxn/SCmaJW6tYrzWqwcDo0gMDJjj1Pm4OtrWXR7Oc0Y2e8ngAh/Mep9iFhVbsqntY1eGLaQaXssGvFgA==",
       "binaryPath": "vendor/aarch64-unknown-linux-musl/bin/codex"
     },
     "x86_64-pc-windows-msvc": {
       "package": "@openai/codex",
-      "version": "0.149.0-win32-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.0-win32-x64.tgz",
-      "integrity": "sha512-qKbwSOOO/fdhQ5MlXE2fts6taPxRPZ/zqeC+eqHD72hLRymV9rFCUbUxOCquognUPRPvS/2/kRCV0UVhoDd3yQ==",
+      "version": "0.152.1-win32-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-win32-x64.tgz",
+      "integrity": "sha512-B8h0/2Kt+rKQv2+vqBhlhWkMEdhf4dsn46FNKMEBTXj3YC5hwSioOcTX2hMgJxMEMtKIMH6Ire1eNrQPvaL9og==",
       "binaryPath": "vendor/x86_64-pc-windows-msvc/bin/codex.exe"
     }
   }

--- a/wework/e2e/desktop/modules/desktop-build-flows.mjs
+++ b/wework/e2e/desktop/modules/desktop-build-flows.mjs
@@ -332,7 +332,7 @@ function hostCodexTarget() {
 }
 
 async function resolveDesktopCodexBinary() {
-  const configured = process.env.WEWORK_E2E_CODEX_BIN || process.env.CODEX_BIN
+  const configured = process.env.WEWORK_E2E_CODEX_BIN
   if (configured) {
     return resolveExecutable(configured, 'codex', 'Configured Wework E2E Codex')
   }

--- a/wework/e2e/desktop/modules/desktop-server.mjs
+++ b/wework/e2e/desktop/modules/desktop-server.mjs
@@ -277,6 +277,33 @@ function findNestedString(value, predicate) {
   return null
 }
 
+function requestContainsSkillLocator(body, skillPath, skillName) {
+  const requestText = JSON.stringify(body)
+  if (requestText.includes(skillPath)) return true
+
+  const normalizedSkillPath = skillPath.replaceAll('\\', '/')
+  const relativeSkillPath = `${skillName}/SKILL.md`
+  const skillRoot = normalizedSkillPath.slice(0, -relativeSkillPath.length).replace(/\/$/u, '')
+  const catalog = findNestedString(
+    body,
+    value => value.includes('### Skill roots') && value.includes(relativeSkillPath)
+  )
+  if (!catalog) return false
+
+  for (const line of catalog.split(/\r?\n/u)) {
+    const rootMatch = line.match(/^- `([^`]+)` = `([^`]+)`$/u)
+    if (!rootMatch) continue
+    const [, alias, root] = rootMatch
+    if (
+      root.replaceAll('\\', '/') === skillRoot &&
+      catalog.includes(`(file: ${alias}/${relativeSkillPath})`)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
 function toolOutputText(request, callId) {
   const findOutput = value => {
     if (Array.isArray(value)) {
@@ -3185,7 +3212,7 @@ class DesktopE2EServer {
         assert.ok(
           requestText.includes(OFFICIAL_PLUGIN_NAME) &&
             requestText.includes(OFFICIAL_PLUGIN_SKILL_NAME) &&
-            requestText.includes(skillPath),
+            requestContainsSkillLocator(body, skillPath, OFFICIAL_PLUGIN_SKILL_NAME),
           'The real Codex request did not inject the selected official plugin skill'
         )
         const shell = selectShellToolCommand(


### PR DESCRIPTION
## Summary

- upgrade the bundled Codex sidecars for all supported desktop platforms from 0.149.0 to 0.152.1
- explicitly enable `tools.update_plan` because Codex 0.152 makes that tool opt-in while Wework consumes its plan events
- ensure desktop E2E runs use the repository-managed Codex binary unless `WEWORK_E2E_CODEX_BIN` is explicitly set
- make Codex app-server contract tests wait for observed requests and isolate the runtime-bin environment
- document the Codex pin, update-plan requirement, and E2E override policy in Chinese and English

## Verification

- `pnpm --filter wework test scripts/prepare-codex-binary.test.mjs scripts/desktop-resource-migration.test.mjs`
- `pnpm --filter wework run prepare:codex --all`
- `cargo test --manifest-path executor/Cargo.toml agents::codex::tests --lib`
- `cargo test --manifest-path executor/Cargo.toml --test codex_app_server_contract`
- `pnpm --filter wework e2e:desktop --segment codex-notification-isolation`
- `pnpm --filter wework e2e:desktop --segment goal-lifecycle`
- `pnpm --filter wework e2e:desktop --segment release-package-startup`
- real Electron `ai:verify` startup and Codex app-server initialization with 0.152.1
- repository pre-push quality checks (Wework lint/unit tests, executor fmt/lib tests/clippy)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated the bundled Codex version to 0.152.1 across supported platforms.
  - Enabled Codex update-plan support so plans can be displayed correctly in the desktop experience.
  - Desktop end-to-end testing now uses the bundled Codex version by default, with a dedicated override available when needed.

- **Documentation**
  - Updated English and Chinese macOS release guides with the current Codex version and configuration details.

- **Tests**
  - Improved coverage for update-plan configuration and reliability of Codex restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->