### PR TITLE
fix(wework): preserve embedded browser during task creation

### DIFF
--- a/wework/e2e/desktop/run-checkpoints.mjs
+++ b/wework/e2e/desktop/run-checkpoints.mjs
@@ -83,6 +83,7 @@ const SCENARIO_ONLY_CHECKPOINTS = new Set([
   'browser-annotation-anchors',
   'browser-annotation-design',
   'external-content-import',
+  'browser-multi-tabs',
 ])
 const CLOUD_ONLY_CHECKPOINTS = new Set([
   'cloud-git-worktree',
@@ -257,7 +258,7 @@ async function readFailureSummary(result) {
 
 function checkpointScenarioEnv(env, checkpoint) {
   const nextEnv = { ...env }
-  if (checkpoint === 'native-window-chrome') {
+  if (checkpoint === 'native-window-chrome' || checkpoint === 'browser-multi-tabs') {
     nextEnv.WEWORK_E2E_BACKGROUND_WINDOW = '0'
   }
   const module = CHECKPOINT_SCENARIO_MODULES[checkpoint]

--- a/wework/e2e/desktop/run-checkpoints.mjs
+++ b/wework/e2e/desktop/run-checkpoints.mjs
@@ -83,7 +83,6 @@ const SCENARIO_ONLY_CHECKPOINTS = new Set([
   'browser-annotation-anchors',
   'browser-annotation-design',
   'external-content-import',
-  'browser-multi-tabs',
 ])
 const CLOUD_ONLY_CHECKPOINTS = new Set([
   'cloud-git-worktree',

--- a/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict'
-import { readFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+
+import { CHECKPOINT_TASK_PROMPT } from '../modules/shared.mjs'
 
 const ACTIVE_WORKBENCH_SELECTOR =
   '[data-testid="desktop-workbench-main"][data-active-workbench-pane="true"]'
+const ACTIVE_COMPOSER_SELECTOR =
+  ACTIVE_WORKBENCH_SELECTOR + ' [data-testid="chat-message-input"][contenteditable="true"]'
 const RIGHT_PANEL_TOGGLE_SELECTOR =
   '[data-workspace-tab-portal-owner]:not([hidden]) [data-testid="toggle-right-workspace-panel-button"]'
 const RIGHT_NEW_TAB_CHAT_OPTION_SELECTOR =
@@ -20,12 +24,18 @@ const FIRST_BROWSER_LOADING_ICON_SELECTOR =
   FIRST_BROWSER_TAB_SELECTOR + ' [data-testid="right-workspace-browser-tab-1-loading-icon"]'
 const FIRST_BROWSER_TAB_CLOSE_SELECTOR =
   FIRST_BROWSER_TAB_SELECTOR + ' [data-testid="right-workspace-browser-tab-1-close-button"]'
+const SECOND_BROWSER_TAB_SELECTOR = '[data-testid="right-workspace-browser-tab-2"]'
+const SECOND_BROWSER_TAB_CLOSE_SELECTOR =
+  SECOND_BROWSER_TAB_SELECTOR + ' [data-testid="right-workspace-browser-tab-2-close-button"]'
 const BROWSER_RELOAD_SELECTOR =
   ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-reload-button"]'
 const BROWSER_NAVIGATION_ERROR_SELECTOR =
   ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-navigation-error"]'
 const RIGHT_WORKSPACE_NEW_TAB_SELECTOR = '[data-testid="right-workspace-new-tab-button"]'
 const RIGHT_WORKSPACE_TABBAR_SELECTOR = '[data-testid="right-workspace-tabbar"]'
+const WORKBENCH_BROWSER_LABEL_SELECTOR =
+  ACTIVE_WORKBENCH_SELECTOR +
+  ' [data-testid="desktop-workbench-content"][data-embedded-browser-label]'
 const FIXTURE_A_PATH = '/embedded-browser-multi-tabs-a'
 const FIXTURE_B_PATH = '/embedded-browser-multi-tabs-b'
 const NAVIGATION_FAILURE_PATH = '/embedded-browser-navigation-failure'
@@ -79,6 +89,7 @@ async function waitForBridgeIdentity(executorHome, timeoutMs) {
 }
 
 async function callBridge(identity, payload, label = BROWSER_LABEL) {
+  const requestTimeoutMs = Math.max(Number(payload.timeoutMs ?? 0), 15_000) + 2_000
   const response = await fetch(identity.baseUrl + '/browser', {
     method: 'POST',
     headers: {
@@ -86,6 +97,7 @@ async function callBridge(identity, payload, label = BROWSER_LABEL) {
       'content-type': 'application/json',
     },
     body: JSON.stringify({ label, ...payload }),
+    signal: AbortSignal.timeout(requestTimeoutMs),
   })
   const body = await response.json()
   assert.equal(response.ok, true, 'Bridge HTTP failed: ' + JSON.stringify(body))
@@ -128,7 +140,91 @@ async function waitForSnapshot(control, predicate, message, timeoutMs, selector 
   )
 }
 
-export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
+async function waitForRuntimeTaskId(control, timeoutMs) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const snapshot = JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body'))
+    const taskId = snapshot.workbench?.currentRuntimeTask?.taskId
+    if (taskId) return taskId
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error('Timed out waiting for the browser-owning pane to become a local task')
+}
+
+async function waitForBrowserLabel(control, expected, timeoutMs) {
+  const startedAt = Date.now()
+  let actual = null
+  while (Date.now() - startedAt < timeoutMs) {
+    actual = await control.command('getAttribute', WORKBENCH_BROWSER_LABEL_SELECTOR, {
+      value: 'data-embedded-browser-label',
+    })
+    if (actual === expected) return actual
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`Timed out waiting for browser label ${expected}; last label=${actual}`)
+}
+
+async function waitForElementMetricsSample(control, timeoutMs) {
+  const startedAt = Date.now()
+  let sample = null
+  while (Date.now() - startedAt < timeoutMs) {
+    sample = JSON.parse(await control.command('getElementMetricsSample', 'body'))
+    if (sample.done) return sample
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(
+    'Timed out waiting for browser element metrics sample' +
+      (sample ? '; frames=' + sample.frames.length : '')
+  )
+}
+
+async function waitForBridgeText(identity, label, text, timeoutMs, message) {
+  const startedAt = Date.now()
+  let lastInspectText = null
+  let lastPageState = null
+  while (Date.now() - startedAt < timeoutMs) {
+    const page = await callBridge(
+      identity,
+      {
+        action: 'inspect',
+        options: { includeTextBlocks: true, interactiveOnly: false, maxNodes: 40 },
+        timeoutMs: 5000,
+      },
+      label
+    ).catch(() => null)
+    if (page?.inspectText.includes(text)) return page
+    lastInspectText = page?.inspectText ?? null
+    lastPageState = await callBridge(identity, { action: 'pageState' }, label).catch(() => null)
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(
+    `${message}; label=${label}; pageState=${JSON.stringify(lastPageState)}; ` +
+      `inspect=${JSON.stringify(lastInspectText?.slice(0, 240) ?? null)}`
+  )
+}
+
+function fixtureTextFromInspect(inspectText) {
+  if (inspectText.includes(FIXTURE_A_TEXT)) return FIXTURE_A_TEXT
+  if (inspectText.includes(FIXTURE_B_TEXT)) return FIXTURE_B_TEXT
+  throw new Error(`Expected a loaded browser fixture; inspect=${JSON.stringify(inspectText)}`)
+}
+
+async function captureMigrationScreenshot(captureScreenshot, control, resultDir) {
+  const screenshotPath = join(resultDir, 'embedded-browser-migration-page-retained.png')
+  await captureScreenshot(
+    control,
+    'embedded-browser-migration-page-retained.png',
+    ACTIVE_WORKBENCH_SELECTOR
+  )
+  const screenshotBytes = await readFile(screenshotPath)
+  assert.equal(
+    screenshotBytes.subarray(0, 8).toString('hex'),
+    '89504e470d0a1a0a',
+    'Migration screenshot is not a PNG file'
+  )
+}
+
+export function createDesktopScenario({ captureScreenshot, executorHome, resultDir, uiTimeoutMs }) {
   let fixtureAResponseGate = null
   let fixtureARequestStartCount = 0
   let fixtureAResponseCount = 0
@@ -525,6 +621,164 @@ export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
       assert.ok(
         popupTabText.inspectText.includes(FIXTURE_B_TEXT),
         'The popup browser tab did not retain the linked page state'
+      )
+      await control.command('hover', SECOND_BROWSER_TAB_SELECTOR)
+      await control.command('click', SECOND_BROWSER_TAB_CLOSE_SELECTOR)
+      await waitForSnapshot(
+        control,
+        snapshot =>
+          snapshot.testIds.filter(testId => /^right-workspace-browser-tab-\d+$/.test(testId))
+            .length === 1 && !snapshot.testIds.includes('right-workspace-browser-tab-2'),
+        'Closing the background browser tab did not leave one loaded page',
+        uiTimeoutMs,
+        RIGHT_WORKSPACE_TABBAR_SELECTOR
+      )
+      await waitForValue(
+        control,
+        BROWSER_INPUT_SELECTOR,
+        fixtureBUrl,
+        uiTimeoutMs,
+        'The loaded popup page was not preserved before task creation'
+      )
+      const activeTemporaryLabel = (
+        await callBridge(bridgeIdentity, { action: 'status' }, firstBrowserLabel)
+      ).label
+      assert.ok(
+        activeTemporaryLabel === firstBrowserLabel ||
+          activeTemporaryLabel.startsWith(firstBrowserLabel + '-'),
+        'The active browser tab was not scoped to the temporary conversation label'
+      )
+      const activeTemporaryText = await callBridge(
+        bridgeIdentity,
+        {
+          action: 'inspect',
+          options: { includeTextBlocks: true, interactiveOnly: false, maxNodes: 40 },
+          timeoutMs: 5000,
+        },
+        activeTemporaryLabel
+      )
+      const activeExpectedText = fixtureTextFromInspect(activeTemporaryText.inspectText)
+      const activeTemporaryPageState = await callBridge(
+        bridgeIdentity,
+        { action: 'pageState' },
+        activeTemporaryLabel
+      )
+      const attachmentRequestCountBeforeTask = (
+        (await readFile(join(resultDir, 'app.log'), 'utf8')).match(
+          /\[embedded-browser\] webview attachment requested/g
+        ) ?? []
+      ).length
+      control.setScenario('checkpoint_task')
+      await control.command('fill', ACTIVE_COMPOSER_SELECTOR, {
+        value: CHECKPOINT_TASK_PROMPT,
+      })
+      await control.command('startElementMetricsSampling', ACTIVE_BROWSER_PANEL_SELECTOR, {
+        value: '2000',
+        visible: true,
+      })
+      await control.command('press', ACTIVE_COMPOSER_SELECTOR, { key: 'Enter' })
+      const taskId = await waitForRuntimeTaskId(control, uiTimeoutMs)
+      console.log(`[browser-multi-tabs] task created: ${taskId}`)
+      const expectedMigratedBaseLabel =
+        'workspace-browser-' + taskId.replace(/[^a-zA-Z0-9_-]/g, '-')
+      const migratedBaseLabel = await waitForBrowserLabel(
+        control,
+        expectedMigratedBaseLabel,
+        uiTimeoutMs
+      )
+      console.log(`[browser-multi-tabs] renderer label migrated: ${migratedBaseLabel}`)
+      const elementMetricsSample = await waitForElementMetricsSample(control, uiTimeoutMs)
+      await writeFile(
+        join(resultDir, 'embedded-browser-migration-element-metrics.json'),
+        JSON.stringify(elementMetricsSample, null, 2) + '\n',
+        'utf8'
+      )
+      const sampledWidths = elementMetricsSample.frames.map(frame => frame.width)
+      const sampledLefts = elementMetricsSample.frames.map(frame => frame.left)
+      const minimumWidth = Math.min(...sampledWidths)
+      const maximumWidth = Math.max(...sampledWidths)
+      const minimumLeft = Math.min(...sampledLefts)
+      const maximumLeft = Math.max(...sampledLefts)
+      console.log(
+        '[browser-multi-tabs] migration panel bounds: ' +
+          `width=${minimumWidth}..${maximumWidth}, left=${minimumLeft}..${maximumLeft}`
+      )
+      assert.ok(
+        maximumWidth - minimumWidth <= 1,
+        `Creating the first task resized the browser panel: ${minimumWidth}..${maximumWidth}`
+      )
+      assert.ok(
+        maximumLeft - minimumLeft <= 1,
+        `Creating the first task shifted the browser panel: ${minimumLeft}..${maximumLeft}`
+      )
+      const framesWithoutNativeView = elementMetricsSample.frames.filter(
+        frame => !frame.testIds.includes('workspace-browser-native-view')
+      )
+      assert.equal(
+        framesWithoutNativeView.length,
+        0,
+        `Creating the first task briefly rendered the empty browser state for ` +
+          `${framesWithoutNativeView.length} frames`
+      )
+      const activeSuffix = activeTemporaryLabel.slice(firstBrowserLabel.length)
+      const activeMigratedLabel = migratedBaseLabel + activeSuffix
+      await waitForBridgeActiveLabel(
+        bridgeIdentity,
+        firstBrowserLabel,
+        activeMigratedLabel,
+        uiTimeoutMs,
+        'The browser bridge did not preserve the temporary task route after migration'
+      )
+      console.log('[browser-multi-tabs] bridge label migration completed')
+      const migratedText = await waitForBridgeText(
+        bridgeIdentity,
+        activeMigratedLabel,
+        activeExpectedText,
+        uiTimeoutMs,
+        'The browser tool lost the loaded page after its temporary label migrated'
+      )
+      console.log('[browser-multi-tabs] migrated active page inspected')
+      assert.ok(migratedText.inspectText.includes(activeExpectedText))
+      const activeBeforeReload = await callBridge(
+        bridgeIdentity,
+        { action: 'pageState' },
+        activeMigratedLabel
+      )
+      assert.equal(activeBeforeReload.navigationError, null)
+      assert.equal(activeBeforeReload.url, activeTemporaryPageState.url)
+      await callBridge(bridgeIdentity, { action: 'reload' }, activeMigratedLabel)
+      await waitForBridgeText(
+        bridgeIdentity,
+        activeMigratedLabel,
+        activeExpectedText,
+        uiTimeoutMs,
+        'Reloading the migrated browser page left it blank'
+      )
+      const activeAfterReload = await callBridge(
+        bridgeIdentity,
+        { action: 'pageState' },
+        activeMigratedLabel
+      )
+      assert.equal(activeAfterReload.navigationError, null)
+      assert.equal(activeAfterReload.url, activeTemporaryPageState.url)
+      console.log('[browser-multi-tabs] migrated page reloaded')
+      await waitForSnapshot(
+        control,
+        snapshot => !snapshot.testIds.includes('workspace-browser-navigation-error'),
+        'The active migrated browser page showed an error after reload',
+        uiTimeoutMs,
+        ACTIVE_BROWSER_PANEL_SELECTOR
+      )
+      await captureMigrationScreenshot(captureScreenshot, control, resultDir)
+      console.log('[browser-multi-tabs] migration screenshot captured')
+      const appLog = await readFile(join(resultDir, 'app.log'), 'utf8')
+      const attachmentRequestCountAfterTask = (
+        appLog.match(/\[embedded-browser\] webview attachment requested/g) ?? []
+      ).length
+      assert.equal(
+        attachmentRequestCountAfterTask,
+        attachmentRequestCountBeforeTask,
+        'Creating the first task attached a second blank webview instead of transferring the loaded one'
       )
     },
   }

--- a/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
@@ -193,7 +193,7 @@ async function waitForBridgeText(identity, label, text, timeoutMs, message) {
       },
       label
     ).catch(() => null)
-    if (page?.inspectText.includes(text)) return page
+    if (page?.inspectText?.includes(text)) return page
     lastInspectText = page?.inspectText ?? null
     lastPageState = await callBridge(identity, { action: 'pageState' }, label).catch(() => null)
     await new Promise(resolve => setTimeout(resolve, 100))

--- a/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
@@ -17,6 +17,7 @@ const RIGHT_NEW_TAB_TERMINAL_OPTION_SELECTOR =
 const ACTIVE_BROWSER_PANEL_SELECTOR =
   ACTIVE_WORKBENCH_SELECTOR +
   ' [data-testid="right-workspace-panel"] div:not(.hidden) > [data-testid="workspace-browser-panel"]'
+const ACTIVE_BROWSER_WEBVIEW_HOST_SELECTOR = '[data-testid="workspace-browser-electron-webview"]'
 const BROWSER_INPUT_SELECTOR =
   ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-url-input"]'
 const FIRST_BROWSER_TAB_SELECTOR = '[data-testid="right-workspace-browser-tab-1"]'
@@ -285,7 +286,8 @@ export function createDesktopScenario({ captureScreenshot, executorHome, resultD
         return true
       }
       if (url.pathname === NAVIGATION_FAILURE_PATH) {
-        request.socket.destroy()
+        response.writeHead(302, { location: NAVIGATION_FAILURE_PATH })
+        response.end()
         return true
       }
       return false
@@ -672,7 +674,7 @@ export function createDesktopScenario({ captureScreenshot, executorHome, resultD
       await control.command('fill', ACTIVE_COMPOSER_SELECTOR, {
         value: CHECKPOINT_TASK_PROMPT,
       })
-      await control.command('startElementMetricsSampling', ACTIVE_BROWSER_PANEL_SELECTOR, {
+      await control.command('startElementMetricsSampling', ACTIVE_BROWSER_WEBVIEW_HOST_SELECTOR, {
         value: '2000',
         visible: true,
       })
@@ -693,6 +695,13 @@ export function createDesktopScenario({ captureScreenshot, executorHome, resultD
         JSON.stringify(elementMetricsSample, null, 2) + '\n',
         'utf8'
       )
+      const disconnectedFrames = elementMetricsSample.frames.filter(frame => !frame.connected)
+      assert.equal(
+        disconnectedFrames.length,
+        0,
+        `Creating the first task remounted the browser webview for ` +
+          `${disconnectedFrames.length} frames`
+      )
       const sampledWidths = elementMetricsSample.frames.map(frame => frame.width)
       const sampledLefts = elementMetricsSample.frames.map(frame => frame.left)
       const minimumWidth = Math.min(...sampledWidths)
@@ -700,25 +709,24 @@ export function createDesktopScenario({ captureScreenshot, executorHome, resultD
       const minimumLeft = Math.min(...sampledLefts)
       const maximumLeft = Math.max(...sampledLefts)
       console.log(
-        '[browser-multi-tabs] migration panel bounds: ' +
+        '[browser-multi-tabs] migration webview bounds: ' +
           `width=${minimumWidth}..${maximumWidth}, left=${minimumLeft}..${maximumLeft}`
       )
       assert.ok(
         maximumWidth - minimumWidth <= 1,
-        `Creating the first task resized the browser panel: ${minimumWidth}..${maximumWidth}`
+        `Creating the first task resized the browser webview: ${minimumWidth}..${maximumWidth}`
       )
       assert.ok(
         maximumLeft - minimumLeft <= 1,
-        `Creating the first task shifted the browser panel: ${minimumLeft}..${maximumLeft}`
+        `Creating the first task shifted the browser webview: ${minimumLeft}..${maximumLeft}`
       )
-      const framesWithoutNativeView = elementMetricsSample.frames.filter(
-        frame => !frame.testIds.includes('workspace-browser-native-view')
+      const hiddenFrames = elementMetricsSample.frames.filter(
+        frame => frame.visibility !== 'visible'
       )
       assert.equal(
-        framesWithoutNativeView.length,
+        hiddenFrames.length,
         0,
-        `Creating the first task briefly rendered the empty browser state for ` +
-          `${framesWithoutNativeView.length} frames`
+        `Creating the first task hid the browser webview for ${hiddenFrames.length} frames`
       )
       const activeSuffix = activeTemporaryLabel.slice(firstBrowserLabel.length)
       const activeMigratedLabel = migratedBaseLabel + activeSuffix

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -737,6 +737,40 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     await rm(directory, { recursive: true, force: true })
   })
 
+  test('keeps existing browser routes valid after relabeling a browser entry', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    const temporaryLabel = 'workspace-browser-blank-1'
+    const taskLabel = 'workspace-browser-task-1'
+    manager.attach(temporaryLabel, contents as unknown as WebContents)
+    await manager.open({
+      label: temporaryLabel,
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+    manager.setActiveTab(temporaryLabel, temporaryLabel)
+    manager.setActiveTab('workspace-browser', temporaryLabel)
+
+    manager.relabel(temporaryLabel, taskLabel)
+
+    expect(manager.activeLabel(temporaryLabel)).toBe(taskLabel)
+    expect(manager.activeLabel('workspace-browser')).toBe(taskLabel)
+    expect(manager.state(manager.activeLabel(temporaryLabel))).toMatchObject({
+      label: taskLabel,
+      url: 'https://example.test/',
+    })
+
+    contents.close()
+    expect(manager.has(taskLabel)).toBe(false)
+    await rm(directory, { recursive: true, force: true })
+  })
+
   test('records, searches, removes, and clears persisted browser history', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
     const manager = new EmbeddedBrowserManager(directory)

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -771,6 +771,89 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     await rm(directory, { recursive: true, force: true })
   })
 
+  test('settles a pending target open when relabeling an attached browser', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    const temporaryLabel = 'workspace-browser-blank-1'
+    const taskLabel = 'workspace-browser-task-1'
+    manager.attach(temporaryLabel, contents as unknown as WebContents)
+    await manager.open({
+      label: temporaryLabel,
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+    const pendingOpen = manager.open({
+      label: taskLabel,
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: false,
+    })
+
+    manager.relabel(temporaryLabel, taskLabel)
+
+    await expect(pendingOpen).resolves.toMatchObject({
+      label: taskLabel,
+      url: 'https://example.test/',
+    })
+    manager.close(taskLabel)
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('clears migrated label state when the attached web contents is destroyed', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    const temporaryLabel = 'workspace-browser-blank-1'
+    const taskLabel = 'workspace-browser-task-1'
+    manager.attach(temporaryLabel, contents as unknown as WebContents)
+    await manager.open({
+      label: temporaryLabel,
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+    manager.setAgentControlPaused(temporaryLabel, true)
+    manager.emitAgentState(temporaryLabel, 'running')
+    manager.showAgentCursor(temporaryLabel, 120, 80)
+    const approvalResult = {
+      error: { code: 'approval_required' },
+      approval: { actionKind: 'click' },
+    }
+    const approval = manager.registerAgentApproval(
+      temporaryLabel,
+      'click:button',
+      'click',
+      approvalResult
+    )
+    expect(approval).not.toBeNull()
+    manager.resolveAgentApproval(temporaryLabel, approval?.approvalId ?? '', true)
+    manager.relabel(temporaryLabel, taskLabel)
+
+    contents.close()
+
+    const internals = manager as unknown as {
+      agentActive: Set<string>
+      agentCursorStates: Map<string, unknown>
+    }
+    expect(manager.has(taskLabel)).toBe(false)
+    expect(manager.isAgentControlPaused(taskLabel)).toBe(false)
+    expect(manager.consumeApprovedAgentRisk(taskLabel, 'click:button')).toBe(false)
+    expect(internals.agentActive.has(taskLabel)).toBe(false)
+    expect(internals.agentCursorStates.has(taskLabel)).toBe(false)
+    await rm(directory, { recursive: true, force: true })
+  })
+
   test('records, searches, removes, and clears persisted browser history', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
     const manager = new EmbeddedBrowserManager(directory)

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -337,11 +337,11 @@ export class EmbeddedBrowserManager {
       this.setAgentControlPaused(entry.label, true)
     })
     contents.once('destroyed', () => {
-      if (this.attachedContents.get(normalizedLabel)?.id === contents.id) {
-        this.attachedContents.delete(normalizedLabel)
+      for (const [attachedLabel, attached] of this.attachedContents) {
+        if (attached.id === contents.id) this.attachedContents.delete(attachedLabel)
       }
-      if (this.entries.get(normalizedLabel)?.contents.id === contents.id) {
-        this.entries.delete(normalizedLabel)
+      for (const [entryLabel, entry] of this.entries) {
+        if (entry.contents.id === contents.id) this.entries.delete(entryLabel)
       }
     })
     const waiters = this.attachmentWaiters.get(normalizedLabel)
@@ -615,6 +615,28 @@ export class EmbeddedBrowserManager {
     const entry = this.required(fromLabel)
     const target = requiredLabel(toLabel)
     if (this.entries.has(target)) throw new Error(`Browser label already exists: ${target}`)
+    const attached = this.attachedContents.get(entry.label)
+    const targetAttached = this.attachedContents.get(target)
+    if (
+      attached &&
+      targetAttached &&
+      attached.id !== targetAttached.id &&
+      !targetAttached.isDestroyed()
+    ) {
+      targetAttached.close()
+    }
+    this.attachedContents.delete(entry.label)
+    if (attached && !attached.isDestroyed()) this.attachedContents.set(target, attached)
+    for (const [baseLabel, activeLabel] of this.activeTabs) {
+      if (activeLabel === entry.label) this.activeTabs.set(baseLabel, target)
+    }
+    if (this.agentControlPaused.delete(entry.label)) this.agentControlPaused.add(target)
+    for (const approval of this.agentApprovals.values()) {
+      if (approval.label === entry.label) approval.label = target
+    }
+    for (const download of this.downloads.values()) {
+      if (download.label === entry.label) download.label = target
+    }
     this.entries.delete(entry.label)
     entry.label = target
     this.entries.set(target, entry)

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -57,6 +57,14 @@ interface BrowserEntry {
   historyGeneration: number
 }
 
+interface BrowserOpenInput {
+  label: string
+  url: string
+  bounds: BrowserBounds
+  visible: boolean
+  navigateExisting: boolean
+}
+
 export interface BrowserHostEvent {
   sequence: number
   type:
@@ -337,20 +345,20 @@ export class EmbeddedBrowserManager {
       this.setAgentControlPaused(entry.label, true)
     })
     contents.once('destroyed', () => {
+      const removedLabels = new Set<string>()
       for (const [attachedLabel, attached] of this.attachedContents) {
-        if (attached.id === contents.id) this.attachedContents.delete(attachedLabel)
+        if (attached.id !== contents.id) continue
+        this.attachedContents.delete(attachedLabel)
+        removedLabels.add(attachedLabel)
       }
       for (const [entryLabel, entry] of this.entries) {
-        if (entry.contents.id === contents.id) this.entries.delete(entryLabel)
+        if (entry.contents.id !== contents.id) continue
+        this.entries.delete(entryLabel)
+        removedLabels.add(entryLabel)
       }
+      for (const removedLabel of removedLabels) this.clearLabelScopedState(removedLabel)
     })
-    const waiters = this.attachmentWaiters.get(normalizedLabel)
-    if (!waiters) return
-    this.attachmentWaiters.delete(normalizedLabel)
-    for (const waiter of waiters) {
-      clearTimeout(waiter.timeout)
-      waiter.resolve(contents)
-    }
+    this.resolveAttachmentWaiters(normalizedLabel, contents)
   }
 
   requestPopupTab(parentLabel: string, url: string): void {
@@ -373,26 +381,13 @@ export class EmbeddedBrowserManager {
     })
   }
 
-  async open(input: {
-    label: string
-    url: string
-    bounds: BrowserBounds
-    visible: boolean
-    navigateExisting: boolean
-  }): Promise<BrowserPageState> {
+  async open(input: BrowserOpenInput): Promise<BrowserPageState> {
     const label = requiredLabel(input.label)
     const existing = this.entries.get(label)
-    if (existing) {
-      existing.bounds = validBounds(input.bounds)
-      existing.visible = input.visible
-      if (input.navigateExisting && existing.contents.getURL() !== input.url) {
-        const url = validBrowserUrl(input.url)
-        existing.requestedUrl = url
-        await this.load(existing, url)
-      }
-      return this.state(label)
-    }
+    if (existing) return this.openExisting(existing, input)
     const contents = await this.waitForAttachedContents(label)
+    const migrated = this.entries.get(label)
+    if (migrated) return this.openExisting(migrated, input)
     const entry: BrowserEntry = {
       label,
       nativeLabel: `electron-browser-${randomUUID()}`,
@@ -486,6 +481,20 @@ export class EmbeddedBrowserManager {
     // The requested URL is already authoritative in state() while Chromium finishes loading.
     await this.load(entry, entry.requestedUrl as string)
     return this.state(label)
+  }
+
+  private async openExisting(
+    entry: BrowserEntry,
+    input: BrowserOpenInput
+  ): Promise<BrowserPageState> {
+    entry.bounds = validBounds(input.bounds)
+    entry.visible = input.visible
+    if (input.navigateExisting && entry.contents.getURL() !== input.url) {
+      const url = validBrowserUrl(input.url)
+      entry.requestedUrl = url
+      await this.load(entry, url)
+    }
+    return this.state(entry.label)
   }
 
   setBounds(label: string, bounds: BrowserBounds, visible: boolean): void {
@@ -654,6 +663,7 @@ export class EmbeddedBrowserManager {
     this.clearAgentCursorHide(fromLabel)
     if (cursorState && !this.agentActive.has(fromLabel)) this.scheduleAgentCursorHide(target)
     if (this.agentActive.delete(fromLabel)) this.agentActive.add(target)
+    if (attached && !attached.isDestroyed()) this.resolveAttachmentWaiters(target, attached)
   }
 
   setActiveTab(baseLabel: string, activeLabel: string): void {
@@ -896,6 +906,11 @@ export class EmbeddedBrowserManager {
     if (!entry) return
     if (expectedNativeLabel && entry.nativeLabel !== expectedNativeLabel) return
     this.entries.delete(label)
+    this.clearLabelScopedState(label)
+    if (!entry.contents.isDestroyed()) entry.contents.close()
+  }
+
+  private clearLabelScopedState(label: string): void {
     this.agentControlPaused.delete(label)
     this.agentActive.delete(label)
     this.clearAgentCursorHide(label)
@@ -906,7 +921,10 @@ export class EmbeddedBrowserManager {
       if (approval.label === label) this.agentApprovals.delete(approvalId)
     }
     this.attachedContents.delete(label)
-    if (!entry.contents.isDestroyed()) entry.contents.close()
+    this.rejectAttachmentWaiters(
+      label,
+      new Error(`Embedded browser webview was closed before attachment: ${label}`)
+    )
   }
 
   closeMany(labels: string[]): void {
@@ -1280,6 +1298,26 @@ export class EmbeddedBrowserManager {
       waiters.add({ resolve, reject, timeout })
       this.attachmentWaiters.set(label, waiters)
     })
+  }
+
+  private resolveAttachmentWaiters(label: string, contents: WebContents): void {
+    const waiters = this.attachmentWaiters.get(label)
+    if (!waiters) return
+    this.attachmentWaiters.delete(label)
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout)
+      waiter.resolve(contents)
+    }
+  }
+
+  private rejectAttachmentWaiters(label: string, error: Error): void {
+    const waiters = this.attachmentWaiters.get(label)
+    if (!waiters) return
+    this.attachmentWaiters.delete(label)
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout)
+      waiter.reject(error)
+    }
   }
 }
 

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -85,6 +85,7 @@ import {
   type RightWorkspacePanelView,
   type RightWorkspaceTerminalTab,
 } from './workspace-panels/RightWorkspacePanel'
+import { retainElectronEmbeddedBrowserView } from './workspace-panels/electronEmbeddedBrowserHost'
 import {
   attachRightWorkspaceSidebarController,
   encodeRightWorkspaceExtensionTabId,
@@ -164,7 +165,7 @@ import {
   listenEmbeddedBrowserOpenRequests,
   listenEmbeddedBrowserPopupRequests,
   markEmbeddedBrowserLabelTransferred,
-  relabelEmbeddedBrowser,
+  migrateEmbeddedBrowserLabel,
   setEmbeddedBrowserActiveTab,
   type EmbeddedBrowserOpenRequest,
 } from '@/lib/embedded-browser'
@@ -363,7 +364,9 @@ function consumeLatestBlankBrowserMigration(): PendingBlankBrowserMigration | nu
   const migration = latestBlankBrowserMigration
   latestBlankBrowserMigration = null
   Object.values(migration.browserStates).forEach(state => {
-    if (state?.label) markEmbeddedBrowserLabelTransferred(state.label)
+    if (!state?.label) return
+    retainElectronEmbeddedBrowserView(state.label)
+    markEmbeddedBrowserLabelTransferred(state.label)
   })
   return migration
 }
@@ -454,6 +457,7 @@ function normalizeRightWorkspaceBrowserState(
     label: state?.label ?? label,
     nativeLabel: state?.nativeLabel ?? null,
     browserSessionId: state?.browserSessionId ?? getRightWorkspaceBrowserLabelSuffix(tab),
+    url: state?.url ?? null,
     title: state?.title ?? null,
     faviconUrl: state?.faviconUrl ?? null,
     isLoading: state?.isLoading ?? false,
@@ -1367,6 +1371,17 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     initialWorkspaceState,
     defaultEmbeddedBrowserLabel,
   })
+  const browserTransferSourceLabels = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(initialBlankBrowserMigration?.browserStates ?? {})
+          .filter((entry): entry is [RightWorkspaceBrowserTab, RightWorkspaceBrowserState] =>
+            Boolean(entry[1]?.label)
+          )
+          .map(([tab, state]) => [tab, state.label])
+      ) as Partial<Record<RightWorkspaceBrowserTab, string>>,
+    [initialBlankBrowserMigration]
+  )
   const [rightPanelOpen, setRightPanelOpen] = useState(
     () =>
       initialBlankBrowserMigration?.rightPanelOpen ?? initialWorkspaceState?.rightPanelOpen ?? false
@@ -1480,6 +1495,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     ): RightWorkspaceBrowserState => ({
       label: browserLabelForRightWorkspaceTab(defaultEmbeddedBrowserLabel, tab),
       browserSessionId: getRightWorkspaceBrowserLabelSuffix(tab),
+      url: null,
       title: null,
       faviconUrl: null,
       isLoading: false,
@@ -2495,6 +2511,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     if (!initialBlankBrowserMigration || !currentRuntimeTask) return
 
     let disposed = false
+    const abortController = new AbortController()
     const mappings = Object.entries(initialBlankBrowserMigration.browserStates)
       .filter((entry): entry is [RightWorkspaceBrowserTab, RightWorkspaceBrowserState] =>
         Boolean(entry[1]?.label)
@@ -2503,13 +2520,17 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         tab,
         fromLabel: state.label,
         toLabel: browserLabelForRightWorkspaceTab(defaultEmbeddedBrowserLabel, tab),
+        waitForSource: Boolean(state.nativeLabel || state.openRequest),
       }))
 
     void mappings
-      .reduce(async (previous, { fromLabel, toLabel }) => {
+      .reduce(async (previous, { fromLabel, toLabel, waitForSource }) => {
         await previous
         if (fromLabel === toLabel) return
-        await relabelEmbeddedBrowser(fromLabel, toLabel)
+        await migrateEmbeddedBrowserLabel(fromLabel, toLabel, {
+          waitForSource,
+          signal: abortController.signal,
+        })
       }, Promise.resolve())
       .then(() => {
         if (disposed) return
@@ -2531,6 +2552,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
 
     return () => {
       disposed = true
+      abortController.abort()
     }
   }, [currentRuntimeTask, defaultEmbeddedBrowserLabel, initialBlankBrowserMigration])
 
@@ -5099,6 +5121,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 ) : null
               }
               browserStates={browserStates}
+              browserTransferSourceLabels={browserTransferSourceLabels}
               onBrowserStateChange={updateBrowserState}
               onReloadSmartAppDevelopmentPreview={reloadSmartAppDevelopmentPreview}
               onAddSmartAppDevelopmentPlugin={addSmartAppDevelopmentPlugin}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -165,7 +165,7 @@ import {
   listenEmbeddedBrowserOpenRequests,
   listenEmbeddedBrowserPopupRequests,
   markEmbeddedBrowserLabelTransferred,
-  migrateEmbeddedBrowserLabel,
+  migrateEmbeddedBrowserLabelSequence,
   setEmbeddedBrowserActiveTab,
   type EmbeddedBrowserOpenRequest,
 } from '@/lib/embedded-browser'
@@ -2523,32 +2523,22 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         waitForSource: Boolean(state.nativeLabel || state.openRequest),
       }))
 
-    void mappings
-      .reduce(async (previous, { fromLabel, toLabel, waitForSource }) => {
-        await previous
-        if (fromLabel === toLabel) return
-        await migrateEmbeddedBrowserLabel(fromLabel, toLabel, {
-          waitForSource,
-          signal: abortController.signal,
-        })
-      }, Promise.resolve())
-      .then(() => {
+    void migrateEmbeddedBrowserLabelSequence(mappings, {
+      signal: abortController.signal,
+      onMigrated: ({ tab, toLabel }) => {
         if (disposed) return
         setBrowserStates(current => {
-          let changed = false
-          const next = { ...current }
-          mappings.forEach(({ tab, toLabel }) => {
-            const state = next[tab]
-            if (!state || state.label === toLabel) return
-            next[tab] = { ...state, label: toLabel }
-            changed = true
-          })
-          return changed ? next : current
+          const state = current[tab]
+          if (!state || state.label === toLabel) return current
+          return {
+            ...current,
+            [tab]: { ...state, label: toLabel },
+          }
         })
-      })
-      .catch(error => {
-        console.error('Failed to migrate embedded browser label:', error)
-      })
+      },
+    }).catch(error => {
+      console.error('Failed to migrate embedded browser label:', error)
+    })
 
     return () => {
       disposed = true

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
@@ -1,7 +1,12 @@
 import { act, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ElectronEmbeddedBrowserView } from './ElectronEmbeddedBrowserView'
-import { retainElectronEmbeddedBrowserView } from './electronEmbeddedBrowserHost'
+import {
+  claimElectronEmbeddedBrowserView,
+  relabelElectronEmbeddedBrowserView,
+  releaseElectronEmbeddedBrowserView,
+  retainElectronEmbeddedBrowserView,
+} from './electronEmbeddedBrowserHost'
 
 const embeddedBrowserMocks = vi.hoisted(() => ({
   notifyEmbeddedBrowserAgentCursorArrived: vi.fn(),
@@ -163,7 +168,7 @@ describe('ElectronEmbeddedBrowserView', () => {
     retainElectronEmbeddedBrowserView('workspace-browser-blank-0')
     source.unmount()
     expect(screen.getByTestId('workspace-browser-electron-webview')).toBe(sourceHost)
-    expect(sourceHost.style.visibility).toBe('visible')
+    expect(sourceHost.style.visibility).toBe('hidden')
     expect(sourceHost.style.pointerEvents).toBe('none')
 
     const destination = render(
@@ -195,6 +200,24 @@ describe('ElectronEmbeddedBrowserView', () => {
       await Promise.resolve()
     })
     expect(screen.queryByTestId('workspace-browser-electron-webview')).not.toBeInTheDocument()
+  })
+
+  test('does not replace an active host while relabeling', () => {
+    const sourceOwner = Symbol('source')
+    const targetOwner = Symbol('target')
+    const source = claimElectronEmbeddedBrowserView('workspace-browser-source', sourceOwner)
+    const target = claimElectronEmbeddedBrowserView('workspace-browser-target', targetOwner)
+
+    expect(() =>
+      relabelElectronEmbeddedBrowserView(source, sourceOwner, 'workspace-browser-target')
+    ).toThrow('Embedded browser label already has an active host')
+    expect(source.destroyed).toBe(false)
+    expect(target.destroyed).toBe(false)
+    expect(source.container.isConnected).toBe(true)
+    expect(target.container.isConnected).toBe(true)
+
+    releaseElectronEmbeddedBrowserView(source, sourceOwner)
+    releaseElectronEmbeddedBrowserView(target, targetOwner)
   })
 
   test('claims the retained blank webview when the task label renders first', async () => {

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
@@ -283,6 +283,51 @@ describe('ElectronEmbeddedBrowserView', () => {
     expect(screen.queryByTestId('workspace-browser-electron-webview')).not.toBeInTheDocument()
   })
 
+  test('restores the prior owner when the newer overlapping panel unmounts first', async () => {
+    const first = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-overlap-reverse"
+        visualRect={null}
+      />
+    )
+    const host = screen.getByTestId('workspace-browser-electron-webview')
+    const webview = host.querySelector('webview')
+    const second = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-overlap-reverse"
+        visualRect={null}
+      />
+    )
+
+    second.unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId('workspace-browser-electron-webview')).toBe(host)
+    expect(host.querySelector('webview')).toBe(webview)
+    first.rerender(
+      <ElectronEmbeddedBrowserView
+        active={false}
+        interactionBlocked
+        label="workspace-browser-overlap-reverse"
+        visualRect={null}
+      />
+    )
+    expect(host.style.visibility).toBe('hidden')
+    expect(host.style.pointerEvents).toBe('none')
+
+    first.unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByTestId('workspace-browser-electron-webview')).not.toBeInTheDocument()
+  })
+
   test('ignores stale bounds updates after ownership moves to the task pane', () => {
     const source = render(
       <ElectronEmbeddedBrowserView
@@ -313,7 +358,21 @@ describe('ElectronEmbeddedBrowserView', () => {
       '[data-testid="workspace-browser-electron-webview-placeholder"]'
     )
     expect(destinationPlaceholder).not.toBeNull()
-    vi.spyOn(destinationPlaceholder, 'getBoundingClientRect').mockReturnValue({
+    const destinationRect = vi
+      .spyOn(destinationPlaceholder, 'getBoundingClientRect')
+      .mockReturnValue({
+        height: 0,
+        left: 0,
+        top: 0,
+        width: 0,
+      } as DOMRect)
+    resizeObserverCallbacks[1]?.()
+
+    const host = screen.getByTestId('workspace-browser-electron-webview')
+    expect(host.style.left).toBe('10px')
+    expect(host.style.width).toBe('600px')
+
+    destinationRect.mockReturnValue({
       height: 500,
       left: 700,
       top: 30,
@@ -321,7 +380,6 @@ describe('ElectronEmbeddedBrowserView', () => {
     } as DOMRect)
     resizeObserverCallbacks[1]?.()
 
-    const host = screen.getByTestId('workspace-browser-electron-webview')
     expect(host.style.left).toBe('700px')
     expect(host.style.width).toBe('800px')
 

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
@@ -9,6 +9,8 @@ import {
 } from './electronEmbeddedBrowserHost'
 
 const embeddedBrowserMocks = vi.hoisted(() => ({
+  closeRequestHandler: null as ((event: { label: string; nativeLabel: string }) => void) | null,
+  listenEmbeddedBrowserCloseRequests: vi.fn(),
   notifyEmbeddedBrowserAgentCursorArrived: vi.fn(),
 }))
 
@@ -31,6 +33,16 @@ describe('ElectronEmbeddedBrowserView', () => {
     vi.useFakeTimers()
     embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived.mockReset()
     embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived.mockResolvedValue(undefined)
+    embeddedBrowserMocks.closeRequestHandler = null
+    embeddedBrowserMocks.listenEmbeddedBrowserCloseRequests.mockReset()
+    embeddedBrowserMocks.listenEmbeddedBrowserCloseRequests.mockImplementation(handler => {
+      embeddedBrowserMocks.closeRequestHandler = handler
+      return Promise.resolve(() => {
+        if (embeddedBrowserMocks.closeRequestHandler === handler) {
+          embeddedBrowserMocks.closeRequestHandler = null
+        }
+      })
+    })
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
     document.querySelector('[data-wework-browser-webview-host-root]')?.remove()
   })
@@ -200,6 +212,35 @@ describe('ElectronEmbeddedBrowserView', () => {
       await Promise.resolve()
     })
     expect(screen.queryByTestId('workspace-browser-electron-webview')).not.toBeInTheDocument()
+  })
+
+  test('replaces a closed webview before the same route is reopened', async () => {
+    render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser"
+        visualRect={null}
+      />
+    )
+    const host = screen.getByTestId('workspace-browser-electron-webview')
+    const previousWebview = host.querySelector('webview')
+    const previousPartition = previousWebview?.getAttribute('partition')
+
+    await act(async () => {
+      embeddedBrowserMocks.closeRequestHandler?.({
+        label: 'workspace-browser',
+        nativeLabel: 'electron-browser-1',
+      })
+    })
+
+    const nextWebview = host.querySelector('webview')
+    expect(nextWebview).not.toBe(previousWebview)
+    expect(host.querySelectorAll('webview')).toHaveLength(1)
+    expect(nextWebview?.getAttribute('partition')).not.toBe(previousPartition)
+    expect(previousWebview?.isConnected).toBe(false)
+    expect(host.style.visibility).toBe('visible')
+    expect(host.style.pointerEvents).toBe('auto')
   })
 
   test('does not replace an active host while relabeling', () => {

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ElectronEmbeddedBrowserView } from './ElectronEmbeddedBrowserView'
+import { retainElectronEmbeddedBrowserView } from './electronEmbeddedBrowserHost'
 
 const embeddedBrowserMocks = vi.hoisted(() => ({
   notifyEmbeddedBrowserAgentCursorArrived: vi.fn(),
@@ -8,17 +9,30 @@ const embeddedBrowserMocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/embedded-browser', () => embeddedBrowserMocks)
 
+const resizeObserverCallbacks: Array<() => void> = []
+
 class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallbacks.push(() => callback([], this as unknown as ResizeObserver))
+  }
+
   observe = vi.fn()
   disconnect = vi.fn()
 }
 
 describe('ElectronEmbeddedBrowserView', () => {
   beforeEach(() => {
+    resizeObserverCallbacks.length = 0
     vi.useFakeTimers()
     embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived.mockReset()
     embeddedBrowserMocks.notifyEmbeddedBrowserAgentCursorArrived.mockResolvedValue(undefined)
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    document.querySelector('[data-wework-browser-webview-host-root]')?.remove()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
     document.querySelector('[data-wework-browser-webview-host-root]')?.remove()
   })
 
@@ -132,5 +146,190 @@ describe('ElectronEmbeddedBrowserView', () => {
       'workspace-browser',
       8
     )
+  })
+
+  test('reuses the loaded webview when a blank conversation becomes a task', async () => {
+    const source = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-blank-0"
+        visualRect={null}
+      />
+    )
+    const sourceHost = screen.getByTestId('workspace-browser-electron-webview')
+    const loadedWebview = sourceHost.querySelector('webview')
+
+    retainElectronEmbeddedBrowserView('workspace-browser-blank-0')
+    source.unmount()
+    expect(screen.getByTestId('workspace-browser-electron-webview')).toBe(sourceHost)
+    expect(sourceHost.style.visibility).toBe('visible')
+    expect(sourceHost.style.pointerEvents).toBe('none')
+
+    const destination = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-blank-0"
+        visualRect={null}
+      />
+    )
+    const transferredHost = screen.getByTestId('workspace-browser-electron-webview')
+    expect(transferredHost.querySelector('webview')).toBe(loadedWebview)
+
+    destination.rerender(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-task-1"
+        visualRect={null}
+      />
+    )
+    expect(transferredHost).toHaveAttribute(
+      'data-wework-browser-webview',
+      'workspace-browser-task-1'
+    )
+
+    destination.unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByTestId('workspace-browser-electron-webview')).not.toBeInTheDocument()
+  })
+
+  test('claims the retained blank webview when the task label renders first', async () => {
+    const source = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-blank-0"
+        visualRect={null}
+      />
+    )
+    const sourceHost = screen.getByTestId('workspace-browser-electron-webview')
+    const loadedWebview = sourceHost.querySelector('webview')
+    const sourcePartition = loadedWebview?.getAttribute('partition')
+
+    retainElectronEmbeddedBrowserView('workspace-browser-blank-0')
+    source.unmount()
+
+    const destination = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-runtime-1"
+        transferFromLabel="workspace-browser-blank-0"
+        visualRect={null}
+      />
+    )
+
+    const transferredHost = screen.getByTestId('workspace-browser-electron-webview')
+    expect(screen.getAllByTestId('workspace-browser-electron-webview')).toEqual([sourceHost])
+    expect(transferredHost.querySelector('webview')).toBe(loadedWebview)
+    expect(loadedWebview).toHaveAttribute('partition', sourcePartition)
+    expect(transferredHost).toHaveAttribute(
+      'data-wework-browser-webview',
+      'workspace-browser-runtime-1'
+    )
+
+    destination.unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByTestId('workspace-browser-electron-webview')).not.toBeInTheDocument()
+  })
+
+  test('keeps one webview when ownership overlaps during a panel transition', async () => {
+    const first = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-overlap"
+        visualRect={null}
+      />
+    )
+    const host = screen.getByTestId('workspace-browser-electron-webview')
+    const webview = host.querySelector('webview')
+
+    const second = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-overlap"
+        visualRect={null}
+      />
+    )
+    expect(screen.getAllByTestId('workspace-browser-electron-webview')).toEqual([host])
+    expect(host.querySelector('webview')).toBe(webview)
+
+    first.rerender(
+      <ElectronEmbeddedBrowserView
+        active={false}
+        interactionBlocked
+        label="workspace-browser-overlap"
+        visualRect={null}
+      />
+    )
+    expect(host.style.visibility).toBe('visible')
+    expect(host.style.pointerEvents).toBe('auto')
+
+    first.unmount()
+    expect(screen.getByTestId('workspace-browser-electron-webview')).toBe(host)
+
+    second.unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByTestId('workspace-browser-electron-webview')).not.toBeInTheDocument()
+  })
+
+  test('ignores stale bounds updates after ownership moves to the task pane', () => {
+    const source = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-overlap"
+        visualRect={null}
+      />
+    )
+    const sourcePlaceholder = source.getByTestId('workspace-browser-electron-webview-placeholder')
+    vi.spyOn(sourcePlaceholder, 'getBoundingClientRect').mockReturnValue({
+      height: 400,
+      left: 10,
+      top: 20,
+      width: 600,
+    } as DOMRect)
+    resizeObserverCallbacks[0]?.()
+
+    const destination = render(
+      <ElectronEmbeddedBrowserView
+        active
+        interactionBlocked={false}
+        label="workspace-browser-overlap"
+        visualRect={null}
+      />
+    )
+    const destinationPlaceholder = destination.container.querySelector<HTMLElement>(
+      '[data-testid="workspace-browser-electron-webview-placeholder"]'
+    )
+    expect(destinationPlaceholder).not.toBeNull()
+    vi.spyOn(destinationPlaceholder, 'getBoundingClientRect').mockReturnValue({
+      height: 500,
+      left: 700,
+      top: 30,
+      width: 800,
+    } as DOMRect)
+    resizeObserverCallbacks[1]?.()
+
+    const host = screen.getByTestId('workspace-browser-electron-webview')
+    expect(host.style.left).toBe('700px')
+    expect(host.style.width).toBe('800px')
+
+    resizeObserverCallbacks[0]?.()
+
+    expect(host.style.left).toBe('700px')
+    expect(host.style.top).toBe('30px')
+    expect(host.style.width).toBe('800px')
+    expect(host.style.height).toBe('500px')
   })
 })

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
@@ -7,6 +7,7 @@ import {
 import { BrowserAgentCursorIcon } from './BrowserAgentCursorIcon'
 import {
   claimElectronEmbeddedBrowserView,
+  positionElectronEmbeddedBrowserView,
   relabelElectronEmbeddedBrowserView,
   releaseElectronEmbeddedBrowserView,
   syncElectronEmbeddedBrowserView,
@@ -69,13 +70,12 @@ export function ElectronEmbeddedBrowserView({
     setCursorOverlayHost(host.cursorHost)
 
     const syncBounds = () => {
-      if (host.owner !== owner) return
       const rect = placeholder.getBoundingClientRect()
-      Object.assign(host.container.style, {
-        height: `${Math.max(0, rect.height)}px`,
-        left: `${rect.left}px`,
-        top: `${rect.top}px`,
-        width: `${Math.max(0, rect.width)}px`,
+      positionElectronEmbeddedBrowserView(host, owner, {
+        height: Math.max(0, rect.height),
+        left: rect.left,
+        top: rect.top,
+        width: Math.max(0, rect.width),
       })
     }
 

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
@@ -5,6 +5,13 @@ import {
   type EmbeddedBrowserAgentCursorEvent,
 } from '@/lib/embedded-browser'
 import { BrowserAgentCursorIcon } from './BrowserAgentCursorIcon'
+import {
+  claimElectronEmbeddedBrowserView,
+  relabelElectronEmbeddedBrowserView,
+  releaseElectronEmbeddedBrowserView,
+  syncElectronEmbeddedBrowserView,
+  type HostedElectronWebview,
+} from './electronEmbeddedBrowserHost'
 
 interface BrowserVisualRect {
   x: number
@@ -17,20 +24,12 @@ interface ElectronEmbeddedBrowserViewProps {
   active: boolean
   interactionBlocked: boolean
   label: string
+  transferFromLabel?: string
   visualRect: BrowserVisualRect | null
   cursor?: EmbeddedBrowserAgentCursorEvent | null
   cursorScale?: number
 }
 
-interface ElectronWebviewElement extends HTMLElement {
-  destroy?: () => void
-}
-
-const WEBVIEW_HOST_ROOT_ATTRIBUTE = 'data-wework-browser-webview-host-root'
-const ROUTE_PARTITION_PREFIX = 'persist:wework-browser-app-route:'
-const ROUTE_HOST_SEPARATOR = ':host:'
-const rendererInstanceId = getRendererInstanceId()
-let nextHostGeneration = 0
 const CURSOR_FADE_MS = 180
 const CURSOR_CURVE_THRESHOLD = 196
 const CURSOR_SPRING_DAMPING = 0.9
@@ -41,122 +40,72 @@ interface CursorPoint {
   y: number
 }
 
-function getRendererInstanceId() {
-  const storageKey = 'wework.browser.renderer-instance-id'
-  const stored = window.sessionStorage.getItem(storageKey)
-  if (stored) return stored
-  const id =
-    typeof window.crypto?.randomUUID === 'function'
-      ? window.crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
-  window.sessionStorage.setItem(storageKey, id)
-  return id
-}
-
-function getWebviewHostRoot() {
-  const existing = document.querySelector<HTMLElement>(`[${WEBVIEW_HOST_ROOT_ATTRIBUTE}]`)
-  if (existing) return existing
-  const root = document.createElement('div')
-  root.setAttribute(WEBVIEW_HOST_ROOT_ATTRIBUTE, '')
-  Object.assign(root.style, {
-    inset: '0',
-    overflow: 'visible',
-    pointerEvents: 'none',
-    position: 'fixed',
-    zIndex: '10',
-  })
-  document.body.append(root)
-  return root
-}
-
-function routePartition(label: string, hostGeneration: number) {
-  const route = `${ROUTE_PARTITION_PREFIX}${encodeURIComponent(`wework\0${label}`)}`
-  return `${route}${ROUTE_HOST_SEPARATOR}${rendererInstanceId}:${hostGeneration}`
-}
-
 export function ElectronEmbeddedBrowserView({
   active,
   interactionBlocked,
   label,
+  transferFromLabel,
   visualRect,
   cursor = null,
   cursorScale = 1,
 }: ElectronEmbeddedBrowserViewProps) {
   const placeholderRef = useRef<HTMLDivElement | null>(null)
   const initialLabelRef = useRef(label)
-  const containerRef = useRef<HTMLDivElement | null>(null)
+  const initialTransferFromLabelRef = useRef(transferFromLabel)
+  const hostRef = useRef<HostedElectronWebview | null>(null)
+  const ownerRef = useRef(Symbol('electron-embedded-browser-view'))
   const [cursorOverlayHost, setCursorOverlayHost] = useState<HTMLDivElement | null>(null)
 
   useLayoutEffect(() => {
     const placeholder = placeholderRef.current
     if (!placeholder) return
-    const container = document.createElement('div')
-    const webview = document.createElement('webview') as ElectronWebviewElement
-    const cursorHost = document.createElement('div')
-    const hostGeneration = ++nextHostGeneration
-    container.dataset.testid = 'workspace-browser-electron-webview'
-    container.dataset.weworkBrowserWebview = initialLabelRef.current
-    webview.setAttribute('data-wework-browser-label', initialLabelRef.current)
-    webview.setAttribute('data-browser-sidebar-conversation-id', 'wework')
-    webview.setAttribute('data-browser-sidebar-browser-tab-id', initialLabelRef.current)
-    webview.setAttribute('allowpopups', 'true')
-    webview.setAttribute('partition', routePartition(initialLabelRef.current, hostGeneration))
-    webview.setAttribute('src', 'about:blank')
-    webview.setAttribute('webviewrole', 'tab')
-    webview.setAttribute('aria-label', 'Wework built-in browser content')
-    Object.assign(webview.style, {
-      display: 'flex',
-      height: '100%',
-      width: '100%',
-    })
-    Object.assign(container.style, {
-      overflow: 'hidden',
-      position: 'fixed',
-    })
-    cursorHost.dataset.testid = 'workspace-browser-agent-cursor-overlay'
-    Object.assign(cursorHost.style, {
-      inset: '0',
-      pointerEvents: 'none',
-      position: 'absolute',
-      zIndex: '1',
-    })
-    container.append(webview, cursorHost)
-    getWebviewHostRoot().append(container)
-    containerRef.current = container
-    setCursorOverlayHost(cursorHost)
+    const owner = ownerRef.current
+    const host = claimElectronEmbeddedBrowserView(
+      initialLabelRef.current,
+      owner,
+      initialTransferFromLabelRef.current
+    )
+    hostRef.current = host
+    setCursorOverlayHost(host.cursorHost)
 
     const syncBounds = () => {
+      if (host.owner !== owner) return
       const rect = placeholder.getBoundingClientRect()
-      Object.assign(container.style, {
+      Object.assign(host.container.style, {
         height: `${Math.max(0, rect.height)}px`,
         left: `${rect.left}px`,
         top: `${rect.top}px`,
         width: `${Math.max(0, rect.width)}px`,
       })
     }
+
     syncBounds()
+    const handleViewportChange = () => syncBounds()
     const resizeObserver =
-      typeof ResizeObserver === 'function' ? new ResizeObserver(syncBounds) : null
+      typeof ResizeObserver === 'function' ? new ResizeObserver(handleViewportChange) : null
     resizeObserver?.observe(placeholder)
-    window.addEventListener('resize', syncBounds)
-    window.addEventListener('scroll', syncBounds, true)
+    window.addEventListener('resize', handleViewportChange)
+    window.addEventListener('scroll', handleViewportChange, true)
     return () => {
       resizeObserver?.disconnect()
-      window.removeEventListener('resize', syncBounds)
-      window.removeEventListener('scroll', syncBounds, true)
-      containerRef.current = null
+      window.removeEventListener('resize', handleViewportChange)
+      window.removeEventListener('scroll', handleViewportChange, true)
+      hostRef.current = null
       setCursorOverlayHost(null)
-      if (typeof webview.destroy === 'function') webview.destroy()
-      else webview.remove()
-      container.remove()
+      releaseElectronEmbeddedBrowserView(host, owner)
     }
   }, [])
 
   useLayoutEffect(() => {
-    const container = containerRef.current
-    if (!container) return
-    container.style.pointerEvents = interactionBlocked ? 'none' : 'auto'
-    container.style.visibility = active ? 'visible' : 'hidden'
+    const host = hostRef.current
+    if (!host) return
+    relabelElectronEmbeddedBrowserView(host, ownerRef.current, label)
+  }, [label])
+
+  useLayoutEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    syncElectronEmbeddedBrowserView(host, ownerRef.current, active, interactionBlocked)
   }, [active, interactionBlocked])
 
   return (

--- a/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
+++ b/wework/src/components/layout/workspace-panels/ElectronEmbeddedBrowserView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type MutableRefObject } from 'react'
 import { createPortal } from 'react-dom'
 import {
+  listenEmbeddedBrowserCloseRequests,
   notifyEmbeddedBrowserAgentCursorArrived,
   type EmbeddedBrowserAgentCursorEvent,
 } from '@/lib/embedded-browser'
@@ -10,6 +11,7 @@ import {
   positionElectronEmbeddedBrowserView,
   relabelElectronEmbeddedBrowserView,
   releaseElectronEmbeddedBrowserView,
+  resetElectronEmbeddedBrowserView,
   syncElectronEmbeddedBrowserView,
   type HostedElectronWebview,
 } from './electronEmbeddedBrowserHost'
@@ -54,6 +56,7 @@ export function ElectronEmbeddedBrowserView({
   const initialLabelRef = useRef(label)
   const initialTransferFromLabelRef = useRef(transferFromLabel)
   const hostRef = useRef<HostedElectronWebview | null>(null)
+  const labelRef = useRef(label)
   const ownerRef = useRef(Symbol('electron-embedded-browser-view'))
   const [cursorOverlayHost, setCursorOverlayHost] = useState<HTMLDivElement | null>(null)
 
@@ -97,6 +100,7 @@ export function ElectronEmbeddedBrowserView({
   }, [])
 
   useLayoutEffect(() => {
+    labelRef.current = label
     const host = hostRef.current
     if (!host) return
     relabelElectronEmbeddedBrowserView(host, ownerRef.current, label)
@@ -107,6 +111,29 @@ export function ElectronEmbeddedBrowserView({
     if (!host) return
     syncElectronEmbeddedBrowserView(host, ownerRef.current, active, interactionBlocked)
   }, [active, interactionBlocked])
+
+  useEffect(() => {
+    const listener = listenEmbeddedBrowserCloseRequests(event => {
+      if (event.label !== labelRef.current) return
+      const host = hostRef.current
+      if (!host) return
+      resetElectronEmbeddedBrowserView(host, ownerRef.current)
+    })
+    if (!listener) return undefined
+    let disposed = false
+    let unlisten: (() => void) | null = null
+    void listener.then(nextUnlisten => {
+      if (disposed) {
+        nextUnlisten()
+        return
+      }
+      unlisten = nextUnlisten
+    })
+    return () => {
+      disposed = true
+      unlisten?.()
+    }
+  }, [])
 
   return (
     <>

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+import { RightWorkspacePanel } from './RightWorkspacePanel'
+
+vi.mock('./WorkspaceBrowserPanelContainer', () => ({
+  WorkspaceBrowserPanel: ({
+    active,
+    transferredUrl,
+    onUrlChange,
+  }: {
+    active: boolean
+    transferredUrl?: string | null
+    onUrlChange?: (url: string | null) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="workspace-browser-panel"
+      data-active={String(active)}
+      data-transferred-url={transferredUrl ?? ''}
+      onClick={() => onUrlChange?.('https://example.test/next')}
+    />
+  ),
+}))
+
+vi.mock('./WorkspaceAddMenu', () => ({
+  WorkspaceAddMenu: () => <button data-testid="right-workspace-new-tab-button" />,
+}))
+
+const browserState = {
+  label: 'workspace-browser-runtime-1',
+  browserSessionId: '1',
+  url: 'https://www.baidu.com/',
+  title: 'Baidu',
+  faviconUrl: null,
+  isLoading: false,
+  hasActiveDownload: false,
+  openRequest: null,
+}
+
+function renderPanel(overrides: Partial<ComponentProps<typeof RightWorkspacePanel>> = {}) {
+  const noop = vi.fn()
+  return render(
+    <RightWorkspacePanel
+      visible
+      renderTabsInAppTitlebar={false}
+      activeView="browser:1"
+      openTabs={['browser:1']}
+      currentProject={null}
+      canBrowseFiles
+      currentRuntimeTask={null}
+      devices={[]}
+      workspaceTarget={null}
+      workspaceFileApi={{} as ComponentProps<typeof RightWorkspacePanel>['workspaceFileApi']}
+      workspaceTargetError="Workspace is not ready"
+      review={{ loading: false, diff: '' }}
+      extensionScope={{ sessionId: 'test' }}
+      browserStates={{ 'browser:1': browserState }}
+      onBrowserStateChange={noop}
+      canOpenReview={false}
+      onAddCodeComment={noop}
+      onSelectReview={noop}
+      onSelectTerminal={noop}
+      onSelectBrowser={noop}
+      onSelectFiles={noop}
+      onSelectChat={noop}
+      onSelectPlan={noop}
+      onSelectTab={noop}
+      onCloseTab={noop}
+      {...overrides}
+    />
+  )
+}
+
+describe('RightWorkspacePanel workspace target errors', () => {
+  test('does not mount the file error beside an active browser', () => {
+    renderPanel()
+
+    expect(screen.getByTestId('workspace-browser-panel')).toHaveAttribute('data-active', 'true')
+    expect(screen.queryByTestId('workspace-target-error')).not.toBeInTheDocument()
+    expect(screen.queryByText('Workspace is not ready')).not.toBeInTheDocument()
+  })
+
+  test('passes the transferred URL into the first browser render', () => {
+    const onBrowserStateChange = vi.fn()
+    renderPanel({
+      browserTransferSourceLabels: { 'browser:1': 'workspace-browser-blank-0' },
+      onBrowserStateChange,
+    })
+
+    const browserPanel = screen.getByTestId('workspace-browser-panel')
+    expect(browserPanel).toHaveAttribute('data-transferred-url', 'https://www.baidu.com/')
+    browserPanel.click()
+    expect(onBrowserStateChange).toHaveBeenCalledWith('browser:1', {
+      url: 'https://example.test/next',
+    })
+  })
+
+  test('shows the workspace target error on the files tab', () => {
+    renderPanel({
+      activeView: 'files',
+      openTabs: ['files'],
+      browserStates: {},
+    })
+
+    expect(screen.getByTestId('workspace-target-error')).toHaveTextContent('Workspace is not ready')
+  })
+})

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -130,6 +130,7 @@ export interface RightWorkspaceBrowserState {
   label: string
   nativeLabel?: string | null
   browserSessionId: string
+  url: string | null
   title: string | null
   faviconUrl: string | null
   isLoading: boolean
@@ -186,6 +187,7 @@ interface RightWorkspacePanelProps {
   extensionTabs?: Partial<Record<RightWorkspaceExtensionTab, RightWorkspaceExtensionTabState>>
   extensionScope: WeworkWorkspaceScope
   browserStates: Partial<Record<RightWorkspaceBrowserTab, RightWorkspaceBrowserState>>
+  browserTransferSourceLabels?: Partial<Record<RightWorkspaceBrowserTab, string>>
   onBrowserStateChange: (
     tab: RightWorkspaceBrowserTab,
     update: Partial<RightWorkspaceBrowserState>
@@ -233,6 +235,7 @@ interface RightWorkspaceBrowserPanelSlotProps {
   tab: RightWorkspaceBrowserTab
   active: boolean
   state: RightWorkspaceBrowserState
+  transferFromLabel?: string
   codeCommentCount: number
   codeCommentContexts: CodeCommentContext[]
   browserAnnotationCommand?: BrowserAnnotationCommand | null
@@ -252,6 +255,7 @@ function RightWorkspaceBrowserPanelSlot({
   tab,
   active,
   state,
+  transferFromLabel,
   codeCommentCount,
   codeCommentContexts,
   browserAnnotationCommand,
@@ -284,12 +288,19 @@ function RightWorkspaceBrowserPanelSlot({
     (nativeLabel: string | null) => onBrowserStateChange(tab, { nativeLabel }),
     [onBrowserStateChange, tab]
   )
+  const handleUrlChange = useCallback(
+    (url: string | null) => onBrowserStateChange(tab, { url }),
+    [onBrowserStateChange, tab]
+  )
 
   return (
     <WorkspaceBrowserPanel
       active={active}
       hideToolbar={Boolean(state.developmentPreview)}
       label={state.label}
+      transferFromLabel={transferFromLabel}
+      transferredNativeLabel={transferFromLabel ? state.nativeLabel : null}
+      transferredUrl={transferFromLabel ? state.url : null}
       browserTabId={tab}
       openRequest={state.openRequest}
       codeCommentCount={codeCommentCount}
@@ -304,6 +315,7 @@ function RightWorkspaceBrowserPanelSlot({
       onAgentActiveChange={handleAgentActiveChange}
       onTitleChange={handleTitleChange}
       onNativeLabelChange={handleNativeLabelChange}
+      onUrlChange={handleUrlChange}
     />
   )
 }
@@ -378,6 +390,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
   extensionTabs = {},
   extensionScope,
   browserStates,
+  browserTransferSourceLabels = {},
   onBrowserStateChange,
   onReloadSmartAppDevelopmentPreview,
   onAddSmartAppDevelopmentPlugin,
@@ -668,10 +681,9 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
           <PlanWorkspacePanel content={planContent ?? ''} />
         ) : !isRightWorkspaceChatTab(activeView) && activeView === 'work-item' ? (
           workItemPanel
-        ) : !isRightWorkspaceChatTab(activeView) && workspaceTargetError ? (
+        ) : activeView === 'files' && workspaceTargetError ? (
           <section
             data-testid="workspace-target-error"
-            hidden={activeView !== 'files'}
             className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-sm text-red-500"
           >
             {workspaceTargetError}
@@ -751,6 +763,7 @@ export const RightWorkspacePanel = memo(function RightWorkspacePanel({
               tab={tab}
               active={visible && activeView === tab}
               state={browserState}
+              transferFromLabel={browserTransferSourceLabels[tab]}
               codeCommentCount={codeCommentCount}
               codeCommentContexts={codeCommentContexts}
               browserAnnotationCommand={browserAnnotationCommand}

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -260,6 +260,26 @@ describe('WorkspaceBrowserPanel', () => {
     expect(screen.getByTestId('workspace-browser-url-input')).toHaveAttribute('spellcheck', 'false')
   })
 
+  test('renders a transferred page on the first frame without reopening the browser', async () => {
+    render(
+      <WorkspaceBrowserPanel
+        active
+        label="workspace-browser-runtime-1"
+        transferFromLabel="workspace-browser-blank-0"
+        transferredNativeLabel="workspace-browser-native-1"
+        transferredUrl="https://www.baidu.com/"
+      />
+    )
+
+    expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://www.baidu.com/')
+    expect(screen.getByTestId('workspace-browser-native-view')).toBeInTheDocument()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(embeddedBrowserMocks.openEmbeddedBrowser).not.toHaveBeenCalled()
+  })
+
   test('clears cookies from the browser actions submenu and reports completion', async () => {
     render(<WorkspaceBrowserPanel active />)
 

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -183,6 +183,9 @@ export interface WorkspaceBrowserPanelProps {
   active: boolean
   hideToolbar?: boolean
   label?: string
+  transferFromLabel?: string
+  transferredNativeLabel?: string | null
+  transferredUrl?: string | null
   browserTabId?: string
   openRequest?: EmbeddedBrowserOpenRequest | null
   codeCommentCount?: number
@@ -200,6 +203,7 @@ export interface WorkspaceBrowserPanelProps {
   onLoadingChange?: (isLoading: boolean) => void
   onTitleChange?: (title: string | null) => void
   onAgentActiveChange?: (agentActive: boolean) => void
+  onUrlChange?: (url: string | null) => void
 }
 
 export const WorkspaceBrowserPanel = WorkspaceBrowserTabPanel
@@ -341,6 +345,9 @@ export function WorkspaceBrowserTabPanel({
   active,
   hideToolbar = false,
   label = 'workspace-browser',
+  transferFromLabel,
+  transferredNativeLabel,
+  transferredUrl,
   browserTabId = label,
   openRequest,
   codeCommentCount = 0,
@@ -355,23 +362,29 @@ export function WorkspaceBrowserTabPanel({
   onLoadingChange,
   onTitleChange,
   onAgentActiveChange,
+  onUrlChange,
 }: WorkspaceBrowserPanelProps) {
   const { t } = useTranslation('common')
   const electronRuntime = isElectronRuntime()
   const browserPanelRef = useRef<HTMLDivElement | null>(null)
   const browserHostRef = useRef<HTMLDivElement | null>(null)
-  const nativeBrowserOpenRef = useRef(false)
+  const initialTransferredUrl = transferFromLabel ? (transferredUrl ?? null) : null
+  const nativeBrowserOpenRef = useRef(Boolean(initialTransferredUrl))
   const nativeBrowserOpeningRef = useRef(false)
-  const currentUrlRef = useRef<string | null>(null)
+  const currentUrlRef = useRef<string | null>(initialTransferredUrl)
   const pendingNavigationUrlRef = useRef<string | null>(null)
-  const activePageUrlRef = useRef<string | null>(null)
+  const activePageUrlRef = useRef<string | null>(initialTransferredUrl)
   const addressInputRef = useRef<HTMLInputElement | null>(null)
   const addressEditingRef = useRef(false)
   const annotationModeRef = useRef(false)
   const currentLabelRef = useRef(label)
   const activeRef = useRef(active)
-  const nativeLabelRef = useRef<string | null>(null)
-  const adoptedDownloadOwnerLabelRef = useRef<string | null>(null)
+  const nativeLabelRef = useRef<string | null>(
+    initialTransferredUrl ? (transferredNativeLabel ?? null) : null
+  )
+  const adoptedDownloadOwnerLabelRef = useRef<string | null>(
+    initialTransferredUrl && transferredNativeLabel ? label : null
+  )
   const trackedTerminalDownloadIdsRef = useRef(new Set<string>())
   const activeDownloadIdsRef = useRef(new Set<string>())
   const mountedRef = useRef(true)
@@ -397,11 +410,11 @@ export function WorkspaceBrowserTabPanel({
   const occlusionSnapshotReadyRef = useRef(true)
   const occlusionSnapshotFallbackTimerRef = useRef<number | null>(null)
   const embeddedBrowserOccludedRef = useRef(false)
-  const [address, setAddress] = useState('')
-  const [currentUrl, setCurrentUrl] = useState<string | null>(null)
+  const [address, setAddress] = useState(initialTransferredUrl ?? '')
+  const [currentUrl, setCurrentUrl] = useState<string | null>(initialTransferredUrl)
   const [browserOpenAttempt, setBrowserOpenAttempt] = useState(0)
-  const [pageUrl, setPageUrl] = useState<string | null>(null)
-  const [status, setStatus] = useState<BrowserStatus>('idle')
+  const [pageUrl, setPageUrl] = useState<string | null>(initialTransferredUrl)
+  const [status, setStatus] = useState<BrowserStatus>(initialTransferredUrl ? 'ready' : 'idle')
   const [error, setError] = useState<string | null>(null)
   const [navigationError, setNavigationError] = useState<EmbeddedBrowserNavigationError | null>(
     null
@@ -733,6 +746,7 @@ export function WorkspaceBrowserTabPanel({
       setCurrentUrl(null)
       setPageUrl(null)
       setAddress('')
+      onUrlChange?.(null)
       setStatus('ready')
       setError(null)
       setInvalidTlsCertificate(null)
@@ -767,7 +781,7 @@ export function WorkspaceBrowserTabPanel({
       disposed = true
       unlisten?.()
     }
-  }, [onDownloadActivityChange, onFaviconChange, onNativeLabelChange, onTitleChange])
+  }, [onDownloadActivityChange, onFaviconChange, onNativeLabelChange, onTitleChange, onUrlChange])
 
   useEffect(() => {
     if (!active || !nativeLabelRef.current) return
@@ -780,6 +794,7 @@ export function WorkspaceBrowserTabPanel({
       if (pendingNavigationUrl && url && url !== pendingNavigationUrl) return
       activePageUrlRef.current = url
       setPageUrl(url)
+      onUrlChange?.(url)
       if (url) {
         if (!addressEditingRef.current && document.activeElement !== addressInputRef.current) {
           setAddress(url)
@@ -792,7 +807,7 @@ export function WorkspaceBrowserTabPanel({
       onTitleChange?.(null)
       onFaviconChange?.(null)
     },
-    [onFaviconChange, onTitleChange]
+    [onFaviconChange, onTitleChange, onUrlChange]
   )
 
   useEffect(() => {
@@ -2933,6 +2948,7 @@ export function WorkspaceBrowserTabPanel({
                 }
                 interactionBlocked={embeddedBrowserOccluded || Boolean(navigationError)}
                 label={label}
+                transferFromLabel={transferFromLabel}
                 visualRect={deviceVisualRect}
               />
             ) : active &&

--- a/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
+++ b/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
@@ -142,7 +142,12 @@ function connectedHostedWebview(label: string): HostedElectronWebview | null {
 function assignHostedWebviewLabel(host: HostedElectronWebview, label: string): void {
   if (host.label === label) return
   const existing = connectedHostedWebview(label)
-  if (existing && existing !== host) destroyHostedWebview(existing)
+  if (existing && existing !== host) {
+    if (existing.owner !== null || existing.claims.length > 0) {
+      throw new Error(`Embedded browser label already has an active host: ${label}`)
+    }
+    destroyHostedWebview(existing)
+  }
   if (hostedWebviews.get(host.label) === host) hostedWebviews.delete(host.label)
   host.label = label
   host.container.dataset.weworkBrowserWebview = label
@@ -229,8 +234,8 @@ export function releaseElectronEmbeddedBrowserView(
     return
   }
   host.container.style.pointerEvents = 'none'
-  if (host.retained) return
   host.container.style.visibility = 'hidden'
+  if (host.retained) return
   queueMicrotask(() => {
     if (host.owner !== null || host.retained) return
     destroyHostedWebview(host)

--- a/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
+++ b/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
@@ -2,7 +2,22 @@ interface ElectronWebviewElement extends HTMLElement {
   destroy?: () => void
 }
 
+interface HostedElectronWebviewClaim {
+  active: boolean
+  bounds: ElectronEmbeddedBrowserBounds | null
+  interactionBlocked: boolean
+  owner: symbol
+}
+
+export interface ElectronEmbeddedBrowserBounds {
+  height: number
+  left: number
+  top: number
+  width: number
+}
+
 export interface HostedElectronWebview {
+  claims: HostedElectronWebviewClaim[]
   container: HTMLDivElement
   cursorHost: HTMLDivElement
   destroyed: boolean
@@ -88,6 +103,7 @@ function createHostedWebview(label: string): HostedElectronWebview {
   container.append(webview, cursorHost)
   getWebviewHostRoot().append(container)
   return {
+    claims: [],
     container,
     cursorHost,
     destroyed: false,
@@ -135,6 +151,46 @@ function assignHostedWebviewLabel(host: HostedElectronWebview, label: string): v
   hostedWebviews.set(label, host)
 }
 
+function currentClaim(host: HostedElectronWebview): HostedElectronWebviewClaim | null {
+  return host.claims.at(-1) ?? null
+}
+
+function applyClaim(host: HostedElectronWebview, claim: HostedElectronWebviewClaim): void {
+  if (claim.bounds) {
+    Object.assign(host.container.style, {
+      height: `${claim.bounds.height}px`,
+      left: `${claim.bounds.left}px`,
+      top: `${claim.bounds.top}px`,
+      width: `${claim.bounds.width}px`,
+    })
+  }
+  host.container.style.pointerEvents = claim.interactionBlocked ? 'none' : 'auto'
+  host.container.style.visibility = claim.active ? 'visible' : 'hidden'
+}
+
+function claimForOwner(
+  host: HostedElectronWebview,
+  owner: symbol
+): HostedElectronWebviewClaim | null {
+  return host.claims.find(claim => claim.owner === owner) ?? null
+}
+
+function assignOwner(host: HostedElectronWebview, owner: symbol): void {
+  const existingClaim = claimForOwner(host, owner)
+  if (existingClaim) {
+    host.claims = host.claims.filter(claim => claim !== existingClaim)
+    host.claims.push(existingClaim)
+  } else {
+    host.claims.push({
+      active: false,
+      bounds: null,
+      interactionBlocked: true,
+      owner,
+    })
+  }
+  host.owner = owner
+}
+
 export function claimElectronEmbeddedBrowserView(
   label: string,
   owner: symbol,
@@ -146,13 +202,13 @@ export function claimElectronEmbeddedBrowserView(
   if (existing) {
     assignHostedWebviewLabel(existing, label)
     clearRetentionTimeout(existing)
-    existing.owner = owner
+    assignOwner(existing, owner)
     existing.retained = false
     return existing
   }
 
   const host = createHostedWebview(label)
-  host.owner = owner
+  assignOwner(host, owner)
   hostedWebviews.set(label, host)
   return host
 }
@@ -161,8 +217,17 @@ export function releaseElectronEmbeddedBrowserView(
   host: HostedElectronWebview,
   owner: symbol
 ): void {
-  if (host.owner !== owner) return
-  host.owner = null
+  const claim = claimForOwner(host, owner)
+  if (!claim) return
+  const wasCurrentOwner = host.owner === owner
+  host.claims = host.claims.filter(candidate => candidate !== claim)
+  if (!wasCurrentOwner) return
+  const nextClaim = currentClaim(host)
+  host.owner = nextClaim?.owner ?? null
+  if (nextClaim) {
+    applyClaim(host, nextClaim)
+    return
+  }
   host.container.style.pointerEvents = 'none'
   if (host.retained) return
   host.container.style.visibility = 'hidden'
@@ -181,15 +246,28 @@ export function relabelElectronEmbeddedBrowserView(
   assignHostedWebviewLabel(host, label)
 }
 
+export function positionElectronEmbeddedBrowserView(
+  host: HostedElectronWebview,
+  owner: symbol,
+  bounds: ElectronEmbeddedBrowserBounds
+): void {
+  const claim = claimForOwner(host, owner)
+  if (!claim || bounds.width <= 0 || bounds.height <= 0) return
+  claim.bounds = bounds
+  if (host.owner === owner) applyClaim(host, claim)
+}
+
 export function syncElectronEmbeddedBrowserView(
   host: HostedElectronWebview,
   owner: symbol,
   active: boolean,
   interactionBlocked: boolean
 ): void {
-  if (host.owner !== owner) return
-  host.container.style.pointerEvents = interactionBlocked ? 'none' : 'auto'
-  host.container.style.visibility = active ? 'visible' : 'hidden'
+  const claim = claimForOwner(host, owner)
+  if (!claim) return
+  claim.active = active
+  claim.interactionBlocked = interactionBlocked
+  if (host.owner === owner) applyClaim(host, claim)
 }
 
 export function retainElectronEmbeddedBrowserView(label: string): void {

--- a/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
+++ b/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
@@ -69,13 +69,9 @@ function routePartition(label: string, hostGeneration: number) {
   return `${route}${ROUTE_HOST_SEPARATOR}${rendererInstanceId}:${hostGeneration}`
 }
 
-function createHostedWebview(label: string): HostedElectronWebview {
-  const container = document.createElement('div')
+function createElectronWebview(label: string): ElectronWebviewElement {
   const webview = document.createElement('webview') as ElectronWebviewElement
-  const cursorHost = document.createElement('div')
   const hostGeneration = ++nextHostGeneration
-  container.dataset.testid = 'workspace-browser-electron-webview'
-  container.dataset.weworkBrowserWebview = label
   webview.setAttribute('data-wework-browser-label', label)
   webview.setAttribute('data-browser-sidebar-conversation-id', 'wework')
   webview.setAttribute('data-browser-sidebar-browser-tab-id', label)
@@ -89,6 +85,15 @@ function createHostedWebview(label: string): HostedElectronWebview {
     height: '100%',
     width: '100%',
   })
+  return webview
+}
+
+function createHostedWebview(label: string): HostedElectronWebview {
+  const container = document.createElement('div')
+  const webview = createElectronWebview(label)
+  const cursorHost = document.createElement('div')
+  container.dataset.testid = 'workspace-browser-electron-webview'
+  container.dataset.weworkBrowserWebview = label
   Object.assign(container.style, {
     overflow: 'hidden',
     position: 'fixed',
@@ -121,13 +126,17 @@ function clearRetentionTimeout(host: HostedElectronWebview) {
   host.retentionTimeout = null
 }
 
+function destroyElectronWebview(webview: ElectronWebviewElement): void {
+  if (typeof webview.destroy === 'function') webview.destroy()
+  webview.remove()
+}
+
 function destroyHostedWebview(host: HostedElectronWebview) {
   if (host.destroyed) return
   host.destroyed = true
   clearRetentionTimeout(host)
   if (hostedWebviews.get(host.label) === host) hostedWebviews.delete(host.label)
-  if (typeof host.webview.destroy === 'function') host.webview.destroy()
-  else host.webview.remove()
+  destroyElectronWebview(host.webview)
   host.container.remove()
 }
 
@@ -249,6 +258,15 @@ export function relabelElectronEmbeddedBrowserView(
 ): void {
   if (host.owner !== owner || host.label === label) return
   assignHostedWebviewLabel(host, label)
+}
+
+export function resetElectronEmbeddedBrowserView(host: HostedElectronWebview, owner: symbol): void {
+  if (host.destroyed || host.owner !== owner) return
+  const previousWebview = host.webview
+  const nextWebview = createElectronWebview(host.label)
+  host.webview = nextWebview
+  destroyElectronWebview(previousWebview)
+  host.container.insertBefore(nextWebview, host.cursorHost)
 }
 
 export function positionElectronEmbeddedBrowserView(

--- a/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
+++ b/wework/src/components/layout/workspace-panels/electronEmbeddedBrowserHost.ts
@@ -1,0 +1,205 @@
+interface ElectronWebviewElement extends HTMLElement {
+  destroy?: () => void
+}
+
+export interface HostedElectronWebview {
+  container: HTMLDivElement
+  cursorHost: HTMLDivElement
+  destroyed: boolean
+  label: string
+  owner: symbol | null
+  retained: boolean
+  retentionTimeout: number | null
+  webview: ElectronWebviewElement
+}
+
+const WEBVIEW_HOST_ROOT_ATTRIBUTE = 'data-wework-browser-webview-host-root'
+const ROUTE_PARTITION_PREFIX = 'persist:wework-browser-app-route:'
+const ROUTE_HOST_SEPARATOR = ':host:'
+const WEBVIEW_TRANSFER_RETENTION_MS = 6_000
+const rendererInstanceId = getRendererInstanceId()
+const hostedWebviews = new Map<string, HostedElectronWebview>()
+let nextHostGeneration = 0
+
+function getRendererInstanceId() {
+  const storageKey = 'wework.browser.renderer-instance-id'
+  const stored = window.sessionStorage.getItem(storageKey)
+  if (stored) return stored
+  const id =
+    typeof window.crypto?.randomUUID === 'function'
+      ? window.crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  window.sessionStorage.setItem(storageKey, id)
+  return id
+}
+
+function getWebviewHostRoot() {
+  const existing = document.querySelector<HTMLElement>(`[${WEBVIEW_HOST_ROOT_ATTRIBUTE}]`)
+  if (existing) return existing
+  const root = document.createElement('div')
+  root.setAttribute(WEBVIEW_HOST_ROOT_ATTRIBUTE, '')
+  Object.assign(root.style, {
+    inset: '0',
+    overflow: 'visible',
+    pointerEvents: 'none',
+    position: 'fixed',
+    zIndex: '10',
+  })
+  document.body.append(root)
+  return root
+}
+
+function routePartition(label: string, hostGeneration: number) {
+  const route = `${ROUTE_PARTITION_PREFIX}${encodeURIComponent(`wework\0${label}`)}`
+  return `${route}${ROUTE_HOST_SEPARATOR}${rendererInstanceId}:${hostGeneration}`
+}
+
+function createHostedWebview(label: string): HostedElectronWebview {
+  const container = document.createElement('div')
+  const webview = document.createElement('webview') as ElectronWebviewElement
+  const cursorHost = document.createElement('div')
+  const hostGeneration = ++nextHostGeneration
+  container.dataset.testid = 'workspace-browser-electron-webview'
+  container.dataset.weworkBrowserWebview = label
+  webview.setAttribute('data-wework-browser-label', label)
+  webview.setAttribute('data-browser-sidebar-conversation-id', 'wework')
+  webview.setAttribute('data-browser-sidebar-browser-tab-id', label)
+  webview.setAttribute('allowpopups', 'true')
+  webview.setAttribute('partition', routePartition(label, hostGeneration))
+  webview.setAttribute('src', 'about:blank')
+  webview.setAttribute('webviewrole', 'tab')
+  webview.setAttribute('aria-label', 'Wework built-in browser content')
+  Object.assign(webview.style, {
+    display: 'flex',
+    height: '100%',
+    width: '100%',
+  })
+  Object.assign(container.style, {
+    overflow: 'hidden',
+    position: 'fixed',
+  })
+  cursorHost.dataset.testid = 'workspace-browser-agent-cursor-overlay'
+  Object.assign(cursorHost.style, {
+    inset: '0',
+    pointerEvents: 'none',
+    position: 'absolute',
+    zIndex: '1',
+  })
+  container.append(webview, cursorHost)
+  getWebviewHostRoot().append(container)
+  return {
+    container,
+    cursorHost,
+    destroyed: false,
+    label,
+    owner: null,
+    retained: false,
+    retentionTimeout: null,
+    webview,
+  }
+}
+
+function clearRetentionTimeout(host: HostedElectronWebview) {
+  if (host.retentionTimeout === null) return
+  window.clearTimeout(host.retentionTimeout)
+  host.retentionTimeout = null
+}
+
+function destroyHostedWebview(host: HostedElectronWebview) {
+  if (host.destroyed) return
+  host.destroyed = true
+  clearRetentionTimeout(host)
+  if (hostedWebviews.get(host.label) === host) hostedWebviews.delete(host.label)
+  if (typeof host.webview.destroy === 'function') host.webview.destroy()
+  else host.webview.remove()
+  host.container.remove()
+}
+
+function connectedHostedWebview(label: string): HostedElectronWebview | null {
+  const candidate = hostedWebviews.get(label)
+  if (!candidate) return null
+  if (!candidate.destroyed && candidate.container.isConnected) return candidate
+  hostedWebviews.delete(label)
+  return null
+}
+
+function assignHostedWebviewLabel(host: HostedElectronWebview, label: string): void {
+  if (host.label === label) return
+  const existing = connectedHostedWebview(label)
+  if (existing && existing !== host) destroyHostedWebview(existing)
+  if (hostedWebviews.get(host.label) === host) hostedWebviews.delete(host.label)
+  host.label = label
+  host.container.dataset.weworkBrowserWebview = label
+  host.webview.setAttribute('data-wework-browser-label', label)
+  host.webview.setAttribute('data-browser-sidebar-browser-tab-id', label)
+  hostedWebviews.set(label, host)
+}
+
+export function claimElectronEmbeddedBrowserView(
+  label: string,
+  owner: symbol,
+  transferFromLabel?: string
+): HostedElectronWebview {
+  const existing =
+    connectedHostedWebview(label) ??
+    (transferFromLabel ? connectedHostedWebview(transferFromLabel) : null)
+  if (existing) {
+    assignHostedWebviewLabel(existing, label)
+    clearRetentionTimeout(existing)
+    existing.owner = owner
+    existing.retained = false
+    return existing
+  }
+
+  const host = createHostedWebview(label)
+  host.owner = owner
+  hostedWebviews.set(label, host)
+  return host
+}
+
+export function releaseElectronEmbeddedBrowserView(
+  host: HostedElectronWebview,
+  owner: symbol
+): void {
+  if (host.owner !== owner) return
+  host.owner = null
+  host.container.style.pointerEvents = 'none'
+  if (host.retained) return
+  host.container.style.visibility = 'hidden'
+  queueMicrotask(() => {
+    if (host.owner !== null || host.retained) return
+    destroyHostedWebview(host)
+  })
+}
+
+export function relabelElectronEmbeddedBrowserView(
+  host: HostedElectronWebview,
+  owner: symbol,
+  label: string
+): void {
+  if (host.owner !== owner || host.label === label) return
+  assignHostedWebviewLabel(host, label)
+}
+
+export function syncElectronEmbeddedBrowserView(
+  host: HostedElectronWebview,
+  owner: symbol,
+  active: boolean,
+  interactionBlocked: boolean
+): void {
+  if (host.owner !== owner) return
+  host.container.style.pointerEvents = interactionBlocked ? 'none' : 'auto'
+  host.container.style.visibility = active ? 'visible' : 'hidden'
+}
+
+export function retainElectronEmbeddedBrowserView(label: string): void {
+  const host = hostedWebviews.get(label)
+  if (!host || host.destroyed || !host.container.isConnected) return
+  host.retained = true
+  clearRetentionTimeout(host)
+  host.retentionTimeout = window.setTimeout(() => {
+    host.retentionTimeout = null
+    host.retained = false
+    if (host.owner === null) destroyHostedWebview(host)
+  }, WEBVIEW_TRANSFER_RETENTION_MS)
+}

--- a/wework/src/components/topnav/AppIframe.test.tsx
+++ b/wework/src/components/topnav/AppIframe.test.tsx
@@ -6,6 +6,7 @@ import { AppIframe } from './AppIframe'
 const embeddedBrowserMocks = vi.hoisted(() => ({
   closeEmbeddedBrowser: vi.fn().mockResolvedValue(undefined),
   evalEmbeddedBrowserJson: vi.fn().mockResolvedValue(true),
+  listenEmbeddedBrowserCloseRequests: vi.fn(() => null),
   navigateEmbeddedBrowser: vi.fn().mockResolvedValue(undefined),
   openEmbeddedBrowser: vi.fn().mockResolvedValue({
     nativeLabel: 'embedded-browser-native-1',

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -1792,8 +1792,7 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
         if (animationFrame) window.cancelAnimationFrame(animationFrame)
       }
       const captureFrame = (time: number) => {
-        const elements = findDesktopControlElements(command.selector)
-        const element = command.visible ? elements.find(desktopControlElementVisible) : elements[0]
+        const element = initialElement
         const rect = element?.getBoundingClientRect()
         const testIds = element
           ? [element, ...element.querySelectorAll<HTMLElement>('[data-testid]')]

--- a/wework/src/e2e/automation.ts
+++ b/wework/src/e2e/automation.ts
@@ -80,7 +80,26 @@ interface ScrollStabilitySample {
   stop: () => void
 }
 
+interface ElementMetricsSamplePoint {
+  connected: boolean
+  height: number
+  label: string | null
+  left: number
+  testIds: string[]
+  time: number
+  top: number
+  visibility: string
+  width: number
+}
+
+interface ElementMetricsSample {
+  done: boolean
+  frames: ElementMetricsSamplePoint[]
+  stop: () => void
+}
+
 let activeScrollStabilitySample: ScrollStabilitySample | null = null
+let activeElementMetricsSample: ElementMetricsSample | null = null
 
 export interface WeworkAutomationBridge {
   version: 1
@@ -1749,6 +1768,68 @@ async function executeDesktopControlCommand(command: DesktopControlCommand): Pro
     }
     case 'getElementMetrics':
       return desktopControlElementMetrics(command.selector)
+    case 'startElementMetricsSampling': {
+      const durationMs = Number(command.value)
+      if (!Number.isFinite(durationMs) || durationMs <= 0) {
+        throw new Error('startElementMetricsSampling requires a finite positive durationMs')
+      }
+      const initialElements = findDesktopControlElements(command.selector)
+      const initialElement = command.visible
+        ? initialElements.find(desktopControlElementVisible)
+        : initialElements[0]
+      if (!initialElement) throw new Error(`Unable to find selector "${command.selector}"`)
+      activeElementMetricsSample?.stop()
+      const startedAt = performance.now()
+      let animationFrame = 0
+      const sample: ElementMetricsSample = {
+        done: false,
+        frames: [],
+        stop: () => {},
+      }
+      const finish = () => {
+        if (sample.done) return
+        sample.done = true
+        if (animationFrame) window.cancelAnimationFrame(animationFrame)
+      }
+      const captureFrame = (time: number) => {
+        const elements = findDesktopControlElements(command.selector)
+        const element = command.visible ? elements.find(desktopControlElementVisible) : elements[0]
+        const rect = element?.getBoundingClientRect()
+        const testIds = element
+          ? [element, ...element.querySelectorAll<HTMLElement>('[data-testid]')]
+              .map(candidate => candidate.dataset.testid)
+              .filter((testId): testId is string => Boolean(testId))
+          : []
+        sample.frames.push({
+          connected: element?.isConnected ?? false,
+          height: rect?.height ?? 0,
+          label: element?.dataset.weworkBrowserWebview ?? null,
+          left: rect?.left ?? 0,
+          testIds,
+          time: time - startedAt,
+          top: rect?.top ?? 0,
+          visibility: element ? window.getComputedStyle(element).visibility : '',
+          width: rect?.width ?? 0,
+        })
+        if (time - startedAt >= durationMs) {
+          finish()
+          return
+        }
+        animationFrame = window.requestAnimationFrame(captureFrame)
+      }
+      sample.stop = finish
+      activeElementMetricsSample = sample
+      animationFrame = window.requestAnimationFrame(captureFrame)
+      return ''
+    }
+    case 'getElementMetricsSample': {
+      const sample = activeElementMetricsSample
+      if (!sample) throw new Error('Element metrics sampling has not started')
+      return JSON.stringify({
+        done: sample.done,
+        frames: sample.frames,
+      })
+    }
     case 'startScrollStabilitySampling': {
       const options = JSON.parse(command.value ?? '{}') as {
         anchorText?: string

--- a/wework/src/lib/embedded-browser.test.ts
+++ b/wework/src/lib/embedded-browser.test.ts
@@ -9,6 +9,7 @@ import {
   listenEmbeddedBrowserAgentState,
   listenEmbeddedBrowserOpenRequests,
   listenEmbeddedBrowserPageStateChanges,
+  migrateEmbeddedBrowserLabel,
   relabelEmbeddedBrowser,
   notifyEmbeddedBrowserAgentCursorArrived,
   resolveEmbeddedBrowserAgentApproval,
@@ -72,6 +73,49 @@ describe('embedded-browser', () => {
       fromLabel: 'workspace-browser-blank-0',
       toLabel: 'workspace-browser-task-1',
     })
+  })
+
+  test('waits for an opening browser before migrating its label', async () => {
+    vi.useFakeTimers()
+    desktopHostMocks.invoke
+      .mockRejectedValueOnce(
+        new Error('Embedded browser is unavailable: workspace-browser-blank-0')
+      )
+      .mockResolvedValueOnce(undefined)
+
+    const migration = migrateEmbeddedBrowserLabel(
+      'workspace-browser-blank-0',
+      'workspace-browser-task-1',
+      { waitForSource: true }
+    )
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(migration).resolves.toBeUndefined()
+    expect(desktopHostMocks.invoke).toHaveBeenCalledTimes(2)
+  })
+
+  test('migrates an empty browser label without waiting for a native browser', async () => {
+    desktopHostMocks.invoke.mockRejectedValueOnce(
+      new Error('Embedded browser is unavailable: workspace-browser-blank-0')
+    )
+
+    await expect(
+      migrateEmbeddedBrowserLabel('workspace-browser-blank-0', 'workspace-browser-task-1', {
+        waitForSource: false,
+      })
+    ).resolves.toBeUndefined()
+    expect(desktopHostMocks.invoke).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not retry unrelated browser migration errors', async () => {
+    desktopHostMocks.invoke.mockRejectedValueOnce(new Error('Browser label already exists'))
+
+    await expect(
+      migrateEmbeddedBrowserLabel('workspace-browser-blank-0', 'workspace-browser-task-1', {
+        waitForSource: true,
+      })
+    ).rejects.toThrow('Browser label already exists')
+    expect(desktopHostMocks.invoke).toHaveBeenCalledTimes(1)
   })
 
   test('closes only the expected native browser identity', async () => {

--- a/wework/src/lib/embedded-browser.test.ts
+++ b/wework/src/lib/embedded-browser.test.ts
@@ -10,6 +10,7 @@ import {
   listenEmbeddedBrowserOpenRequests,
   listenEmbeddedBrowserPageStateChanges,
   migrateEmbeddedBrowserLabel,
+  migrateEmbeddedBrowserLabelSequence,
   relabelEmbeddedBrowser,
   notifyEmbeddedBrowserAgentCursorArrived,
   resolveEmbeddedBrowserAgentApproval,
@@ -116,6 +117,40 @@ describe('embedded-browser', () => {
       })
     ).rejects.toThrow('Browser label already exists')
     expect(desktopHostMocks.invoke).toHaveBeenCalledTimes(1)
+  })
+
+  test('reports each successful label migration before a later migration fails', async () => {
+    const onMigrated = vi.fn()
+    desktopHostMocks.invoke
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Browser label already exists'))
+
+    await expect(
+      migrateEmbeddedBrowserLabelSequence(
+        [
+          {
+            tab: 'browser-1',
+            fromLabel: 'workspace-browser-blank-0',
+            toLabel: 'workspace-browser-task-1',
+            waitForSource: true,
+          },
+          {
+            tab: 'browser-2',
+            fromLabel: 'workspace-browser-blank-0:tab-2',
+            toLabel: 'workspace-browser-task-1:tab-2',
+            waitForSource: true,
+          },
+        ],
+        { onMigrated }
+      )
+    ).rejects.toThrow('Browser label already exists')
+    expect(onMigrated).toHaveBeenCalledOnce()
+    expect(onMigrated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tab: 'browser-1',
+        toLabel: 'workspace-browser-task-1',
+      })
+    )
   })
 
   test('closes only the expected native browser identity', async () => {

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -517,6 +517,30 @@ export async function migrateEmbeddedBrowserLabel(
   }
 }
 
+export async function migrateEmbeddedBrowserLabelSequence<
+  T extends {
+    fromLabel: string
+    toLabel: string
+    waitForSource: boolean
+  },
+>(
+  mappings: readonly T[],
+  options: {
+    onMigrated: (mapping: T) => void
+    signal?: AbortSignal
+  }
+): Promise<void> {
+  for (const mapping of mappings) {
+    if (mapping.fromLabel === mapping.toLabel) continue
+    await migrateEmbeddedBrowserLabel(mapping.fromLabel, mapping.toLabel, {
+      waitForSource: mapping.waitForSource,
+      signal: options.signal,
+    })
+    if (options.signal?.aborted) return
+    options.onMigrated(mapping)
+  }
+}
+
 export async function setEmbeddedBrowserActiveTab(
   baseLabel: string,
   activeTabLabel: string

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -6,6 +6,8 @@ import type { BrowserAnnotationState } from '@/types/browser-annotation'
 type UnlistenFn = () => void
 
 export const DEFAULT_EMBEDDED_BROWSER_LABEL = 'workspace-browser'
+const EMBEDDED_BROWSER_RELABEL_WAIT_INTERVAL_MS = 50
+const EMBEDDED_BROWSER_RELABEL_WAIT_TIMEOUT_MS = 6_000
 const transferredBrowserLabels = new Set<string>()
 const embeddedBrowserOpenRequestHandlers = new Set<(request: EmbeddedBrowserOpenRequest) => void>()
 let embeddedBrowserOpenRequestSequence = 0
@@ -496,6 +498,25 @@ export async function relabelEmbeddedBrowser(
   await invokeDesktopHost<void>('browser.relabel', { fromLabel, toLabel })
 }
 
+export async function migrateEmbeddedBrowserLabel(
+  fromLabel: string,
+  toLabel: string,
+  options: { waitForSource: boolean; signal?: AbortSignal }
+): Promise<void> {
+  const deadline = Date.now() + EMBEDDED_BROWSER_RELABEL_WAIT_TIMEOUT_MS
+  while (!options.signal?.aborted) {
+    try {
+      await relabelEmbeddedBrowser(fromLabel, toLabel)
+      return
+    } catch (error) {
+      if (!isEmbeddedBrowserUnavailableError(error, fromLabel)) throw error
+      if (!options.waitForSource) return
+      if (Date.now() >= deadline) throw error
+      await new Promise(resolve => setTimeout(resolve, EMBEDDED_BROWSER_RELABEL_WAIT_INTERVAL_MS))
+    }
+  }
+}
+
 export async function setEmbeddedBrowserActiveTab(
   baseLabel: string,
   activeTabLabel: string
@@ -520,6 +541,10 @@ export async function closeEmbeddedBrowsers(labels: string[]): Promise<void> {
 
 export async function clearEmbeddedBrowserData(kinds?: EmbeddedBrowserDataKind[]): Promise<number> {
   return invokeDesktopHost<number>('browser.clearData', { dataKinds: kinds ?? null })
+}
+
+function isEmbeddedBrowserUnavailableError(error: unknown, label: string): boolean {
+  return error instanceof Error && error.message === `Embedded browser is unavailable: ${label}`
 }
 
 export function requestEmbeddedBrowserOpen(


### PR DESCRIPTION
## Summary

- retain the existing Wework built-in browser WebView when a blank conversation becomes a local task
- migrate browser route and native state without remounting the loaded page, while preserving cursor and layout state
- recreate only the destroyed guest after an explicit browser close so immediate close/reopen cannot reuse an invalid WebView
- scope workspace target errors to the files tab so task creation does not stretch the browser panel
- add regression coverage for renderer ownership, Electron relabeling, close/reopen, and the real desktop handoff flow

## Verification

- focused renderer regression scope: 2 files, 28 tests passed
- Electron unit suite: 71 files, 359 tests passed
- Wework lint and renderer/Electron TypeScript checks passed
- real Electron embedded-browser checkpoint passed, including two consecutive close/reopen cycles with fresh guest attachments
- real Electron browser-multi-tabs checkpoint passed: the original browser host stayed connected and visible for all 222 sampled frames at constant 775 x 828 bounds, retaining its URL and page content

No documentation changes are needed because this fixes internal desktop lifecycle behavior without changing user-facing configuration or APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded browser tab transfers and migrations, preserving the active page, URL, and browser state.
  * Prevented duplicate browser views and stale layout updates during tab ownership changes.
  * Improved cleanup and reset behavior when browser tabs or views are closed.
  * Workspace target errors now appear only on the Files view.
  * Improved multi-tab diagnostics and polling reliability.

* **Tests**
  * Added coverage for browser migration, tab transfer, view retention, layout stability, and end-to-end multi-tab behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->