### PR TITLE
feat(backend): add scheduled task master switch

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,6 +45,12 @@ DEFAULT_VIDEO_GENERATION_MODEL=
 # Set to 'wegent_online' or 'wegent_preview' as needed
 # CELERY_TASK_DEFAULT_QUEUE=wegent_online
 
+# Master switch for periodic work started by this Backend process.
+# Set to false for traffic verification against shared resources. This disables
+# background maintenance workers, scheduler startup, embedded Celery worker/Beat,
+# and the device heartbeat monitor. Do not start standalone Celery workers there.
+# SCHEDULED_TASKS_ENABLED=true
+
 # Subscription scheduler database scan switch
 # Set to false in environments that must not scan shared Subscription data.
 # SUBSCRIPTION_SCHEDULER_ENABLED=true

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -43,6 +43,42 @@ from app.core.logging import RequestIdFilter, _create_file_handler
 broker_url = settings.CELERY_BROKER_URL or settings.REDIS_URL
 result_backend = settings.CELERY_RESULT_BACKEND or settings.REDIS_URL
 
+
+def build_beat_schedule() -> dict:
+    """Return periodic Celery tasks enabled for this Backend process."""
+    if not settings.SCHEDULED_TASKS_ENABLED:
+        return {}
+
+    return {
+        "check-due-subscriptions": {
+            "task": "app.tasks.subscription_tasks.check_due_subscriptions",
+            "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
+        },
+        "scan-robot-queue": {
+            "task": "app.tasks.robot_queue_tasks.scan_robot_queue",
+            "schedule": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
+            "options": {
+                # A maintenance scan older than one interval has been replaced
+                # by a newer scan and must not delay execution tasks.
+                "expires": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
+                "priority": 0,
+            },
+        },
+        "check-due-project-automations": {
+            "task": "app.tasks.project_automation_tasks.check_due_project_automations",
+            "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
+        },
+        "scan-stale-index-tasks": {
+            "task": "app.tasks.knowledge_tasks.scan_stale_index_tasks",
+            "schedule": 5 * 60,  # every 5 minutes
+        },
+        "sync-plugin-upstreams": {
+            "task": "app.tasks.plugin_marketplace_tasks.sync_plugin_upstreams",
+            "schedule": 6 * 60 * 60,
+        },
+    }
+
+
 celery_app = Celery(
     "wegent",
     broker=broker_url,
@@ -92,35 +128,9 @@ celery_app.conf.update(
             "queue": settings.KNOWLEDGE_CONVERSION_QUEUE,
         },
     },
-    # Beat schedule for periodic tasks
-    beat_schedule={
-        "check-due-subscriptions": {
-            "task": "app.tasks.subscription_tasks.check_due_subscriptions",
-            "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
-        },
-        "scan-robot-queue": {
-            "task": "app.tasks.robot_queue_tasks.scan_robot_queue",
-            "schedule": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
-            "options": {
-                # A maintenance scan older than one interval has been replaced
-                # by a newer scan and must not delay execution tasks.
-                "expires": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
-                "priority": 0,
-            },
-        },
-        "check-due-project-automations": {
-            "task": "app.tasks.project_automation_tasks.check_due_project_automations",
-            "schedule": float(settings.FLOW_SCHEDULER_INTERVAL_SECONDS),
-        },
-        "scan-stale-index-tasks": {
-            "task": "app.tasks.knowledge_tasks.scan_stale_index_tasks",
-            "schedule": 5 * 60,  # every 5 minutes
-        },
-        "sync-plugin-upstreams": {
-            "task": "app.tasks.plugin_marketplace_tasks.sync_plugin_upstreams",
-            "schedule": 6 * 60 * 60,
-        },
-    },
+    # Keep this empty in verification environments even if Celery Beat is
+    # started independently from the Backend process.
+    beat_schedule=build_beat_schedule(),
     # Beat scheduler class - Use default PersistentScheduler (file-based)
     # Note: Only run ONE Celery Beat instance in production
     # Application-level distributed lock in check_due_subscriptions prevents duplicate execution

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -415,6 +415,12 @@ class Settings(BaseSettings):
             return _normalize_rag_runtime_mode_value(raw, label="global")
         raise ValueError(f"Unsupported RAG_RUNTIME_MODE value: {v!r}")
 
+    # Master switch for scheduled work started by this Backend process.
+    # Disable it for traffic-verification environments that share production
+    # resources but must not run maintenance, scheduling, or queue-consuming
+    # workers. Scheduled work can run on a dedicated deployment instead.
+    SCHEDULED_TASKS_ENABLED: bool = True
+
     # Scheduler backend configuration
     # Supported backends: "celery" (default), "apscheduler", "xxljob"
     SCHEDULER_BACKEND: str = "celery"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -340,26 +340,31 @@ async def lifespan(app: FastAPI):
     task_run_metric_hooks.register()
     logger.info("✓ Task run metric transaction hooks registered")
 
