### PR TITLE
fix(wework): reduce CPU usage from status animations

### DIFF
--- a/docs/en/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/wework/developer-guide/wework-performance-diagnostics.md
@@ -152,6 +152,21 @@ Distinguish these cases when investigating streaming stalls:
 
 Streaming-buffer unit tests live in `wework/src/components/chat/useBufferedStreamingText.test.ts`. Changes to the reserve or advance rate must continue to cover Unicode boundaries, non-append updates, and immediate alignment when streaming ends.
 
+## Persistent Animation Rendering
+
+Status spinners and text shimmers are persistent animations: they can keep the Web Content process busy even when there is no input or streamed message. Implement these effects so that each frame changes only compositable `transform` or `opacity`. Do not animate paint-bound properties such as `background-position` or `mask-position`, and do not rotate a complex stroked SVG directly.
+
+A spinner should keep its SVG static inside a fixed-size HTML wrapper and animate the wrapper's `transform` with `will-change: transform`. A text shimmer should keep the base text normally rendered and use fixed highlight bands with staggered `opacity` animations to reproduce the left-to-right sweep. Both implementations must preserve `prefers-reduced-motion` behavior.
+
+Do not infer compositor behavior from CSS property names alone. `will-change` is only a hint, and apparently compositable properties such as `clip-path` can still cause per-frame main-thread work in the Electron version that ships with Wework. After changing a persistent animation, capture the old and new implementations for at least 10 seconds under the same Electron version, element count, and window state, and verify:
+
+- Pausing animations causes CPU usage to fall, establishing that the animation is causal.
+- The new implementation no longer emits per-frame `Paint` or `PaintImage` events.
+- `UpdateLayoutTree` and `Layerize` event counts and total durations no longer grow continuously with animation frames.
+- Direction, period, color, dimensions, and visibility states match the previous effect.
+
+If the replacement still produces continuous painting or layerization, revise the implementation again. Visual smoothness or an occasional reduction in average CPU is not sufficient evidence.
+
 ## Collected Data
 
 When enabled, the diagnostics module records:

--- a/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
@@ -152,6 +152,21 @@ Wework 将 executor 高频到达的文本增量与 Markdown 展示节奏分离�
 
 流式文本缓冲的单元测试位于 `wework/src/components/chat/useBufferedStreamingText.test.ts`。修改缓冲水位或推进速率时，应同时验证 Unicode 字符边界、非追加更新和流结束立即对齐行为。
 
+## 常驻动画渲染
+
+状态旋转图标和文字扫光属于常驻动画：即使页面没有输入或流式消息，它们也可能持续驱动 Web Content 进程。实现这类效果时，应保持每帧只更新可合成的 `transform` 或 `opacity`，避免动画化 `background-position`、`mask-position` 等需要重新绘制的属性，也不要直接旋转带有复杂描边的 SVG。
+
+旋转图标应把静态 SVG 放在固定尺寸的 HTML 包装层中，由包装层执行 `transform` 动画并声明 `will-change: transform`。文字扫光应使用固定位置的高亮层，通过分段且错峰的 `opacity` 动画形成从左到右的扫光；基础文字始终正常渲染。两类实现都必须保留 `prefers-reduced-motion` 行为。
+
+不能仅凭 CSS 属性名称判断动画是否进入合成线程。`will-change` 只是提示，`clip-path` 等看似可合成的属性在实际 Electron 版本中仍可能每帧触发主线程工作。修改常驻动画后，应在同一 Electron 版本、相同元素数量和相同窗口状态下分别录制至少 10 秒的旧实现与新实现，并验证：
+
+- 暂停动画后 CPU 明显下降，以证明动画与占用存在因果关系。
+- 新实现不再随帧产生 `Paint` 或 `PaintImage`。
+- `UpdateLayoutTree` 和 `Layerize` 的事件数量与总耗时不再随动画帧持续增长。
+- 动画方向、周期、颜色、尺寸和可见状态与修改前一致。
+
+如果新实现仍持续产生绘制或图层化事件，应继续修改实现，而不是以视觉上流畅或平均 CPU 偶尔下降作为验收依据。
+
 ## 采集内容
 
 开启后，诊断模块会采集：

--- a/wework/src/components/chat/ActivityShimmerText.test.tsx
+++ b/wework/src/components/chat/ActivityShimmerText.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { ActivityShimmerText } from './ActivityShimmerText'
+
+describe('ActivityShimmerText', () => {
+  it('renders one bounded highlight band per grapheme without copying the full text', () => {
+    const text = 'W'.repeat(120)
+    const { container } = render(<ActivityShimmerText variant="tool">{text}</ActivityShimmerText>)
+
+    const bands = container.querySelectorAll('.activity-shimmer-band')
+
+    expect(bands).toHaveLength(96)
+    expect(bands[0]).toHaveAttribute('data-grapheme', 'W')
+    expect(container.querySelector('[data-text]')).not.toBeInTheDocument()
+  })
+
+  it('keeps proportional graphemes in independent inline bands', () => {
+    const { container } = render(<ActivityShimmerText variant="thinking">Wi</ActivityShimmerText>)
+
+    expect(
+      Array.from(container.querySelectorAll('.activity-shimmer-band'), band =>
+        band.getAttribute('data-grapheme')
+      )
+    ).toEqual(['W', 'i'])
+  })
+})

