### PR TITLE
fix(wework): align cloud runtime event identity

### DIFF
--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -363,8 +363,9 @@ def _match_cloud_device_sync(
     Synchronous helper to match cloud device by device_id.
 
     Returns:
-        Tuple of (sandbox_id, needs_migration, device_data) if matched, None otherwise.
-        - sandbox_id: The matched sandbox ID
+        Tuple of (logical_device_id, needs_migration, device_data) if matched,
+        None otherwise.
+        - logical_device_id: The canonical Device CRD name exposed to clients
         - needs_migration: True if legacy device needs migration
         - device_data: Dict with device info for migration (device_id, etc.)
     """
@@ -425,10 +426,11 @@ def _match_cloud_device_sync(
                         db.commit()
                     logger.info(
                         f"[Device WS] Cloud device matched by device_id: "
+                        f"logical_device_id={device.name}, "
                         f"sandbox_id={sandbox_id}, "
                         f"device_id={executor_device_id}"
                     )
-                    return (sandbox_id, False, None)
+                    return (device.name, False, None)
                 else:
                     # Device ID mismatch - skip this device
                     logger.debug(
@@ -452,9 +454,9 @@ def _match_cloud_device_sync(
                         f"new_device_id={executor_device_id}"
                     )
                     return (
-                        sandbox_id,
+                        device.name,
                         True,
-                        {"device_id": device.id},
+                        {"device_id": device.id, "sandbox_id": sandbox_id},
                     )
 
     return None
@@ -477,7 +479,7 @@ def _update_cloud_device_id_sync(
         sandbox_id: Sandbox ID
 
     Returns:
-        Sandbox ID
+        Canonical Device CRD name after migration
     """
     import copy
 
@@ -502,7 +504,7 @@ def _update_cloud_device_id_sync(
             logger.error(
                 f"[Device WS] Device not found for migration: id={device_db_id}"
             )
-            return sandbox_id
+            return executor_device_id
 
         device_json = copy.deepcopy(device.json)
         validate_persistent_runtime_instance_id(
@@ -530,7 +532,7 @@ def _update_cloud_device_id_sync(
             f"sandbox_id={sandbox_id}"
         )
 
-    return sandbox_id
+    return executor_device_id
 
 
 def _verify_api_key_sync(token: str) -> Optional[tuple[int, str]]:
@@ -1475,7 +1477,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
             executor_device_id: Device ID from executor (should match server-generated)
 
         Returns:
-            Cloud device ID (sandbox_id) if matched, None otherwise
+            Canonical Device CRD name if matched, None otherwise
         """
         try:
             # Run database query in executor to avoid blocking event loop
@@ -1490,20 +1492,20 @@ class DeviceNamespace(socketio.AsyncNamespace):
             if result is None:
                 return None
 
-            sandbox_id, needs_migration, device_data = result
+            logical_device_id, needs_migration, device_data = result
 
             # If legacy device needs migration, do it in executor
             if needs_migration and device_data:
-                await run_sync_in_executor(
+                logical_device_id = await run_sync_in_executor(
                     _update_cloud_device_id_sync,
                     user_id,
                     device_data["device_id"],
                     executor_device_id,
-                    sandbox_id,
+                    device_data["sandbox_id"],
                     runtime_instance_id,
                 )
 
-            return sandbox_id
+            return logical_device_id
 
         except RuntimeInstanceMismatchError:
             raise
@@ -1780,10 +1782,10 @@ class DeviceNamespace(socketio.AsyncNamespace):
             app_device_id=str(payload.app_device_id or "").strip(),
         )
         is_cloud_device = False
-        cloud_device_id: Optional[str] = None
+        logical_device_id: Optional[str] = None
         if payload.device_type == DeviceType.CLOUD:
             try:
-                cloud_device_id = await self._match_cloud_device(
+                logical_device_id = await self._match_cloud_device(
                     user_id,
                     client_ip or "",
                     payload.device_id,
@@ -1797,11 +1799,11 @@ class DeviceNamespace(socketio.AsyncNamespace):
                     payload.device_id,
                 )
                 return {"error": f"Registration failed: {exc}"}
-            if cloud_device_id:
+            if logical_device_id:
                 is_cloud_device = True
                 logger.info(
                     f"[Device WS] Matched cloud device: executor_device_id={payload.device_id}, "
-                    f"cloud_device_id={cloud_device_id}"
+                    f"logical_device_id={logical_device_id}"
                 )
 
         # Database operation: skip if cloud device already updated in IP matching
@@ -1842,7 +1844,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
         # Update the Socket.IO session before marking the device online. If the
         # connection disappeared, the online socket would be stale immediately.
         session["device_id"] = payload.device_id
-        session["logical_device_id"] = cloud_device_id or payload.device_id
+        session["logical_device_id"] = logical_device_id or payload.device_id
         session["device_name"] = effective_device_name
         session["runtime_transfer_host"] = runtime_transfer_host
         session["runtime_instance_id"] = payload.runtime_instance_id

--- a/backend/tests/api/ws/test_device_namespace_registration.py
+++ b/backend/tests/api/ws/test_device_namespace_registration.py
@@ -158,6 +158,7 @@ def test_cloud_runtime_matching_pins_first_runtime_instance(
 ):
     logical_device_id = "cloud-unpinned-device"
     runtime_device_id = "cloud-unpinned-route"
+    sandbox_id = "sandbox-unpinned-runtime"
     device = Kind(
         user_id=test_user.id,
         kind="Device",
@@ -176,7 +177,7 @@ def test_cloud_runtime_matching_pins_first_runtime_instance(
                 "deviceType": DeviceType.CLOUD.value,
                 "runtimeInstanceId": None,
                 "cloudConfig": {
-                    "sandboxId": logical_device_id,
+                    "sandboxId": sandbox_id,
                     "deviceId": runtime_device_id,
                 },
             },
@@ -211,6 +212,72 @@ def test_cloud_runtime_matching_pins_first_runtime_instance(
     )
     assert matched == (logical_device_id, False, None)
     assert persisted.json["spec"]["runtimeInstanceId"] == "runtime-instance-first"
+
+
+@pytest.mark.asyncio
+async def test_legacy_cloud_runtime_matching_returns_migrated_canonical_id(
+    test_db,
+    test_user,
+    monkeypatch,
+):
+    sandbox_id = "sandbox-legacy-runtime"
+    runtime_device_id = "cloud-migrated-route"
+    device = Kind(
+        user_id=test_user.id,
+        kind="Device",
+        name=sandbox_id,
+        namespace="default",
+        is_active=True,
+        json={
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Device",
+            "metadata": {"name": sandbox_id, "namespace": "default"},
+            "spec": {
+                "deviceType": DeviceType.CLOUD.value,
+                "cloudConfig": {"sandboxId": sandbox_id},
+            },
+        },
+    )
+    test_db.add(device)
+    test_db.commit()
+
+    @contextmanager
+    def test_db_session():
+        try:
+            yield test_db
+        finally:
+            test_db.commit()
+
+    async def run_inline(func, *args):
+        return func(*args)
+
+    monkeypatch.setattr(device_namespace, "get_db_session", test_db_session)
+    monkeypatch.setattr(device_namespace, "run_sync_in_executor", run_inline)
+
+    matched = await DeviceNamespace()._match_cloud_device(
+        user_id=test_user.id,
+        client_ip="198.51.100.32",
+        executor_device_id=runtime_device_id,
+        runtime_instance_id="runtime-instance-migrated",
+    )
+
+    test_db.expire_all()
+    persisted = (
+        test_db.query(Kind)
+        .filter(
+            Kind.user_id == test_user.id,
+            Kind.kind == "Device",
+            Kind.namespace == "default",
+        )
+        .one()
+    )
+    assert matched == runtime_device_id
+    assert persisted.name == runtime_device_id
+    assert persisted.json["spec"]["deviceId"] == runtime_device_id
+    assert persisted.json["spec"]["cloudConfig"] == {
+        "sandboxId": sandbox_id,
+        "deviceId": runtime_device_id,
+    }
 
 
 @pytest.mark.asyncio

--- a/wework/e2e/desktop/modules/cloud-environment.mjs
+++ b/wework/e2e/desktop/modules/cloud-environment.mjs
@@ -41,6 +41,7 @@ import {
 const REDIS_START_ATTEMPTS = 5
 const REDIS_READY_PATTERN = /Ready to accept connections/
 const REDIS_PORT_CONFLICT_PATTERN = /Address already in use|Failed listening on port/
+const MANAGED_CLOUD_SANDBOX_ID = 'wework-e2e-managed-cloud-sandbox'
 const CLOUD_PUBLIC_MODEL_OPTIONS = {
   weworkCloudModelNamespace: 'default',
   weworkCloudModelResourceUserId: '0',
@@ -219,12 +220,14 @@ class RealCloudEnvironment {
   constructor({
     claudeBinary,
     codexBinary,
+    managedCloudIdentity = false,
     modelServerUrl,
     scenarioConfigToml = '',
     workspacePath,
   }) {
     this.claudeBinary = claudeBinary
     this.codexBinary = codexBinary
+    this.managedCloudIdentity = managedCloudIdentity
     this.modelServerUrl = modelServerUrl
     this.scenarioConfigToml = scenarioConfigToml
     this.workspacePath = workspacePath
@@ -552,6 +555,33 @@ class RealCloudEnvironment {
       this.waitForDevice(CLOUD_DEVICE_ID, this.remoteExecutorLogPath),
       this.waitForDevice(REMOTE_DOCKER_DEVICE_ID, this.remoteDockerExecutorLogPath),
     ])
+    if (this.managedCloudIdentity) {
+      await this.configureManagedCloudIdentity()
+    }
+  }
+
+  async configureManagedCloudIdentity() {
+    await runChecked('sqlite3', [
+      this.databasePath,
+      [
+        'UPDATE kinds',
+        `SET json = json_set(json, '$.spec.cloudConfig.sandboxId', '${MANAGED_CLOUD_SANDBOX_ID}', '$.spec.cloudConfig.deviceId', '${CLOUD_DEVICE_ID}')`,
+        `WHERE kind = 'Device' AND name = '${CLOUD_DEVICE_ID}';`,
+      ].join(' '),
+    ])
+
+    const configured = await this.device(CLOUD_DEVICE_ID)
+    assert.equal(
+      configured?.cloud_config?.sandboxId,
+      MANAGED_CLOUD_SANDBOX_ID,
+      'The cloud E2E fixture did not create a distinct managed Sandbox identity'
+    )
+    assert.equal(
+      configured?.cloud_config?.deviceId,
+      CLOUD_DEVICE_ID,
+      'The cloud E2E fixture changed the Executor route identity'
+    )
+    await this.restartCloudExecutor()
   }
 
   async describePluginWorkspace(pluginRoot, taskWorkspace, taskId) {

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1020,6 +1020,7 @@ async function main() {
       cloudEnvironment = new RealCloudEnvironment({
         claudeBinary: desktopScenario?.claudeBinary,
         codexBinary,
+        managedCloudIdentity: CLOUD_ONLY,
         modelServerUrl: control.url,
         scenarioConfigToml:
           SELECTED_DESKTOP_SEGMENT === 'rendering-extensions' ? toolDetailsMcpConfigToml() : '',


### PR DESCRIPTION
## Summary

- keep `sandboxId` limited to managed cloud infrastructure matching
- project cloud runtime events with the canonical Device CRD name used by WeWork
- cover both current and legacy cloud registration, and make the CI cloud fixture use a distinct Sandbox identity

## Root cause

Cloud Executor events were projected with `cloudConfig.sandboxId`, while WeWork tasks and device routing use the Device CRD name. The IDs differ only for managed cloud devices, so remote devices streamed normally and cloud devices only showed completed output after transcript refresh.

## Validation

- `cd backend && uv run pytest tests/api/ws/test_device_namespace_registration.py tests/api/ws/test_wework_runtime_namespace.py` (39 passed)
- scoped pre-push checks passed with Node 22.22.1: WeWork ESLint/unit tests, Backend Black/isort/syntax, Settings, and Alembic multi-head
- local cloud E2E did not reach the scenario because the Electron app timed out connecting to the E2E controller; the updated `core-task-flow` remains covered by the cloud E2E CI job

## Manual verification

Verify a managed cloud device whose `sandboxId` differs from its Device ID streams assistant content before task completion without refreshing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud device matching to consistently use the canonical device identity.
  * Updated legacy device records during matching to preserve compatibility and correctly associate them with their runtime device.
  * Improved device registration and migration handling for cloud-connected environments.

* **Tests**
  * Added coverage for legacy device migration and canonical identity matching.
  * Expanded end-to-end cloud environment setup to validate managed device identity configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->