-    # Start background jobs
-    logger.info("Starting background jobs...")
-    start_background_jobs(app)
-    logger.info("✓ Background jobs started")
+    if settings.SCHEDULED_TASKS_ENABLED:
+        logger.info("Starting background jobs...")
+        start_background_jobs(app)
+        logger.info("✓ Background jobs started")
+    else:
+        logger.info("Scheduled tasks are disabled; skipping background jobs")
 
     # Start scheduler backend (for Flow scheduling)
     # The scheduler backend is selected based on SCHEDULER_BACKEND config:
     # - "celery" (default): Uses Celery Beat with embedded/standalone mode
     # - "apscheduler": Uses APScheduler (lightweight, no Redis required)
     # - "xxljob": Uses XXL-JOB distributed scheduler
-    logger.info(f"Starting scheduler backend: {settings.SCHEDULER_BACKEND}...")
-    from app.core.scheduler import start_scheduler
+    if settings.SCHEDULED_TASKS_ENABLED:
+        logger.info(f"Starting scheduler backend: {settings.SCHEDULER_BACKEND}...")
+        from app.core.scheduler import start_scheduler
 
-    scheduler = start_scheduler()
-    if scheduler:
-        logger.info(f"✓ Scheduler backend '{scheduler.backend_type}' started")
+        scheduler = start_scheduler()
+        if scheduler:
+            logger.info(f"✓ Scheduler backend '{scheduler.backend_type}' started")
+        else:
+            logger.warning(
+                "Failed to start scheduler backend. Flow scheduling may not work."
+            )
     else:
-        logger.warning(
-            "Failed to start scheduler backend. Flow scheduling may not work."
-        )
+        logger.info("Scheduled tasks are disabled; skipping scheduler backend")
 
     # Initialize Socket.IO WebSocket emitter
     # Note: Chat namespace is already registered in create_socketio_asgi_app()
@@ -443,12 +448,15 @@ async def lifespan(app: FastAPI):
     await get_pending_request_registry()
     logger.info("✓ PendingRequestRegistry initialized")
 
-    # Start device heartbeat monitor for local device support
-    logger.info("Starting device heartbeat monitor...")
-    from app.services.device_monitor import start_device_monitor
+    # Start device heartbeat monitor for local device support.
+    if settings.SCHEDULED_TASKS_ENABLED:
+        logger.info("Starting device heartbeat monitor...")
+        from app.services.device_monitor import start_device_monitor
 
-    start_device_monitor()
-    logger.info("✓ Device heartbeat monitor started")
+        start_device_monitor()
+        logger.info("✓ Device heartbeat monitor started")
+    else:
+        logger.info("Scheduled tasks are disabled; skipping device heartbeat monitor")
 
     # Initialize IM Channel Manager and start enabled channels
     # This enables DingTalk, Feishu, WeChat bot integrations

--- a/backend/tests/core/test_celery_robot_queue_schedule.py
+++ b/backend/tests/core/test_celery_robot_queue_schedule.py
@@ -1,4 +1,4 @@
-from app.core.celery_app import celery_app
+from app.core.celery_app import build_beat_schedule, celery_app
 from app.core.config import settings
 
 
@@ -10,3 +10,9 @@ def test_robot_queue_scan_expires_before_it_can_form_a_backlog() -> None:
         "expires": float(settings.ROBOT_QUEUE_SCAN_INTERVAL_SECONDS),
         "priority": 0,
     }
+
+
+def test_beat_schedule_is_empty_when_scheduled_tasks_are_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "SCHEDULED_TASKS_ENABLED", False)
+
+    assert build_beat_schedule() == {}

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -78,6 +78,15 @@ class TestSettings:
         assert s.ACCESS_TOKEN_EXPIRE_MINUTES == 120
         assert s.ENABLE_API_DOCS is False
 
+    def test_scheduled_tasks_switch_defaults_to_enabled_and_reads_environment(
+        self, monkeypatch
+    ):
+        assert build_settings().SCHEDULED_TASKS_ENABLED is True
+
+        monkeypatch.setenv("SCHEDULED_TASKS_ENABLED", "false")
+
+        assert build_settings_from_env().SCHEDULED_TASKS_ENABLED is False
+
     def test_plugin_publication_active_request_limit_must_be_positive(self):
         """Prevent capacity configuration from disabling publication globally."""
         with pytest.raises(


### PR DESCRIPTION
## Summary

- Add `SCHEDULED_TASKS_ENABLED`, enabled by default, for Backend traffic-verification environments.
- Disable startup background jobs, scheduler startup, embedded Celery worker/Beat, and device heartbeat monitoring when the switch is false.
- Leave Celery Beat schedule empty when disabled, including for independently started Beat processes.

## Verification

- `uv run black --check app/core/config.py app/core/celery_app.py app/main.py tests/core/test_config.py tests/core/test_celery_robot_queue_schedule.py`
- `uv run pytest tests/core/test_config.py tests/core/test_celery_robot_queue_schedule.py` (29 passed)
- `SCHEDULED_TASKS_ENABLED=false uv run python -c ...` confirms an empty Beat schedule.

## Task

- UXfMDfuvGi / 1026063_1#87020: 精简后端重写Skill工程规范

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `SCHEDULED_TASKS_ENABLED` configuration option for controlling periodic backend activity.
  * Scheduled maintenance, queue processing, automation, synchronization, and device monitoring can now be disabled through configuration.
  * The setting is enabled by default and can be overridden through the environment.

* **Tests**
  * Added coverage verifying the default setting, environment-based configuration, and disabled scheduled-task behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->