### PR TITLE
fix(wework): reuse default project space tab

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -2260,7 +2260,7 @@ last_updated = "2026-07-30T00:00:00Z"`
       shouldRunDesktopCheckpoint('task-board-association')
     ) {
       phase = 'project-space-default-association-setup'
-      associatedTaskTabTestId = await verifyDefaultTaskBoardAssociation(control, projectRowSelector)
+      associatedTaskTabTestId = await verifyDefaultTaskBoardAssociation(control)
     }
 
     if (MIXED_TOOL_TURNS_ONLY) {

--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -25,6 +25,12 @@ import {
   writeFile,
 } from './shared.mjs'
 
+const FIXED_BOARD_ROUTE_TAB_ID = 'fixed-board'
+const FIXED_BOARD_TAB_ID = `workspace-tab-${FIXED_BOARD_ROUTE_TAB_ID}`
+const FIXED_BOARD_TAB_SELECT_TEST_ID = `workspace-tab-select-${FIXED_BOARD_ROUTE_TAB_ID}`
+const FIXED_BOARD_TAB_CONTENT_TEST_ID = `workspace-tab-content-${FIXED_BOARD_ROUTE_TAB_ID}`
+const FIXED_BOARD_CONTENT_SELECTOR = `[data-testid="${FIXED_BOARD_TAB_CONTENT_TEST_ID}"]`
+
 async function waitForFolderPathReady(control, expectedPath) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < DEFAULT_STEP_TIMEOUT_MS) {
@@ -875,7 +881,7 @@ async function verifyDefaultTaskBoardAssociation(control) {
     )
     assert.deepEqual(
       workspaceTabIds(startupTabs, 'board'),
-      ['workspace-tab-fixed-board'],
+      [FIXED_BOARD_TAB_ID],
       'The fresh task workspace did not start with one unresolved fixed project-space tab'
     )
     await control.command('markElementWithText', '[data-testid^="project-row-"]', {
@@ -914,6 +920,25 @@ async function verifyDefaultTaskBoardAssociation(control) {
   }
 }
 
+async function requireActiveFixedBoardTab(control, message) {
+  await control.command('waitFor', '[data-tab-kind="board"][aria-selected="true"]', {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  const activeBoardTabTestId = await control.command(
+    'getAttribute',
+    '[data-tab-kind="board"][aria-selected="true"]',
+    { value: 'data-testid' }
+  )
+  assert.equal(activeBoardTabTestId, FIXED_BOARD_TAB_SELECT_TEST_ID, message)
+  const boardTabs = workspaceTabIds(JSON.parse(await control.command('snapshot', 'body')), 'board')
+  assert.deepEqual(
+    boardTabs,
+    [FIXED_BOARD_TAB_ID],
+    'Opening the bound project space created a duplicate board tab'
+  )
+  return FIXED_BOARD_CONTENT_SELECTOR
+}
+
 async function verifyTrackedTaskBoardRunningStatus(
   control,
   screenshotName = 'workspace-02-running-task-synchronized.png'
@@ -928,26 +953,10 @@ async function verifyTrackedTaskBoardRunningStatus(
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
   await control.command('click', '[data-testid="work-item-open-board-menu"]')
-  await control.command('waitFor', '[data-tab-kind="board"][aria-selected="true"]', {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-  })
-  const activeBoardTabTestId = await control.command(
-    'getAttribute',
-    '[data-tab-kind="board"][aria-selected="true"]',
-    { value: 'data-testid' }
-  )
-  assert.equal(
-    activeBoardTabTestId,
-    'workspace-tab-select-fixed-board',
+  const activeBoardContentSelector = await requireActiveFixedBoardTab(
+    control,
     'The first work-item navigation did not reuse the unresolved fixed project-space tab'
   )
-  const boardTabs = workspaceTabIds(JSON.parse(await control.command('snapshot', 'body')), 'board')
-  assert.deepEqual(
-    boardTabs,
-    ['workspace-tab-fixed-board'],
-    'The first work-item navigation created a duplicate project-space tab'
-  )
-  const activeBoardContentSelector = '[data-testid="workspace-tab-content-fixed-board"]'
   const runningColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_progress"]`
   const reviewColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_review"]`
   await control.command('waitFor', runningColumnSelector, {
@@ -1042,20 +1051,10 @@ async function verifyTrackedTaskSettledStatus(control) {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
   await control.command('click', '[data-testid="work-item-open-board-menu"]')
-  await control.command('waitFor', '[data-tab-kind="board"][aria-selected="true"]', {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-  })
-  const activeBoardTabTestId = await control.command(
-    'getAttribute',
-    '[data-tab-kind="board"][aria-selected="true"]',
-    { value: 'data-testid' }
-  )
-  assert.equal(
-    activeBoardTabTestId,
-    'workspace-tab-select-fixed-board',
+  const activeBoardContentSelector = await requireActiveFixedBoardTab(
+    control,
     'The settled work-item navigation did not reuse the fixed project-space tab'
   )
-  const activeBoardContentSelector = '[data-testid="workspace-tab-content-fixed-board"]'
   const runningColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_progress"]`
   const reviewColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_review"]`
   await control.command('scrollIntoView', reviewColumnSelector)
@@ -1107,27 +1106,16 @@ async function verifyExplicitlyTrackedTask(control, taskTabTestId) {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
   await control.command('click', '[data-testid="work-item-open-board"]')
-  await control.command('waitFor', '[data-tab-kind="board"][aria-selected="true"]', {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-  })
-  const activeBoardTabTestId = await control.command(
-    'getAttribute',
-    '[data-tab-kind="board"][aria-selected="true"]',
-    { value: 'data-testid' }
+  const activeBoardContentSelector = await requireActiveFixedBoardTab(
+    control,
+    'The tracked work-item navigation did not reuse the fixed project-space tab'
   )
-  const activeBoardTabPrefix = 'workspace-tab-select-board-'
-  assert.ok(
-    activeBoardTabTestId?.startsWith(activeBoardTabPrefix),
-    'The active work-item board tab identity was unavailable'
-  )
-  const activeBoardTabSuffix = activeBoardTabTestId.slice(activeBoardTabPrefix.length)
-  const activeBoardContentSelector = `[data-testid="workspace-tab-content-board-${activeBoardTabSuffix}"]`
   await waitForStableSnapshot(
     control,
     snapshot =>
-      snapshot.location.includes(`workspaceTab=board-${activeBoardTabSuffix}`) &&
+      snapshot.location.includes(`workspaceTab=${FIXED_BOARD_ROUTE_TAB_ID}`) &&
       !snapshot.location.includes('itemId=') &&
-      snapshot.testIds.includes(`workspace-tab-content-board-${activeBoardTabSuffix}`) &&
+      snapshot.testIds.includes(FIXED_BOARD_TAB_CONTENT_TEST_ID) &&
       !snapshot.testIds.includes('cloud-todo-board-loading') &&
       snapshot.text.includes('WEWORK_DESKTOP_E2E_TASK'),
     'The work-item board did not settle on the tracked task awaiting confirmation'
@@ -1221,21 +1209,10 @@ async function verifyExistingTaskBoardAssociation(
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
   await control.command('click', '[data-testid="work-item-open-board-menu"]')
-  await control.command('waitFor', '[data-tab-kind="board"][aria-selected="true"]', {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-  })
-  const activeBoardTabTestId = await control.command(
-    'getAttribute',
-    '[data-tab-kind="board"][aria-selected="true"]',
-    { value: 'data-testid' }
+  const activeBoardContentSelector = await requireActiveFixedBoardTab(
+    control,
+    'The source work-item navigation did not reuse the fixed project-space tab'
   )
-  const activeBoardTabPrefix = 'workspace-tab-select-board-'
-  assert.ok(
-    activeBoardTabTestId?.startsWith(activeBoardTabPrefix),
-    'The source board tab identity was unavailable before moving the existing task'
-  )
-  const activeBoardTabSuffix = activeBoardTabTestId.slice(activeBoardTabPrefix.length)
-  const activeBoardContentSelector = `[data-testid="workspace-tab-content-board-${activeBoardTabSuffix}"]`
   const targetProjectName = 'Existing Task Target Board'
   await control.command('click', `${activeBoardContentSelector} [data-testid="cloud-project-add"]`)
   await control.command('waitFor', '[data-testid="cloud-project-name"]', {
@@ -1334,20 +1311,10 @@ async function verifyExistingTaskBoardAssociation(
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
   await control.command('click', '[data-testid="work-item-open-board-menu"]')
-  await control.command('waitFor', '[data-tab-kind="board"][aria-selected="true"]', {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
-  })
-  const movedBoardTabTestId = await control.command(
-    'getAttribute',
-    '[data-tab-kind="board"][aria-selected="true"]',
-    { value: 'data-testid' }
+  const movedBoardContentSelector = await requireActiveFixedBoardTab(
+    control,
+    'The moved work-item navigation did not continue reusing the fixed project-space tab'
   )
-  assert.ok(
-    movedBoardTabTestId?.startsWith(activeBoardTabPrefix),
-    'The target board tab identity was unavailable after moving the existing task'
-  )
-  const movedBoardTabSuffix = movedBoardTabTestId.slice(activeBoardTabPrefix.length)
-  const movedBoardContentSelector = `[data-testid="workspace-tab-content-board-${movedBoardTabSuffix}"]`
   await control.command(
     'waitFor',
     `${movedBoardContentSelector} [data-testid="cloud-project-header-title"]`,

--- a/wework/e2e/desktop/modules/workspace-flows.mjs
+++ b/wework/e2e/desktop/modules/workspace-flows.mjs
@@ -856,12 +856,38 @@ async function verifyWorkspaceIssueCreation(control) {
   )
 }
 
-async function verifyDefaultTaskBoardAssociation(control, projectRowSelector) {
+async function verifyDefaultTaskBoardAssociation(control) {
   await ensureExperimentalFeaturesDisabled(control)
   try {
+    await control.command('click', '[data-testid="workspace-tab-select-fixed-task"]')
+    await control.command('navigate', 'body', { value: '/' })
+    await reloadMainWindow(
+      control,
+      'The Wework WebView did not reconnect before the first project-space navigation'
+    )
+    await control.command(
+      'waitFor',
+      '[data-testid="workspace-tab-select-fixed-task"][aria-selected="true"]',
+      { timeoutMs: WORKBENCH_READY_TIMEOUT_MS }
+    )
+    const startupTabs = JSON.parse(
+      await control.command('snapshot', '[data-testid="workspace-tab-strip"]')
+    )
+    assert.deepEqual(
+      workspaceTabIds(startupTabs, 'board'),
+      ['workspace-tab-fixed-board'],
+      'The fresh task workspace did not start with one unresolved fixed project-space tab'
+    )
+    await control.command('markElementWithText', '[data-testid^="project-row-"]', {
+      text: 'workspace',
+      value: 'default-association-project',
+      timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+    })
+    const refreshedProjectRowSelector = '[data-e2e-anchor-id="default-association-project"]'
+    await control.command('hover', refreshedProjectRowSelector, { visible: true })
     await control.command(
       'click',
-      `${projectRowSelector} [data-testid="project-new-conversation-button"]`
+      `${refreshedProjectRowSelector} [data-testid="project-new-conversation-button"]`
     )
     await control.command('waitFor', '[data-testid="project-work-button"]', {
       text: 'workspace',
@@ -910,13 +936,18 @@ async function verifyTrackedTaskBoardRunningStatus(
     '[data-tab-kind="board"][aria-selected="true"]',
     { value: 'data-testid' }
   )
-  const activeBoardTabPrefix = 'workspace-tab-select-board-'
-  assert.ok(
-    activeBoardTabTestId?.startsWith(activeBoardTabPrefix),
-    'The running work-item board tab identity was unavailable'
+  assert.equal(
+    activeBoardTabTestId,
+    'workspace-tab-select-fixed-board',
+    'The first work-item navigation did not reuse the unresolved fixed project-space tab'
   )
-  const activeBoardTabSuffix = activeBoardTabTestId.slice(activeBoardTabPrefix.length)
-  const activeBoardContentSelector = `[data-testid="workspace-tab-content-board-${activeBoardTabSuffix}"]`
+  const boardTabs = workspaceTabIds(JSON.parse(await control.command('snapshot', 'body')), 'board')
+  assert.deepEqual(
+    boardTabs,
+    ['workspace-tab-fixed-board'],
+    'The first work-item navigation created a duplicate project-space tab'
+  )
+  const activeBoardContentSelector = '[data-testid="workspace-tab-content-fixed-board"]'
   const runningColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_progress"]`
   const reviewColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_review"]`
   await control.command('waitFor', runningColumnSelector, {
@@ -1019,13 +1050,12 @@ async function verifyTrackedTaskSettledStatus(control) {
     '[data-tab-kind="board"][aria-selected="true"]',
     { value: 'data-testid' }
   )
-  const activeBoardTabPrefix = 'workspace-tab-select-board-'
-  assert.ok(
-    activeBoardTabTestId?.startsWith(activeBoardTabPrefix),
-    'The settled work-item board tab identity was unavailable'
+  assert.equal(
+    activeBoardTabTestId,
+    'workspace-tab-select-fixed-board',
+    'The settled work-item navigation did not reuse the fixed project-space tab'
   )
-  const activeBoardTabSuffix = activeBoardTabTestId.slice(activeBoardTabPrefix.length)
-  const activeBoardContentSelector = `[data-testid="workspace-tab-content-board-${activeBoardTabSuffix}"]`
+  const activeBoardContentSelector = '[data-testid="workspace-tab-content-fixed-board"]'
   const runningColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_progress"]`
   const reviewColumnSelector = `${activeBoardContentSelector} [data-testid="cloud-todo-column-in_review"]`
   await control.command('scrollIntoView', reviewColumnSelector)

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { PointerEventHandler } from 'react'
-import { DEFAULT_WORK_ITEM_PROJECT_ID } from '@/api/deliveries'
 import type { ProjectCreateMode } from '@/components/chat/ChatInput'
 import { useWorkbench } from '@/features/workbench/useWorkbench'
 import { useAuth } from '@/features/auth/useAuth'
@@ -9,7 +8,6 @@ import type {
   GitCloneProjectOperation,
   IMPrivateSession,
   ProjectWithTasks,
-  RuntimeProjectSpaceRef,
   RuntimeTaskAddress,
   RuntimeIMNotificationSettingsResponse,
 } from '@/types/api'
@@ -41,7 +39,14 @@ import { EMPTY_RUNTIME_TASK_REMINDERS } from '@/features/workbench/runtimeTaskRe
 import { useRuntimeTaskLifecycleStoreSnapshot } from '@/features/workbench/runtimeTaskLifecycle'
 import { CloudTodoWorkspace } from '@/features/todo/CloudTodoWorkspace'
 import { resolveLocalTodoProjects } from '@/features/todo/localTodoProjects'
-import { projectSpaceApis } from '@/features/todo/projectSpaceSelection'
+import { projectSpaceApis, projectSpaceRef } from '@/features/todo/projectSpaceSelection'
+import {
+  defaultProjectSpaceContentRoute,
+  projectSpaceContentRoute,
+  projectSpaceRefFromRoute,
+  projectSpaceRouteParam,
+  projectSpaceRouteRequestsDefaultProject,
+} from '@/features/todo/projectSpaceRoute'
 import { WorkbenchBackground } from '@/features/appearance'
 import { useResizableSidebar } from './useResizableSidebar'
 import { useOptionalWorkspaceTabs } from '@/features/workspace-tabs/workspaceTabsContextValue'
@@ -89,26 +94,6 @@ function isSameRuntimeTask(
     current?.deviceId === next.deviceId &&
     current.taskId === next.taskId &&
     (!currentPath || !nextPath || currentPath === nextPath)
-  )
-}
-
-function boardRouteParam(contentRoute: string, name: string): string | null {
-  const searchIndex = contentRoute.indexOf('?')
-  if (searchIndex < 0) return null
-  return new URLSearchParams(contentRoute.slice(searchIndex + 1)).get(name)
-}
-
-function boardRouteProjectRef(contentRoute: string): RuntimeProjectSpaceRef | null {
-  const projectId = boardRouteParam(contentRoute, 'projectId')
-  const projectStore = boardRouteParam(contentRoute, 'projectStore')
-  if (!projectId || (projectStore !== 'local' && projectStore !== 'backend')) return null
-  return { projectId, projectStore }
-}
-
-function boardRouteRequestsDefaultProject(contentRoute: string): boolean {
-  return (
-    boardRouteParam(contentRoute, 'projectId') === DEFAULT_WORK_ITEM_PROJECT_ID &&
-    boardRouteParam(contentRoute, 'projectStore') === null
   )
 }
 
@@ -1075,33 +1060,30 @@ export function DesktopWorkbenchLayout({
                 onLogout={onLogout}
                 activeProjectRef={
                   workspaceTabs?.activeTab.kind === 'board'
-                    ? boardRouteProjectRef(workspaceTabs.activeTab.contentRoute)
+                    ? projectSpaceRefFromRoute(workspaceTabs.activeTab.contentRoute)
                     : undefined
                 }
                 defaultProjectRequested={
                   workspaceTabs?.activeTab.kind === 'board' &&
-                  boardRouteRequestsDefaultProject(workspaceTabs.activeTab.contentRoute)
+                  projectSpaceRouteRequestsDefaultProject(workspaceTabs.activeTab.contentRoute)
                 }
                 focusedItemId={
                   workspaceTabs?.activeTab.kind === 'board'
-                    ? boardRouteParam(workspaceTabs.activeTab.contentRoute, 'itemId')
+                    ? projectSpaceRouteParam(workspaceTabs.activeTab.contentRoute, 'itemId')
                     : undefined
                 }
                 onFocusedItemHandled={() => {
                   if (!workspaceTabs || workspaceTabs.activeTab.kind !== 'board') return
-                  const projectRef = boardRouteProjectRef(workspaceTabs.activeTab.contentRoute)
-                  const defaultProjectRequested = boardRouteRequestsDefaultProject(
+                  const projectRef = projectSpaceRefFromRoute(workspaceTabs.activeTab.contentRoute)
+                  const defaultProjectRequested = projectSpaceRouteRequestsDefaultProject(
                     workspaceTabs.activeTab.contentRoute
                   )
-                  const params = new URLSearchParams()
-                  if (projectRef) {
-                    params.set('projectStore', projectRef.projectStore)
-                    params.set('projectId', projectRef.projectId)
-                  } else if (defaultProjectRequested) {
-                    params.set('projectId', DEFAULT_WORK_ITEM_PROJECT_ID)
-                  }
                   workspaceTabs.updateActiveTab({
-                    contentRoute: `/todo${params.size ? `?${params.toString()}` : ''}`,
+                    contentRoute: projectRef
+                      ? projectSpaceContentRoute(projectRef)
+                      : defaultProjectRequested
+                        ? defaultProjectSpaceContentRoute()
+                        : '/todo',
                   })
                 }}
                 onActiveProjectChange={project => {
@@ -1113,12 +1095,9 @@ export function DesktopWorkbenchLayout({
                     })
                     return
                   }
-                  const params = new URLSearchParams()
-                  params.set('projectStore', project.project_store)
-                  params.set('projectId', project.id)
                   workspaceTabs.updateActiveTab({
                     title: project.name,
-                    contentRoute: `/todo?${params.toString()}`,
+                    contentRoute: projectSpaceContentRoute(projectSpaceRef(project)),
                   })
                 }}
               />

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
@@ -12,6 +12,7 @@ import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
 import type { RuntimeTaskAddress } from '@/types/api'
 import { WorkspaceTabsContext } from '@/features/workspace-tabs/workspaceTabsContextValue'
 import type { WorkspaceTabsContextValue } from '@/features/workspace-tabs/workspaceTabsContextValue'
+import { defaultProjectSpaceContentRoute } from '@/features/todo/projectSpaceRoute'
 import {
   cloudItemAsLocalWorkItem,
   useWorkbenchCloudProjectContext,
@@ -938,9 +939,28 @@ describe('useWorkbenchCloudProjectContext', () => {
     expect(result.current.closeDeliveryDialog).toBe(closeDeliveryDialog)
   })
 
-  test('reuses the existing project board tab when opening a bound work item', async () => {
-    const cloudProject = project('space-local', 'local')
-    cloudProject.name = '我的任务'
+  test.each([
+    {
+      description: 'resolved project board tab',
+      boardTabId: 'board-existing',
+      boardRoute: '/todo?projectStore=local&projectId=space-local',
+      cloudProject: { ...project('space-local', 'local'), name: '我的任务' },
+      fixed: false,
+    },
+    {
+      description: 'unresolved fixed default project board tab',
+      boardTabId: 'fixed-board',
+      boardRoute: defaultProjectSpaceContentRoute(),
+      cloudProject: {
+        ...project(DEFAULT_WORK_ITEM_PROJECT_ID, 'local'),
+        project_key: DEFAULT_WORK_ITEM_PROJECT_KEY,
+        name: '我的任务',
+        metadata: { system_kind: 'default_work_items' },
+      },
+      fixed: true,
+    },
+  ])('reuses the $description when opening a bound work item', async setup => {
+    const { boardRoute, boardTabId, cloudProject, fixed } = setup
     const item = loopItem(cloudProject.id)
     const currentRuntimeTask = {
       deviceId: 'local-device',
@@ -969,10 +989,11 @@ describe('useWorkbenchCloudProjectContext', () => {
       contentRoute: '/?deviceId=local-device&taskId=runtime-1',
     }
     const boardTab = {
-      id: 'board-existing',
+      id: boardTabId,
       kind: 'board' as const,
-      title: '工作项',
-      contentRoute: `/todo?projectStore=${cloudProject.project_store}&projectId=${cloudProject.id}`,
+      title: fixed ? '工作空间' : '工作项',
+      contentRoute: boardRoute,
+      fixed,
     }
     const openTab = vi.fn()
     const workspaceTabs = {

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
@@ -11,6 +11,10 @@ import {
   subscribeProjectSpaceTaskContextChanged,
   type ProjectSpaceApi,
 } from '@/features/todo/projectSpaceSelection'
+import {
+  projectSpaceContentRoute,
+  projectSpaceRouteMatchesProject,
+} from '@/features/todo/projectSpaceRoute'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
 import { truncateRuntimeTaskTitle } from '@/features/workbench/workbenchRuntimeHelpers'
 import {
@@ -111,15 +115,6 @@ function storePendingBinding(binding: PendingTodoBinding) {
 function clearPendingBinding(binding: PendingTodoBinding) {
   pendingTodoBindingsByPane.delete(binding.paneKey)
   if (binding.target) pendingTodoBindingsByTask.delete(runtimeTaskKey(binding.target))
-}
-
-function boardTabProjectKey(contentRoute: string): string | null {
-  const searchIndex = contentRoute.indexOf('?')
-  if (searchIndex < 0) return null
-  const params = new URLSearchParams(contentRoute.slice(searchIndex + 1))
-  const projectStore = params.get('projectStore')
-  const projectId = params.get('projectId')
-  return projectStore && projectId ? `${projectStore}:${projectId}` : null
 }
 
 function pendingBindingTargetsTask(address: RuntimeTaskAddress): boolean {
@@ -935,14 +930,11 @@ export function useWorkbenchCloudProjectContext({
       : null
   const openBoundProjectSpaceTask = useCallback(() => {
     if (!boundCloudProject || !boundCloudItem) return
-    const params = new URLSearchParams()
-    params.set('projectStore', boundCloudProject.project_store)
-    params.set('projectId', String(boundCloudProject.id))
-    const contentRoute = `/todo?${params.toString()}`
+    const projectRef = projectSpaceRef(boundCloudProject)
+    const contentRoute = projectSpaceContentRoute(projectRef)
     if (workspaceTabs) {
-      const projectKey = projectSpaceKey(projectSpaceRef(boundCloudProject))
       const existingBoardTab = workspaceTabs.tabs.find(
-        tab => tab.kind === 'board' && boardTabProjectKey(tab.contentRoute) === projectKey
+        tab => tab.kind === 'board' && projectSpaceRouteMatchesProject(tab.contentRoute, projectRef)
       )
       if (existingBoardTab) {
         workspaceTabs.selectTab(existingBoardTab.id, {

--- a/wework/src/features/todo/projectSpaceRoute.test.ts
+++ b/wework/src/features/todo/projectSpaceRoute.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest'
+import {
+  defaultProjectSpaceContentRoute,
+  projectSpaceContentRoute,
+  projectSpaceRefFromRoute,
+  projectSpaceRouteMatchesProject,
+  projectSpaceRouteParam,
+  projectSpaceRouteRequestsDefaultProject,
+} from './projectSpaceRoute'
+
+describe('projectSpaceRoute', () => {
+  test('builds and parses a concrete project-space route', () => {
+    const project = { projectStore: 'local' as const, projectId: 'project-1' }
+    const route = projectSpaceContentRoute(project)
+
+    expect(route).toBe('/todo?projectStore=local&projectId=project-1')
+    expect(projectSpaceRefFromRoute(route)).toEqual(project)
+    expect(projectSpaceRouteParam(`${route}&itemId=issue-1`, 'itemId')).toBe('issue-1')
+  })
+
+  test('recognizes the unresolved default project-space route', () => {
+    const route = defaultProjectSpaceContentRoute()
+
+    expect(projectSpaceRouteRequestsDefaultProject(route)).toBe(true)
+    expect(projectSpaceRefFromRoute(route)).toBeNull()
+    expect(
+      projectSpaceRouteMatchesProject(route, {
+        projectStore: 'local',
+        projectId: 'default-work-items',
+      })
+    ).toBe(true)
+    expect(
+      projectSpaceRouteMatchesProject(route, {
+        projectStore: 'backend',
+        projectId: 'default-work-items',
+      })
+    ).toBe(true)
+  })
+
+  test('does not treat the default placeholder as a named project', () => {
+    expect(
+      projectSpaceRouteMatchesProject(defaultProjectSpaceContentRoute(), {
+        projectStore: 'local',
+        projectId: 'project-1',
+      })
+    ).toBe(false)
+  })
+
+  test('keeps concrete local and backend projects distinct', () => {
+    const route = projectSpaceContentRoute({
+      projectStore: 'local',
+      projectId: 'default-work-items',
+    })
+
+    expect(
+      projectSpaceRouteMatchesProject(route, {
+        projectStore: 'backend',
+        projectId: 'default-work-items',
+      })
+    ).toBe(false)
+  })
+})

--- a/wework/src/features/todo/projectSpaceRoute.ts
+++ b/wework/src/features/todo/projectSpaceRoute.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_WORK_ITEM_PROJECT_ID } from '@/api/deliveries'
+import type { RuntimeProjectSpaceRef } from '@/types/api'
+import { sameProjectSpace } from './projectSpaceSelection'
+
+export function projectSpaceRouteParam(contentRoute: string, name: string): string | null {
+  const searchIndex = contentRoute.indexOf('?')
+  if (searchIndex < 0) return null
+  return new URLSearchParams(contentRoute.slice(searchIndex + 1)).get(name)
+}
+
+export function projectSpaceRefFromRoute(contentRoute: string): RuntimeProjectSpaceRef | null {
+  const projectId = projectSpaceRouteParam(contentRoute, 'projectId')
+  const projectStore = projectSpaceRouteParam(contentRoute, 'projectStore')
+  if (!projectId || (projectStore !== 'local' && projectStore !== 'backend')) return null
+  return { projectId, projectStore }
+}
+
+export function projectSpaceRouteRequestsDefaultProject(contentRoute: string): boolean {
+  return (
+    projectSpaceRouteParam(contentRoute, 'projectId') === DEFAULT_WORK_ITEM_PROJECT_ID &&
+    projectSpaceRouteParam(contentRoute, 'projectStore') === null
+  )
+}
+
+export function projectSpaceRouteMatchesProject(
+  contentRoute: string,
+  project: RuntimeProjectSpaceRef
+): boolean {
+  const routedProject = projectSpaceRefFromRoute(contentRoute)
+  if (routedProject) return sameProjectSpace(routedProject, project)
+  return (
+    project.projectId === DEFAULT_WORK_ITEM_PROJECT_ID &&
+    projectSpaceRouteRequestsDefaultProject(contentRoute)
+  )
+}
+
+export function projectSpaceContentRoute(project: RuntimeProjectSpaceRef): string {
+  const params = new URLSearchParams()
+  params.set('projectStore', project.projectStore)
+  params.set('projectId', project.projectId)
+  return `/todo?${params.toString()}`
+}
+
+export function defaultProjectSpaceContentRoute(): string {
+  return `/todo?projectId=${DEFAULT_WORK_ITEM_PROJECT_ID}`
+}

--- a/wework/src/features/workspace-tabs/workspaceTabs.ts
+++ b/wework/src/features/workspace-tabs/workspaceTabs.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_WORK_ITEM_PROJECT_ID } from '@/api/deliveries'
+import { defaultProjectSpaceContentRoute } from '@/features/todo/projectSpaceRoute'
 
 export type WorkspaceTabKind = 'task' | 'board' | 'agent' | 'auxiliary'
 
@@ -43,7 +43,7 @@ function newTabId(kind: WorkspaceTabKind): string {
 export function defaultContentRoute(kind: WorkspaceTabKind): string {
   switch (kind) {
     case 'board':
-      return `/todo?projectId=${DEFAULT_WORK_ITEM_PROJECT_ID}`
+      return defaultProjectSpaceContentRoute()
     case 'agent':
       return '/app/wegent'
     case 'auxiliary':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace task-board navigation by consistently reusing the fixed default board.
  - Improved opening work items so they remain associated with the correct project board.
  - Improved project-space routing across local, backend, and default projects for more reliable tab and work-item navigation.

- **Tests**
  - Added coverage for project-specific and default board routes.
  - Expanded validation for opening work items from both resolved and default board tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->