### PR TITLE
fix(wework): refine conversation typography

### DIFF
--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -254,7 +254,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
 
   return (
     <div
-      className={`${variant === 'process' ? 'thinking-markdown text-text-secondary' : 'assistant-markdown'} min-w-0 max-w-full break-words`}
+      className={`${variant === 'process' ? 'thinking-markdown' : 'assistant-markdown'} min-w-0 max-w-full break-words`}
     >
       {contentParts.map((part, index) =>
         part.kind === 'visualization' ? (

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -40,6 +40,34 @@ vi.mock('@/lib/embedded-browser', () => ({
 }))
 
 describe('MessageList', () => {
+  test('renders complete user and assistant message regions with medium weight', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'user-message',
+            role: 'user',
+            content: '请调整会话字体',
+            status: 'done',
+            createdAt: '2026-09-03T08:00:00Z',
+          },
+          {
+            id: 'assistant-message',
+            role: 'assistant',
+            content: '会话字体已调整',
+            status: 'done',
+            createdAt: '2026-09-03T08:00:01Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('message-user')).toHaveClass('font-medium')
+    expect(screen.getByTestId('message-assistant')).toHaveClass('font-medium')
+    expect(screen.getByTestId('user-message-content')).not.toHaveClass('font-medium')
+    expect(screen.getByTestId('assistant-message-content')).not.toHaveClass('font-medium')
+  })
+
   test('renders a generated Codex inline visualization from the changed workspace file', async () => {
     runtimeMock.electron = true
     desktopHostMock.invoke.mockResolvedValueOnce('<div>折线图</div>')
@@ -2191,7 +2219,10 @@ describe('MessageList', () => {
       assistantContent.compareDocumentPosition(processContent) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(processContent).toHaveClass('text-chat')
+    expect(processContent).toHaveClass('text-text-primary')
+    expect(processContent).not.toHaveClass('text-text-secondary')
     expect(processContent).not.toHaveClass('text-sm')
+    expect(processContent.closest('[data-testid="message-assistant"]')).toHaveClass('font-medium')
   })
 
   test('does not restore hidden failed content from runtime display order', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -587,7 +587,7 @@ export const MessageList = memo(function MessageList({
         const article = (
           <article
             className={cn(
-              'min-w-0',
+              'min-w-0 font-medium',
               !isDesktop &&
                 !disableContentVisibility &&
                 !isTextSelectionActive &&
@@ -660,7 +660,7 @@ export const MessageList = memo(function MessageList({
       })}
       {shouldShowWaitingIndicator && (
         <article
-          className="min-w-0"
+          className="min-w-0 font-medium"
           data-testid="message-assistant-waiting"
           style={
             virtualMessages

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -99,6 +99,8 @@ describe('ToolBlockItem', () => {
 
     expect(block).toHaveAccessibleName('正在处理')
     expect(block).toHaveTextContent('Let me explore the repository structure.')
+    expect(block).toHaveClass('text-text-primary')
+    expect(block).not.toHaveClass('text-text-secondary')
     expect(block.querySelector('svg')).not.toBeInTheDocument()
     expect(screen.queryByTestId('process-text-toggle-button')).not.toBeInTheDocument()
   })

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -952,7 +952,7 @@ function ProcessTextBlockItem({
 
   return (
     <div
-      className="min-w-0 overflow-x-hidden text-chat text-text-secondary"
+      className="min-w-0 overflow-x-hidden text-chat text-text-primary"
       data-processing-block-id={block.id}
       data-message-selectable-text
       role={isRunning ? 'status' : undefined}


### PR DESCRIPTION
## Summary
- use medium weight for complete user and assistant message regions, including waiting and process content
- render process narrative text with the primary text color
- keep desktop sidebar labels at their existing regular weight

## Verification
- `pnpm --filter wework test src/components/chat/MessageList.test.tsx src/components/chat/blocks/ToolBlockItem.test.tsx src/components/layout/DesktopSidebar.test.tsx`
- Prettier and ESLint checks for changed files
- pre-push Wework ESLint, TypeScript, and unit tests
- isolated Electron computed styles: user/assistant message weight 500; assistant text color rgb(26, 26, 26)

Task: WEWORKC2FA61-499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chat message readability by applying medium-weight styling to user and assistant message rows.
  * Updated assistant waiting indicators to use medium font weight.
  * Process and tool-generated text now uses the primary text color instead of the secondary color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->