### PR TITLE
feat(backend): add SCHEDULED_TASKS_ENABLED master switch for periodic tasks

### DIFF
--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -92,35 +92,41 @@ celery_app.conf.update(
             "queue": settings.KNOWLEDGE_CONVERSION_QUEUE,
         },
     },
-    # Beat schedule for periodic tasks
-    beat_schedule={
-        "check-due-subscriptions": {
-            "task": "app.tasks.subscription_tasks.check_due_subscriptions",
-            "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
-        },
-        "scan-robot-queue": {
-            "task": "app.tasks.robot_queue_tasks.scan_robot_queue",
-            "schedule": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
-            "options": {
-                # A maintenance scan older than one interval has been replaced
-                # by a newer scan and must not delay execution tasks.
-                "expires": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
-                "priority": 0,
+    # Beat schedule for periodic tasks.
+    # When SCHEDULED_TASKS_ENABLED is False, this process must not emit beat
+    # ticks: periodic tasks are run by a dedicated deployment instead.
+    beat_schedule=(
+        {}
+        if not settings.SCHEDULED_TASKS_ENABLED
+        else {
+            "check-due-subscriptions": {
+                "task": "app.tasks.subscription_tasks.check_due_subscriptions",
+                "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
             },
-        },
-        "check-due-project-automations": {
-            "task": "app.tasks.project_automation_tasks.check_due_project_automations",
-            "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
-        },
-        "scan-stale-index-tasks": {
-            "task": "app.tasks.knowledge_tasks.scan_stale_index_tasks",
-            "schedule": 5 * 60,  # every 5 minutes
-        },
-        "sync-plugin-upstreams": {
-            "task": "app.tasks.plugin_marketplace_tasks.sync_plugin_upstreams",
-            "schedule": 6 * 60 * 60,
-        },
-    },
+            "scan-robot-queue": {
+                "task": "app.tasks.robot_queue_tasks.scan_robot_queue",
+                "schedule": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
+                "options": {
+                    # A maintenance scan older than one interval has been replaced
+                    # by a newer scan and must not delay execution tasks.
+                    "expires": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
+                    "priority": 0,
+                },
+            },
+            "check-due-project-automations": {
+                "task": "app.tasks.project_automation_tasks.check_due_project_automations",
+                "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
+            },
+            "scan-stale-index-tasks": {
+                "task": "app.tasks.knowledge_tasks.scan_stale_index_tasks",
+                "schedule": 5 * 60,  # every 5 minutes
+            },
+            "sync-plugin-upstreams": {
+                "task": "app.tasks.plugin_marketplace_tasks.sync_plugin_upstreams",
+                "schedule": 6 * 60 * 60,
+            },
+        }
+    ),
     # Beat scheduler class - Use default PersistentScheduler (file-based)
     # Note: Only run ONE Celery Beat instance in production
     # Application-level distributed lock in check_due_subscriptions prevents duplicate execution

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -415,6 +415,13 @@ class Settings(BaseSettings):
             return _normalize_rag_runtime_mode_value(raw, label="global")
         raise ValueError(f"Unsupported RAG_RUNTIME_MODE value: {v!r}")
 
+    # Master switch for all scheduled/periodic tasks started by this Backend
+    # process (background jobs, scheduler backend, Celery Beat schedule, device
+    # heartbeat monitor). Set False when periodic tasks run on a dedicated
+    # machine (e.g. a standalone Celery worker + beat deployment sharing the
+    # same MySQL/Redis) so this process does not compete for the same queues.
+    SCHEDULED_TASKS_ENABLED: bool = True
+
     # Scheduler backend configuration
     # Supported backends: "celery" (default), "apscheduler", "xxljob"
     SCHEDULER_BACKEND: str = "celery"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -340,26 +340,37 @@ async def lifespan(app: FastAPI):
     task_run_metric_hooks.register()
     logger.info("✓ Task run metric transaction hooks registered")
 
-    # Start background jobs
-    logger.info("Starting background jobs...")
-    start_background_jobs(app)
-    logger.info("✓ Background jobs started")
+    # Start background jobs. When periodic tasks run on a dedicated machine
+    # (SCHEDULED_TASKS_ENABLED=false), skip them here so this process does not
+    # compete for the same DB/Redis cleanup and cache-refresh work.
+    if settings.SCHEDULED_TASKS_ENABLED:
+        logger.info("Starting background jobs...")
+        start_background_jobs(app)
+        logger.info("✓ Background jobs started")
+    else:
+        logger.info(
+            "SCHEDULED_TASKS_ENABLED=false, skipping background jobs "
+            "(periodic tasks run on a dedicated deployment)"
+        )
 
     # Start scheduler backend (for Flow scheduling)
     # The scheduler backend is selected based on SCHEDULER_BACKEND config:
     # - "celery" (default): Uses Celery Beat with embedded/standalone mode
     # - "apscheduler": Uses APScheduler (lightweight, no Redis required)
     # - "xxljob": Uses XXL-JOB distributed scheduler
-    logger.info(f"Starting scheduler backend: {settings.SCHEDULER_BACKEND}...")
-    from app.core.scheduler import start_scheduler
+    if settings.SCHEDULED_TASKS_ENABLED:
+        logger.info(f"Starting scheduler backend: {settings.SCHEDULER_BACKEND}...")
+        from app.core.scheduler import start_scheduler
 
-    scheduler = start_scheduler()
-    if scheduler:
-        logger.info(f"✓ Scheduler backend '{scheduler.backend_type}' started")
+        scheduler = start_scheduler()
+        if scheduler:
+            logger.info(f"✓ Scheduler backend '{scheduler.backend_type}' started")
+        else:
+            logger.warning(
+                "Failed to start scheduler backend. Flow scheduling may not work."
+            )
     else:
-        logger.warning(
-            "Failed to start scheduler backend. Flow scheduling may not work."
-        )
+        logger.info("SCHEDULED_TASKS_ENABLED=false, skipping scheduler backend startup")
 
     # Initialize Socket.IO WebSocket emitter
     # Note: Chat namespace is already registered in create_socketio_asgi_app()
@@ -444,11 +455,14 @@ async def lifespan(app: FastAPI):
     logger.info("✓ PendingRequestRegistry initialized")
 
     # Start device heartbeat monitor for local device support
-    logger.info("Starting device heartbeat monitor...")
-    from app.services.device_monitor import start_device_monitor
+    if settings.SCHEDULED_TASKS_ENABLED:
+        logger.info("Starting device heartbeat monitor...")
+        from app.services.device_monitor import start_device_monitor
 
-    start_device_monitor()
-    logger.info("✓ Device heartbeat monitor started")
+        start_device_monitor()
+        logger.info("✓ Device heartbeat monitor started")
+    else:
+        logger.info("SCHEDULED_TASKS_ENABLED=false, skipping device heartbeat monitor")
 
     # Initialize IM Channel Manager and start enabled channels
     # This enables DingTalk, Feishu, WeChat bot integrations


### PR DESCRIPTION
## Summary

- Add a single env-gated master switch `SCHEDULED_TASKS_ENABLED` (default `true`) controlling all periodic-task startup in the backend process
- When disabled, lifespan skips `start_background_jobs()` (executor cleanup + repo cache refresh workers), `start_scheduler()` (including embedded Celery worker/beat), and `start_device_monitor()`
- Celery `beat_schedule` becomes empty when disabled, so even a manually started standalone beat on such a deployment emits no ticks

## Motivation

Periodic tasks can be run on a dedicated deployment (standalone Celery worker + beat sharing the same MySQL/Redis). Other backend processes — e.g. rewrite-comparison verification environments that must not consume production queues — need a one-flag way to opt out of all scheduled work. Default `true` keeps existing behavior unchanged.

## Verification

- `SCHEDULED_TASKS_ENABLED` unset → `beat_schedule` has 5 entries (unchanged)
- `SCHEDULED_TASKS_ENABLED=false` → `beat_schedule` is empty, startup skips background jobs / scheduler / device monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable scheduled background tasks.
  * When disabled, periodic jobs, scheduler services, task scheduling, and device heartbeat monitoring no longer start.
  * Existing scheduled-task behavior remains unchanged when the option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->