--- a/wework/src/components/chat/ActivityShimmerText.tsx
+++ b/wework/src/components/chat/ActivityShimmerText.tsx
@@ -2,14 +2,13 @@ import type { CSSProperties } from 'react'
 
 const SHIMMER_DURATION_SECONDS = 1.6
 const SHIMMER_TRAILING_SLOTS = 5
+const MAX_ANIMATED_GRAPHEMES = 96
 const SHIMMER_SEGMENTER = new Intl.Segmenter(undefined, {
   granularity: 'grapheme',
 })
 
 type ShimmerBandStyle = CSSProperties & {
   '--activity-shimmer-delay': string
-  '--activity-shimmer-left': string
-  '--activity-shimmer-right': string
 }
 
 export function ActivityShimmerText({
@@ -21,7 +20,10 @@ export function ActivityShimmerText({
   variant: 'thinking' | 'tool'
   className?: string
 }) {
-  const segments = Array.from(SHIMMER_SEGMENTER.segment(children), segment => segment.segment)
+  const segments = Array.from(
+    SHIMMER_SEGMENTER.segment(children),
+    segment => segment.segment
+  ).slice(0, MAX_ANIMATED_GRAPHEMES)
   const cycleSlots = segments.length + SHIMMER_TRAILING_SLOTS
 
   return (
@@ -36,17 +38,13 @@ export function ActivityShimmerText({
               ((segments.length - index) * SHIMMER_DURATION_SECONDS) /
               cycleSlots
             ).toFixed(4)}s`,
-            '--activity-shimmer-left': `${((index / segments.length) * 100).toFixed(4)}%`,
-            '--activity-shimmer-right': `${(100 - ((index + 1) / segments.length) * 100).toFixed(
-              4
-            )}%`,
           }
 
           return (
             <span
               key={`${segment}-${index}`}
               className="activity-shimmer-band"
-              data-text={children}
+              data-grapheme={segment}
               style={style}
             />
           )

--- a/wework/src/components/chat/ActivityShimmerText.tsx
+++ b/wework/src/components/chat/ActivityShimmerText.tsx
@@ -1,0 +1,57 @@
+import type { CSSProperties } from 'react'
+
+const SHIMMER_DURATION_SECONDS = 1.6
+const SHIMMER_TRAILING_SLOTS = 5
+const SHIMMER_SEGMENTER = new Intl.Segmenter(undefined, {
+  granularity: 'grapheme',
+})
+
+type ShimmerBandStyle = CSSProperties & {
+  '--activity-shimmer-delay': string
+  '--activity-shimmer-left': string
+  '--activity-shimmer-right': string
+}
+
+export function ActivityShimmerText({
+  children,
+  variant,
+  className = '',
+}: {
+  children: string
+  variant: 'thinking' | 'tool'
+  className?: string
+}) {
+  const segments = Array.from(SHIMMER_SEGMENTER.segment(children), segment => segment.segment)
+  const cycleSlots = segments.length + SHIMMER_TRAILING_SLOTS
+
+  return (
+    <span
+      className={`activity-shimmer-text ${variant === 'thinking' ? 'waiting-thinking-text' : 'tool-activity-shimmer'} ${className}`}
+    >
+      {children}
+      <span aria-hidden="true" className="activity-shimmer-highlight">
+        {segments.map((segment, index) => {
+          const style: ShimmerBandStyle = {
+            '--activity-shimmer-delay': `${-(
+              ((segments.length - index) * SHIMMER_DURATION_SECONDS) /
+              cycleSlots
+            ).toFixed(4)}s`,
+            '--activity-shimmer-left': `${((index / segments.length) * 100).toFixed(4)}%`,
+            '--activity-shimmer-right': `${(100 - ((index + 1) / segments.length) * 100).toFixed(
+              4
+            )}%`,
+          }
+
+          return (
+            <span
+              key={`${segment}-${index}`}
+              className="activity-shimmer-band"
+              data-text={children}
+              style={style}
+            />
+          )
+        })}
+      </span>
+    </span>
+  )
+}

--- a/wework/src/components/chat/AssistantThinkingIndicator.tsx
+++ b/wework/src/components/chat/AssistantThinkingIndicator.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
+import { ActivityShimmerText } from './ActivityShimmerText'
 
 const THINKING_PREVIEW_MAX_LENGTH = 96
 
@@ -21,7 +22,9 @@ export function AssistantThinkingIndicator({
       className={cn('inline-flex min-w-0 max-w-full items-center text-chat', className)}
       data-testid={testId}
     >
-      <span className="waiting-thinking-text min-w-0 truncate">{text}</span>
+      <ActivityShimmerText variant="thinking" className="min-w-0 truncate">
+        {text}
+      </ActivityShimmerText>
     </div>
   )
 }

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1447,7 +1447,15 @@ describe('MessageList', () => {
     expect(shimmer).toHaveClass('tool-activity-shimmer')
     const shimmerBands = shimmer.querySelectorAll('.activity-shimmer-band')
     expect(shimmerBands).toHaveLength(6)
-    expect(shimmerBands[0]).toHaveAttribute('data-text', '正在搜索代码')
+    expect(Array.from(shimmerBands, band => band.getAttribute('data-grapheme'))).toEqual([
+      '正',
+      '在',
+      '搜',
+      '索',
+      '代',
+      '码',
+    ])
+    expect(shimmer.querySelector('[data-text]')).not.toBeInTheDocument()
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1443,7 +1443,11 @@ describe('MessageList', () => {
     )
 
     expect(screen.getByText('我先把硬编码中文改成 chat 命名空间翻译。')).toBeInTheDocument()
-    expect(screen.getByText('正在搜索代码')).toHaveClass('tool-activity-shimmer')
+    const shimmer = screen.getByText('正在搜索代码')
+    expect(shimmer).toHaveClass('tool-activity-shimmer')
+    const shimmerBands = shimmer.querySelectorAll('.activity-shimmer-band')
+    expect(shimmerBands).toHaveLength(6)
+    expect(shimmerBands[0]).toHaveAttribute('data-text', '正在搜索代码')
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -10,6 +10,7 @@ import { track } from '@/telemetry/client'
 import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import type { WorkspaceFileOpenOptions } from '@/types/workspace-files'
+import { ActivityShimmerText } from '../ActivityShimmerText'
 import { AssistantMarkdown } from '../AssistantMarkdown'
 import { AssistantPlanCard, type AssistantPlanOpenRequest } from '../AssistantPlanCard'
 import { localMarkdownImagePath, resolveDirectMarkdownImageSrc } from '../assistantMarkdownLinks'
@@ -151,9 +152,9 @@ export function ToolBlockItem({
         data-testid="runtime-reconnecting-status"
         role="status"
       >
-        <span className="tool-activity-shimmer">
+        <ActivityShimmerText variant="tool">
           {t('tool_activity.reconnecting', '连接中断，正在重连…')}
-        </span>
+        </ActivityShimmerText>
       </div>
     )
   }
@@ -180,9 +181,13 @@ export function ToolBlockItem({
   const labelContent = (
     <>
       {icon}
-      <span className={`min-w-0 truncate ${isRunning || shimmer ? 'tool-activity-shimmer' : ''}`}>
-        {label}
-      </span>
+      {isRunning || shimmer ? (
+        <ActivityShimmerText variant="tool" className="min-w-0 truncate">
+          {label}
+        </ActivityShimmerText>
+      ) : (
+        <span className="min-w-0 truncate">{label}</span>
+      )}
       {isRunning && <span className="animate-pulse text-xs will-change-opacity">...</span>}
     </>
   )
@@ -322,11 +327,13 @@ function ProcessFileChangesBlockItem({
                 className="group relative z-10 flex min-h-8 w-full max-w-full items-center gap-1.5 text-text-secondary disabled:cursor-default"
               >
                 <FileDiff className="h-4 w-4 shrink-0" strokeWidth={1.7} />
-                <span
-                  className={`min-w-0 truncate ${isRunning || shimmer ? 'tool-activity-shimmer' : ''}`}
-                >
-                  {fileChangeRowLabel(file, t, isRunning)}
-                </span>
+                {isRunning || shimmer ? (
+                  <ActivityShimmerText variant="tool" className="min-w-0 truncate">
+                    {fileChangeRowLabel(file, t, isRunning)}
+                  </ActivityShimmerText>
+                ) : (
+                  <span className="min-w-0 truncate">{fileChangeRowLabel(file, t, isRunning)}</span>
+                )}
                 {!file.binary ? (
                   <FileChangeLineStats file={file} isRunning={isRunning} streamId={block.id} />
                 ) : null}

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -1658,8 +1658,13 @@ describe('ToolBlocksDisplay', () => {
     render(<ToolBlocksDisplay blocks={[runningBlock]} isStreaming={true} />)
 
     expect(screen.queryByTestId('processing-summary-toggle')).not.toBeInTheDocument()
-    expect(screen.getByTestId('processing-summary-header')).toHaveTextContent('调用 1 个工具')
-    expect(screen.getByTestId('processing-summary-header')).not.toHaveTextContent('秒')
+    const header = screen.getByTestId('processing-summary-header')
+    expect(header).toHaveTextContent('调用 1 个工具')
+    expect(header).not.toHaveTextContent('秒')
+    const spinner = header.querySelector('.animate-spin')
+    expect(spinner).toBeInstanceOf(HTMLSpanElement)
+    expect(spinner).toHaveClass('will-change-transform')
+    expect(spinner?.querySelector('svg')).not.toHaveClass('animate-spin')
   })
 
   test('shows a subtle one-line reconnecting status after a sustained interruption', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -4,13 +4,13 @@ import {
   Archive,
   ChevronDown,
   FileText,
-  LoaderCircle,
   MessageCircle,
   Pencil,
   Search,
   SquareTerminal,
   Wrench,
 } from 'lucide-react'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { RequestUserInputResponse } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
@@ -437,11 +437,7 @@ function ProcessingSummaryHeader({
       {isRunning || duration ? (
         <span className="ml-auto inline-flex shrink-0 items-center gap-1">
           {isRunning ? (
-            <LoaderCircle
-              className="h-3 w-3 animate-spin text-blue-500 motion-reduce:animate-none"
-              strokeWidth={1.8}
-              aria-hidden="true"
-            />
+            <CompositedSpinner className="h-3 w-3 text-blue-500" strokeWidth={1.8} />
           ) : null}
           {duration}
         </span>

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -20,6 +20,7 @@ import {
   isRequestUserInputBlock,
   type RequestUserInputBlock,
 } from '../requestUserInputMessages'
+import { ActivityShimmerText } from '../ActivityShimmerText'
 import { AssistantThinkingIndicator } from '../AssistantThinkingIndicator'
 import { ToolBlockItem, type FileEditDurationsByBlock } from './ToolBlockItem'
 import {
@@ -831,9 +832,13 @@ function ContextCompactionIndicator({ block }: { block: ToolBlock }) {
         className={`inline-flex min-w-0 max-w-full items-center gap-1.5 text-sm font-semibold ${textClassName}`}
       >
         <Archive className="h-4 w-4 shrink-0" strokeWidth={1.7} aria-hidden="true" />
-        <span className={`min-w-0 truncate ${isRunning ? 'waiting-thinking-text' : ''}`}>
-          {label}
-        </span>
+        {isRunning ? (
+          <ActivityShimmerText variant="thinking" className="min-w-0 truncate">
+            {label}
+          </ActivityShimmerText>
+        ) : (
+          <span className="min-w-0 truncate">{label}</span>
+        )}
       </span>
       <span className="h-px min-w-6 flex-1 bg-border" aria-hidden="true" />
     </div>

--- a/wework/src/components/common/CompositedSpinner.test.tsx
+++ b/wework/src/components/common/CompositedSpinner.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { Loader2 } from 'lucide-react'
+import { describe, expect, test } from 'vitest'
+import { CompositedSpinner } from './CompositedSpinner'
+
+describe('CompositedSpinner', () => {
+  test('rotates an HTML compositing layer without animating the SVG', () => {
+    render(
+      <CompositedSpinner data-testid="spinner" icon={Loader2} className="h-4 w-4 text-primary" />
+    )
+
+    const spinner = screen.getByTestId('spinner')
+    expect(spinner).toBeInstanceOf(HTMLSpanElement)
+    expect(spinner).toHaveClass('animate-spin', 'will-change-transform')
+    expect(spinner.querySelector('svg')).not.toHaveClass('animate-spin')
+  })
+})

--- a/wework/src/components/common/CompositedSpinner.tsx
+++ b/wework/src/components/common/CompositedSpinner.tsx
@@ -1,0 +1,35 @@
+import { LoaderCircle, type LucideIcon } from 'lucide-react'
+import type { ComponentPropsWithoutRef } from 'react'
+import { cn } from '@/lib/utils'
+
+interface CompositedSpinnerProps extends Omit<ComponentPropsWithoutRef<'span'>, 'children'> {
+  icon?: LucideIcon
+  iconClassName?: string
+  strokeWidth?: number
+}
+
+export function CompositedSpinner({
+  icon: Icon = LoaderCircle,
+  className,
+  iconClassName,
+  strokeWidth,
+  'aria-hidden': ariaHidden = true,
+  ...props
+}: CompositedSpinnerProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 animate-spin items-center justify-center will-change-transform motion-reduce:animate-none',
+        className
+      )}
+      aria-hidden={ariaHidden}
+      {...props}
+    >
+      <Icon
+        className={cn('h-full w-full', iconClassName)}
+        strokeWidth={strokeWidth}
+        aria-hidden="true"
+      />
+    </span>
+  )
+}

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -3404,7 +3404,10 @@ describe('DesktopSidebar', () => {
     const runningStatus = screen.getByTestId('runtime-local-task-running-codex-running')
     expect(runningStatus).toHaveAttribute('aria-label', '运行中')
     expect(runningStatus).not.toHaveTextContent('运行中')
-    expect(runningStatus.querySelector('svg')).not.toBeNull()
+    const spinnerLayer = runningStatus.querySelector('.animate-spin')
+    expect(spinnerLayer).toBeInstanceOf(HTMLSpanElement)
+    expect(spinnerLayer).toHaveClass('will-change-transform')
+    expect(spinnerLayer?.querySelector('svg')).not.toHaveClass('animate-spin')
     expect(screen.queryByTestId('runtime-local-task-running-codex-idle')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -575,8 +575,8 @@ function ArchiveConversationsConfirmDialog({
 
 const SIDEBAR_ROW_METADATA_CLASS =
   'flex items-center gap-1 text-xs text-[rgb(var(--color-sidebar-text-muted))] group-hover/task:invisible'
-const SIDEBAR_RUNNING_SPINNER_CLASS =
-  'h-4 w-4 shrink-0 animate-spin text-[rgb(var(--color-sidebar-text-muted))]'
+const SIDEBAR_RUNNING_SPINNER_LAYER_CLASS =
+  'flex h-4 w-4 shrink-0 animate-spin items-center justify-center text-[rgb(var(--color-sidebar-text-muted))] will-change-transform motion-reduce:animate-none'
 const SIDEBAR_HEADER_ICON_BUTTON_CLASS =
   'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))] active:bg-[rgb(var(--color-sidebar-active))]'
 
@@ -1906,7 +1906,9 @@ function RuntimeTaskRow({
                     aria-label={t('workbench.runtime_task_running')}
                     className="flex h-[30px] w-[30px] items-center justify-center"
                   >
-                    <Loader2 className={SIDEBAR_RUNNING_SPINNER_CLASS} aria-hidden="true" />
+                    <span className={SIDEBAR_RUNNING_SPINNER_LAYER_CLASS} aria-hidden="true">
+                      <Loader2 className="h-4 w-4" />
+                    </span>
                   </span>
                 ) : priorityReason === 'waiting' ? (
                   <span

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -45,6 +45,7 @@ import type {
 import { createPortal } from 'react-dom'
 import { ActionMenu } from '@/components/common/ActionMenu'
 import { ChangeRequestStatusIcon } from '@/components/common/ChangeRequestStatusIcon'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import { TextInputDialog } from '@/components/common/TextInputDialog'
 import { ProjectFolderIcon } from '@/components/projects/ProjectFolderIcon'
 import { LocalProjectEditDialog } from '@/components/projects/LocalProjectEditDialog'
@@ -575,8 +576,6 @@ function ArchiveConversationsConfirmDialog({
 
 const SIDEBAR_ROW_METADATA_CLASS =
   'flex items-center gap-1 text-xs text-[rgb(var(--color-sidebar-text-muted))] group-hover/task:invisible'
-const SIDEBAR_RUNNING_SPINNER_LAYER_CLASS =
-  'flex h-4 w-4 shrink-0 animate-spin items-center justify-center text-[rgb(var(--color-sidebar-text-muted))] will-change-transform motion-reduce:animate-none'
 const SIDEBAR_HEADER_ICON_BUTTON_CLASS =
   'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))] active:bg-[rgb(var(--color-sidebar-active))]'
 
@@ -1906,9 +1905,10 @@ function RuntimeTaskRow({
                     aria-label={t('workbench.runtime_task_running')}
                     className="flex h-[30px] w-[30px] items-center justify-center"
                   >
-                    <span className={SIDEBAR_RUNNING_SPINNER_LAYER_CLASS} aria-hidden="true">
-                      <Loader2 className="h-4 w-4" />
-                    </span>
+                    <CompositedSpinner
+                      icon={Loader2}
+                      className="h-4 w-4 text-[rgb(var(--color-sidebar-text-muted))]"
+                    />
                   </span>
                 ) : priorityReason === 'waiting' ? (
                   <span

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -16,6 +16,7 @@ import {
   X,
 } from 'lucide-react'
 import { useContext, useMemo, useRef, useState } from 'react'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import { ProjectCreateDialog } from '@/components/projects/ProjectCreateDialog'
 import { useTranslation } from '@/hooks/useTranslation'
 import { usePullToRefresh } from '@/hooks/usePullToRefresh'
@@ -60,7 +61,6 @@ import {
 } from './runtimeTaskSidebarHelpers'
 import { formatRelativeSidebarTime, useSidebarRelativeTimeRefresh } from './runtimeSidebarTime'
 
-const MOBILE_RUNNING_SPINNER_CLASS = 'h-3.5 w-3.5 shrink-0 animate-spin'
 type ProjectCreateMode = 'scratch' | 'existing' | 'git'
 
 interface MobileDrawerProps {
@@ -182,7 +182,7 @@ export function MobileDrawer({
         title={label}
         className="ml-2 inline-flex h-7 w-7 shrink-0 items-center justify-center text-text-secondary"
       >
-        <Loader2 className={MOBILE_RUNNING_SPINNER_CLASS} aria-hidden="true" />
+        <CompositedSpinner icon={Loader2} className="h-3.5 w-3.5" />
       </span>
     )
   }

--- a/wework/src/components/layout/SubagentStatusIndicator.test.tsx
+++ b/wework/src/components/layout/SubagentStatusIndicator.test.tsx
@@ -21,6 +21,10 @@ describe('SubagentStatusIndicator', () => {
     expect(screen.getByTestId('subagent-status-panel')).toBeInTheDocument()
     expect(screen.getByText('worker')).toBeInTheDocument()
     expect(screen.getByText('0ffa96e5')).toBeInTheDocument()
+    const spinner = screen.getByTestId('subagent-status-item').querySelector('.animate-spin')
+    expect(spinner).toBeInstanceOf(HTMLSpanElement)
+    expect(spinner).toHaveClass('will-change-transform')
+    expect(spinner?.querySelector('svg')).not.toHaveClass('animate-spin')
   })
 
   test('collapses when title space is constrained and opens on hover', () => {

--- a/wework/src/components/layout/SubagentStatusIndicator.tsx
+++ b/wework/src/components/layout/SubagentStatusIndicator.tsx
@@ -1,5 +1,6 @@
 import { Bot, CheckCircle2, ChevronDown, CircleAlert, Loader2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type { RuntimeSubagentStatus } from '@/types/workbench'
@@ -109,7 +110,7 @@ function SubagentStatusIcon({ status }: { status: RuntimeSubagentStatus['status'
   if (status === 'interrupted') {
     return <CircleAlert className="h-4 w-4 shrink-0 text-amber-600" />
   }
-  return <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+  return <CompositedSpinner icon={Loader2} className="h-4 w-4 text-primary" />
 }
 
 function shortSubagentId(agentId: string): string {

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -2041,9 +2041,13 @@ describe('ConnectionsSettingsPage', () => {
     await screen.findByTestId('connection-device-device-1')
     expect(screen.queryByTestId('connection-device-local-device')).not.toBeInTheDocument()
     await waitFor(() => expect(api.getMetrics).toHaveBeenCalledWith('device-1'))
-    expect(screen.getByTestId('connection-device-metric-cpu-device-1')).toHaveTextContent('42%')
-    expect(screen.getByTestId('connection-device-metric-memory-device-1')).toHaveTextContent('68%')
-    expect(screen.getByTestId('connection-device-metric-disk-device-1')).toHaveTextContent('57%')
+    await waitFor(() => {
+      expect(screen.getByTestId('connection-device-metric-cpu-device-1')).toHaveTextContent('42%')
+      expect(screen.getByTestId('connection-device-metric-memory-device-1')).toHaveTextContent(
+        '68%'
+      )
+      expect(screen.getByTestId('connection-device-metric-disk-device-1')).toHaveTextContent('57%')
+    })
     expect(screen.queryByTestId('connection-scale-wiki')).not.toBeInTheDocument()
     expect(screen.queryByTestId('connection-scale-wiki-link')).not.toBeInTheDocument()
   })

--- a/wework/src/features/computer-use/ComputerUseActivityIndicator.test.tsx
+++ b/wework/src/features/computer-use/ComputerUseActivityIndicator.test.tsx
@@ -38,7 +38,11 @@ describe('ComputerUseActivityIndicator', () => {
   test('shows the active tool and stops it from the button', async () => {
     render(<ComputerUseActivityIndicator />)
 
-    expect(await screen.findByTestId('computer-use-activity-indicator')).toBeInTheDocument()
+    const indicator = await screen.findByTestId('computer-use-activity-indicator')
+    const spinner = indicator.querySelector('.animate-spin')
+    expect(spinner).toBeInstanceOf(HTMLSpanElement)
+    expect(spinner).toHaveClass('will-change-transform')
+    expect(spinner?.querySelector('svg')).not.toHaveClass('animate-spin')
     await userEvent.click(screen.getByTestId('computer-use-stop-button'))
 
     await waitFor(() => expect(mocks.stop).toHaveBeenCalledOnce())

--- a/wework/src/features/computer-use/ComputerUseActivityIndicator.tsx
+++ b/wework/src/features/computer-use/ComputerUseActivityIndicator.tsx
@@ -1,5 +1,6 @@
 import { Loader2, Square } from 'lucide-react'
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import {
   getComputerUseStatus,
   stopComputerUseCurrentAction,
@@ -61,7 +62,7 @@ export function ComputerUseActivityIndicator() {
       data-testid="computer-use-activity-indicator"
       className="fixed left-1/2 top-12 z-system-popover flex max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center gap-3 rounded-2xl border border-border bg-popover/95 px-4 py-2.5 text-sm text-text-primary shadow-xl backdrop-blur-md"
     >
-      <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+      <CompositedSpinner icon={Loader2} className="h-4 w-4 text-primary" />
       <span className="min-w-0 truncate">
         {t('workbench.computer_use_current_action', { action: status.currentTool })}
       </span>

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react'
 import type { CloudLoopItem } from '@/api/deliveries'
 import type { TaskChangeRequestSnapshot, TaskChangeRequestTarget } from '@/api/changeRequests'
+import { ActivityShimmerText } from '@/components/chat/ActivityShimmerText'
 import { ChangeRequestStatusIcon } from '@/components/common/ChangeRequestStatusIcon'
 import { AssistantThinkingIndicator } from '@/components/chat/AssistantThinkingIndicator'
 import { ChatInput, type ProjectChatControls } from '@/components/chat/ChatInput'
@@ -1175,9 +1176,13 @@ function RuntimeTaskToolActivity({
       data-testid={`cloud-todo-card-tool-${itemId}-${block.id}`}
       className="flex h-5 min-w-0 items-center"
     >
-      <span className={cn('min-w-0 truncate', running && 'waiting-thinking-text')}>
-        {runtimeToolActivityText(block, t)}
-      </span>
+      {running ? (
+        <ActivityShimmerText variant="thinking" className="min-w-0 truncate">
+          {runtimeToolActivityText(block, t)}
+        </ActivityShimmerText>
+      ) : (
+        <span className="min-w-0 truncate">{runtimeToolActivityText(block, t)}</span>
+      )}
     </div>
   )
 }

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -1595,7 +1595,7 @@ describe('CloudTodoWorkspace', () => {
     await userEvent.click(screen.getByTestId('ai-chat-modal-close'))
     expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
     expect(screen.queryByTestId('cloud-todo-detail')).not.toBeInTheDocument()
-  })
+  }, 10_000)
 
   it('ignores a task address that resolves after reopening the task panel', async () => {
     const workbenchServices = services()

--- a/wework/src/features/todo/ProjectQueueView.test.tsx
+++ b/wework/src/features/todo/ProjectQueueView.test.tsx
@@ -470,6 +470,9 @@ describe('ProjectQueueView', () => {
     )
 
     await waitFor(() => expect(screen.getByText('Running task')).toBeInTheDocument())
-    expect(container.querySelector('svg.animate-spin')).not.toBeNull()
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).toBeInstanceOf(HTMLSpanElement)
+    expect(spinner).toHaveClass('will-change-transform')
+    expect(spinner?.querySelector('svg')).not.toHaveClass('animate-spin')
   })
 })

--- a/wework/src/features/todo/ProjectQueueView.tsx
+++ b/wework/src/features/todo/ProjectQueueView.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { CloudLoopItem, CloudLoopItemExecution, CloudProject } from '@/api/deliveries'
 import type { ProjectChatAgent } from '@/api/projectChatAgents'
 import { runtimeProfileIsRunnable, type RuntimeProfile } from '@/api/runtimeProfiles'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import { MenuSelect } from '@/components/common/MenuSelect'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -205,9 +206,11 @@ function QueueStateChip({ state }: { state?: string | null }) {
         current.className
       )}
     >
-      <Icon
-        className={cn('h-3 w-3', (state === 'running' || state === 'cancelling') && 'animate-spin')}
-      />
+      {state === 'running' || state === 'cancelling' ? (
+        <CompositedSpinner icon={Icon} className="h-3 w-3" />
+      ) : (
+        <Icon className="h-3 w-3" />
+      )}
       {state ? queueStateLabel(state, t) : ''}
     </span>
   )
@@ -520,7 +523,7 @@ export function ProjectQueueView({
       {error ? <p className="mb-3 text-sm text-red-600">{error}</p> : null}
       {loading ? (
         <div className="flex h-40 items-center justify-center text-sm text-text-muted">
-          <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+          <CompositedSpinner className="mr-2 h-4 w-4" />
           {t('workbench.project_chat_loading')}
         </div>
       ) : (

--- a/wework/src/features/todo/RuntimeTaskExecutionOverlay.tsx
+++ b/wework/src/features/todo/RuntimeTaskExecutionOverlay.tsx
@@ -6,12 +6,12 @@ import {
   Check,
   ExternalLink,
   Hash,
-  LoaderCircle,
   Monitor,
   RotateCcw,
   Square,
   X,
 } from 'lucide-react'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import { ScrollableMessageArea } from '@/components/chat/ScrollableMessageArea'
@@ -134,7 +134,7 @@ export function RuntimeTaskExecutionOverlay({
     }[displayStatus]
     return (
       <>
-        <LoaderCircle className="h-3 w-3 animate-spin" />
+        <CompositedSpinner className="h-3 w-3" />
         {t(labelKey)}
       </>
     )
@@ -259,7 +259,7 @@ export function RuntimeTaskExecutionOverlay({
               className="inline-flex h-8 items-center gap-2 rounded-lg px-3 text-sm font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50"
             >
               {stopping ? (
-                <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                <CompositedSpinner className="h-3.5 w-3.5" />
               ) : (
                 <Square className="h-3.5 w-3.5" />
               )}

--- a/wework/src/features/todo/TaskActivityView.test.tsx
+++ b/wework/src/features/todo/TaskActivityView.test.tsx
@@ -1426,7 +1426,7 @@ describe('TaskActivityView', () => {
     await screen.findByTestId('cloud-task-activity-review-actions-WEG-1')
     expect(screen.queryByTestId('cloud-task-activity-continue-WEG-1')).not.toBeInTheDocument()
 
-    await user.click(screen.getByTestId('cloud-task-activity-rerun-WEG-1'))
+    await user.click(await screen.findByTestId('cloud-task-activity-rerun-WEG-1'))
     await waitFor(() =>
       expect(client.startAgentResponse).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/wework/src/features/todo/TaskActivityView.tsx
+++ b/wework/src/features/todo/TaskActivityView.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/components/chat/ChatInput'
 import { ConversationQueuePanel } from '@/components/chat/ConversationQueuePanel'
 import { AssistantMarkdown } from '@/components/chat/AssistantMarkdown'
+import { CompositedSpinner } from '@/components/common/CompositedSpinner'
 import { Tooltip } from '@/components/ui/tooltip'
 import { DESKTOP_MESSAGE_LIST_CLASS } from '@/components/layout/desktopChatLayout'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
@@ -1319,7 +1320,7 @@ export function TaskActivityView({
         >
           {loading ? (
             <div className="flex min-h-48 items-center justify-center text-sm text-text-muted">
-              <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+              <CompositedSpinner className="mr-2 h-4 w-4" />
               {t('workbench.project_chat_loading')}
             </div>
           ) : threadMessages.length === 0 ? (
@@ -1677,7 +1678,11 @@ function TaskExecutionStatusControl({
           onClick={() => setOpen(current => !current)}
           className="task-detail-execution-status-trigger"
         >
-          <Icon className={cn('h-4 w-4', animated && 'animate-spin')} />
+          {animated ? (
+            <CompositedSpinner icon={Icon} className="h-4 w-4" />
+          ) : (
+            <Icon className="h-4 w-4" />
+          )}
         </button>
       </Tooltip>
       {open ? (
@@ -1689,7 +1694,11 @@ function TaskExecutionStatusControl({
         >
           <span className="task-detail-execution-status-popover-head">
             <span className="task-detail-execution-status-popover-title">
-              <Icon className={cn('h-4 w-4', animated && 'animate-spin')} />
+              {animated ? (
+                <CompositedSpinner icon={Icon} className="h-4 w-4" />
+              ) : (
+                <Icon className="h-4 w-4" />
+              )}
               {label}
             </span>
             <button
@@ -1809,7 +1818,7 @@ function ChatMessage({
       ) : null}
       {isAgent && !compact && message.status === 'streaming' ? (
         <span className="mt-1 inline-flex items-center gap-1 text-xs text-text-muted">
-          <LoaderCircle className="h-3 w-3 animate-spin" />
+          <CompositedSpinner className="h-3 w-3" />
           {t('workbench.project_chat_processing')}
         </span>
       ) : null}
@@ -2039,7 +2048,11 @@ function ExecutionStatusBadge({
   const animated = ['starting', 'running', 'cancelling'].includes(kind)
   const statusContent = (
     <>
-      <StatusIcon className={cn('h-3 w-3', animated && 'animate-spin')} />
+      {animated ? (
+        <CompositedSpinner icon={StatusIcon} className="h-3 w-3" />
+      ) : (
+        <StatusIcon className="h-3 w-3" />
+      )}
       {labels[kind]}
     </>
   )
@@ -2076,11 +2089,7 @@ function ExecutionStatusBadge({
             onStopExecution()
           }}
         >
-          {stopping ? (
-            <LoaderCircle className="h-3 w-3 animate-spin" />
-          ) : (
-            <Square className="h-3 w-3" />
-          )}
+          {stopping ? <CompositedSpinner className="h-3 w-3" /> : <Square className="h-3 w-3" />}
         </button>
       ) : null}
     </span>

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -1014,11 +1014,8 @@ button:disabled {
   }
 
   .activity-shimmer-band {
-    position: absolute;
-    inset: 0;
     animation: activity-shimmer-band 1.6s linear infinite;
     animation-delay: var(--activity-shimmer-delay);
-    clip-path: inset(0 var(--activity-shimmer-right) 0 var(--activity-shimmer-left));
     color: rgb(var(--color-text-secondary));
     opacity: 0;
     will-change: opacity;
@@ -1029,8 +1026,7 @@ button:disabled {
   }
 
   .activity-shimmer-band::before {
-    content: attr(data-text);
-    white-space: inherit;
+    content: attr(data-grapheme);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -983,55 +983,63 @@ button:disabled {
     animation: local-skill-caret-blink 1s step-end infinite;
   }
 
-  @keyframes waiting-thinking-text {
-    0% {
-      background-position: 140% 50%;
-    }
+  .activity-shimmer-text {
+    position: relative;
+    display: inline-block;
+    color: rgb(var(--color-text-muted));
+  }
 
+  @keyframes activity-shimmer-band {
+    0%,
+    72%,
     100% {
-      background-position: -40% 50%;
+      opacity: 0;
+    }
+
+    82% {
+      opacity: 1;
+    }
+
+    92% {
+      opacity: 0;
     }
   }
 
-  .waiting-thinking-text {
-    display: inline-block;
-    color: rgb(var(--color-text-muted));
-    background-image: linear-gradient(
-      90deg,
-      rgb(var(--color-text-muted)) 0%,
-      rgb(var(--color-text-muted)) 32%,
-      rgb(var(--color-text-primary)) 50%,
-      rgb(var(--color-text-muted)) 68%,
-      rgb(var(--color-text-muted)) 100%
-    );
-    background-size: 240% 100%;
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    animation: waiting-thinking-text 1.6s linear infinite;
+  .activity-shimmer-highlight {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    white-space: inherit;
   }
 
-  .tool-activity-shimmer {
-    display: inline-block;
-    color: rgb(var(--color-text-muted));
-    background-image: linear-gradient(
-      90deg,
-      rgb(var(--color-text-muted)) calc(50% - 1.25em),
-      rgb(var(--color-text-secondary)) 50%,
-      rgb(var(--color-text-muted)) calc(50% + 1.25em)
-    );
-    background-size: calc(100% + 5em) 100%;
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    animation: waiting-thinking-text 1.6s linear infinite;
+  .activity-shimmer-band {
+    position: absolute;
+    inset: 0;
+    animation: activity-shimmer-band 1.6s linear infinite;
+    animation-delay: var(--activity-shimmer-delay);
+    clip-path: inset(0 var(--activity-shimmer-right) 0 var(--activity-shimmer-left));
+    color: rgb(var(--color-text-secondary));
+    opacity: 0;
+    will-change: opacity;
+  }
+
+  .waiting-thinking-text .activity-shimmer-band {
+    color: rgb(var(--color-text-primary));
+  }
+
+  .activity-shimmer-band::before {
+    content: attr(data-text);
+    white-space: inherit;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .tool-activity-shimmer {
-      background: none;
+    .activity-shimmer-text {
       color: rgb(var(--color-text-secondary));
-      -webkit-text-fill-color: currentColor;
+    }
+
+    .activity-shimmer-highlight {
+      display: none;
     }
   }
 


### PR DESCRIPTION
## Summary

- move persistent status spinner rotation from stroked SVGs to a shared fixed-size composited HTML layer across the sidebar, mobile task list, processing summary, subagent status, computer-use status, project queue, and task execution surfaces
- replace paint-bound `background-position` text shimmers with a shared opacity-only, grapheme-aligned highlight implementation
- cap pathological shimmer inputs at 96 animated graphemes without truncating the visible base text or duplicating full command strings per band
- preserve the existing direction, timing, colors, dimensions, visibility states, and reduced-motion behavior
- document evidence-based verification requirements for persistent renderer animations

## Verification

- latest pre-push Wework ESLint, TypeScript, and renderer unit tests passed
- `pnpm --dir wework build` passed
- focused persistent-animation coverage passed: 8 files, 233 tests
- same-Electron 43.4.1 10-second final trace with six simultaneous spinners and active shimmer: `Paint` 0, `PaintImage` 0, `UpdateLayoutTree` 0, `Layerize` 0, `UpdateLayer` 1 event / 0.005 ms
- original same-scene trace: `Paint` 2,402 events / 150.209 ms, `PaintImage` 1,201 events / 17.899 ms, `UpdateLayoutTree` 1,201 events / 121.421 ms, `Layerize` 1,201 events / 53.339 ms
- visual frame samples confirmed all six spinners rotate and the left-to-right shimmer remains active

## Root cause evidence

The supplied traces showed continuous paint-bound animation work. Pausing document animations reduced CPU. The replacement was measured under the same Electron runtime and scene rather than accepted from CSS-property heuristics. A `clip-path` alternative was rejected after it still produced per-frame main-thread layout and layerization work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent shimmer animations for thinking and tool activity text.
  * Updated loading and activity indicators with smoother, composited spinner animations.
  * Animations now better support reduced-motion preferences.

* **Performance**
  * Improved animation rendering to reduce unnecessary visual processing and help lower CPU usage.

* **Documentation**
  * Added guidance for implementing and validating persistent animations in English and Chinese performance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->