### PR TITLE
fix(wework): restore dark menu text contrast

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -282,6 +282,8 @@ embedded may change spacing and composition, but it must not select a
 light-only or dark-only color recipe. Apply this rule to nested surfaces as
 well as their containers: dialogs, directory pickers, menus, inputs, list rows,
 tooltips, footers, and action groups must all inherit the active theme.
+Surfaces rendered through a portal must explicitly set their semantic
+foreground color instead of relying on an ancestor outside the portal target.
 
 Literal white, black, or neutral fills are allowed only when color is part of
 the content contract rather than application chrome. Examples include a QR

--- a/wework/src/components/common/MenuSelect.test.tsx
+++ b/wework/src/components/common/MenuSelect.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { MenuSelect } from './MenuSelect'
 
@@ -59,5 +60,21 @@ describe('MenuSelect', () => {
     expect(selection()).toHaveAttribute('data-invalid', 'true')
     expect(selection()).toHaveClass('text-destructive', 'ring-destructive/40')
     expect(screen.getByTestId('semantic-select')).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('sets the semantic text color on the portaled menu', async () => {
+    const user = userEvent.setup()
+    render(
+      <MenuSelect
+        testId="theme-select"
+        value="09:00"
+        options={[{ value: '09:00', label: '9:00' }]}
+        onChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByTestId('theme-select'))
+
+    expect(screen.getByTestId('theme-select-menu')).toHaveClass('text-text-primary')
   })
 })

--- a/wework/src/components/common/MenuSelect.tsx
+++ b/wework/src/components/common/MenuSelect.tsx
@@ -314,7 +314,7 @@ export function PopupMenu({
               onClick={() => {
                 if (!keepOpen) close()
               }}
-              className="fixed z-[11000] max-h-[360px] overflow-y-auto rounded-2xl border border-border bg-background p-1.5 shadow-[0_16px_44px_rgba(0,0,0,0.16)]"
+              className="fixed z-[11000] max-h-[360px] overflow-y-auto rounded-2xl border border-border bg-background p-1.5 text-text-primary shadow-[0_16px_44px_rgba(0,0,0,0.16)]"
               role="menu"
             >
               {children(close)}


### PR DESCRIPTION
## Summary

- set the shared portaled `PopupMenu` foreground to the semantic primary text color
- cover the portaled menu theme class with a focused regression test
- document that portaled theme surfaces must declare their semantic foreground

## Root cause

The scheduled-task time menu was rendered through a portal with a dark semantic background but no explicit semantic foreground. Its option text could therefore render with a dark control foreground in dark mode.

## Verification

- `pnpm --filter wework test src/components/common/MenuSelect.test.tsx`
- `pnpm --filter wework exec prettier --check src/components/common/MenuSelect.tsx src/components/common/MenuSelect.test.tsx`
- `pnpm --filter wework exec eslint src/components/common/MenuSelect.tsx src/components/common/MenuSelect.test.tsx`
- pre-push Wework ESLint, TypeScript, and unit tests
- isolated real Electron verification in dark mode: opened the scheduled-task time menu and confirmed readable light option text on the dark surface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portaled dropdown menus so their text consistently uses the primary semantic color, even when rendered outside the surrounding component hierarchy.

* **Documentation**
  * Clarified guidance for setting semantic foreground colors on surfaces rendered through portals.

* **Tests**
  * Added coverage verifying that the theme selection menu applies the expected primary text color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->