### PR TITLE
fix(wework): prevent hover card layout update loop

### DIFF
--- a/wework/src/components/ui/hover-card.test.tsx
+++ b/wework/src/components/ui/hover-card.test.tsx
@@ -388,4 +388,59 @@ describe('HoverCard', () => {
       top: '380px',
     })
   })
+
+  test('calibrates once when the rendered size changes with its position', async () => {
+    vi.useFakeTimers()
+    let cardMeasurements = 0
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      const isCard = this.dataset.testid === 'stable-hover-card'
+      if (!isCard) {
+        return {
+          x: 100,
+          y: 500,
+          width: 100,
+          height: 40,
+          top: 500,
+          right: 200,
+          bottom: 540,
+          left: 100,
+          toJSON: () => undefined,
+        }
+      }
+
+      cardMeasurements += 1
+      const top = Number.parseFloat(this.style.top)
+      const height = top === 500 ? 340 : 220
+      return {
+        x: 210,
+        y: top,
+        width: 360,
+        height,
+        top,
+        right: 570,
+        bottom: top + height,
+        left: 210,
+        toJSON: () => undefined,
+      }
+    })
+    vi.stubGlobal('innerWidth', 1024)
+    vi.stubGlobal('innerHeight', 768)
+
+    render(
+      <HoverCard
+        testId="stable-hover-card"
+        estimatedWidth={360}
+        estimatedHeight={220}
+        content={<div>Position-sensitive details</div>}
+      >
+        <div>Current task</div>
+      </HoverCard>
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Current task'))
+    await act(async () => vi.advanceTimersByTime(450))
+
+    expect(screen.getByTestId('stable-hover-card')).toHaveStyle({ left: '210px', top: '200px' })
+    expect(cardMeasurements).toBe(1)
+  })
 })

--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -91,6 +91,7 @@ export function HoverCard({
   const pinnedRef = useRef(false)
   const [position, setPosition] = useState<HoverCardPosition | null>(null)
   const [pinned, setPinned] = useState(false)
+  const isOpen = position !== null
 
   const clearTimers = useCallback(() => {
     if (openTimerRef.current !== null) {
@@ -206,8 +207,10 @@ export function HoverCard({
     []
   )
 
+  // Calibrate once per open transition. Re-running from the position update can
+  // make position-sensitive content alternate between two measured layouts.
   useLayoutEffect(() => {
-    if (!position) return
+    if (!isOpen) return
     const anchorRect = anchorRef.current?.getBoundingClientRect()
     const cardRect = cardRef.current?.getBoundingClientRect()
     if (!anchorRect || !cardRect) return
@@ -217,9 +220,13 @@ export function HoverCard({
       cardRect.width || estimatedWidth,
       cardRect.height || estimatedHeight
     )
-    if (nextPosition.left === position.left && nextPosition.top === position.top) return
-    setPosition(nextPosition)
-  }, [estimatedHeight, estimatedWidth, position])
+    setPosition(current => {
+      if (!current || (nextPosition.left === current.left && nextPosition.top === current.top)) {
+        return current
+      }
+      return nextPosition
+    })
+  }, [estimatedHeight, estimatedWidth, isOpen])
 
   useEffect(() => {
     if (!position) return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HoverCard positioning when its content height changes after opening.
  - Prevented repeated recalibration while the card remains open.
  - Preserved the current placement when no position adjustment is needed.

- **Tests**
  - Added regression coverage for one-time position calibration based on the card’s initial placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->