### PR TITLE
feat(models): support hiding public models

### DIFF
--- a/backend/app/api/endpoints/admin/public_models.py
+++ b/backend/app/api/endpoints/admin/public_models.py
@@ -19,6 +19,10 @@ from app.schemas.admin import (
     PublicModelResponse,
     PublicModelUpdate,
 )
+from app.services.adapters.public_model import (
+    is_public_model_visible,
+    with_public_model_visibility,
+)
 
 router = APIRouter()
 
@@ -53,6 +57,7 @@ def _model_to_response(model: Kind) -> PublicModelResponse:
         display_name=display_name if display_name != model.name else None,
         model_json=model.json,
         is_active=model.is_active,
+        is_visible=is_public_model_visible(model.json),
         is_advanced=_get_is_advanced(model),
         created_at=model.created_at,
         updated_at=model.updated_at,
@@ -124,7 +129,7 @@ async def create_public_model(
         kind="Model",
         name=model_data.name,
         namespace=model_data.namespace,
-        json=model_data.model_json,
+        json=with_public_model_visibility(model_data.model_json, model_data.is_visible),
         is_active=True,
     )
     db.add(new_model)
@@ -180,9 +185,14 @@ async def update_public_model(
     if model_data.namespace is not None:
         model.namespace = model_data.namespace
     if model_data.model_json is not None:
-        model.json = model_data.model_json
+        model.json = with_public_model_visibility(
+            model_data.model_json,
+            is_public_model_visible(model.json),
+        )
     if model_data.is_active is not None:
         model.is_active = model_data.is_active
+    if model_data.is_visible is not None:
+        model.json = with_public_model_visibility(model.json, model_data.is_visible)
     if model_data.is_advanced is not None:
         updated_json = dict(model.json) if isinstance(model.json, dict) else {}
         if "spec" not in updated_json or not isinstance(updated_json.get("spec"), dict):

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -82,6 +82,7 @@ class PublicModelCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     namespace: str = Field(default="default", max_length=100)
     model_json: dict = Field(..., alias="json")
+    is_visible: bool = True
 
     class Config:
         populate_by_name = True
@@ -94,6 +95,7 @@ class PublicModelUpdate(BaseModel):
     namespace: Optional[str] = Field(None, max_length=100)
     model_json: Optional[dict] = Field(None, alias="json")
     is_active: Optional[bool] = None
+    is_visible: Optional[bool] = None
     is_advanced: Optional[bool] = None
 
     class Config:
@@ -109,6 +111,7 @@ class PublicModelResponse(BaseModel):
     display_name: Optional[str] = None
     model_json: dict = Field(..., alias="json", serialization_alias="json")
     is_active: bool
+    is_visible: bool = True
     is_advanced: bool = False
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -76,6 +76,13 @@ class AdminUserListResponse(BaseModel):
 
 
 # Public Model Management Schemas
+def _validate_public_model_json(value: Optional[dict]) -> Optional[dict]:
+    """Require an object-valued spec when a public model JSON defines one."""
+    if value is not None and "spec" in value and not isinstance(value["spec"], dict):
+        raise ValueError("Public model JSON spec must be an object")
+    return value
+
+
 class PublicModelCreate(BaseModel):
     """Public model creation model"""
 
@@ -83,6 +90,8 @@ class PublicModelCreate(BaseModel):
     namespace: str = Field(default="default", max_length=100)
     model_json: dict = Field(..., alias="json")
     is_visible: bool = True
+
+    _validate_model_json = field_validator("model_json")(_validate_public_model_json)
 
     class Config:
         populate_by_name = True
@@ -97,6 +106,8 @@ class PublicModelUpdate(BaseModel):
     is_active: Optional[bool] = None
     is_visible: Optional[bool] = None
     is_advanced: Optional[bool] = None
+
+    _validate_model_json = field_validator("model_json")(_validate_public_model_json)
 
     class Config:
         populate_by_name = True

--- a/backend/app/schemas/kind.py
+++ b/backend/app/schemas/kind.py
@@ -338,6 +338,11 @@ class ModelSpec(BaseModel):
         description="Whether this model is available in the wework desktop client. "
         "Only models with this field set to True are returned to wework.",
     )
+    isVisible: bool = Field(
+        True,
+        description="Whether this public model is visible in user model selectors. "
+        "Hidden models remain available to existing bindings.",
+    )
     modelCapabilities: Optional[ModelCapabilities] = Field(
         None,
         description="Declared multimodal capabilities (supportsImage / supportsVideo). "

--- a/backend/app/services/adapters/public_model.py
+++ b/backend/app/services/adapters/public_model.py
@@ -35,6 +35,11 @@ def with_public_model_visibility(
     """Return a model CRD payload with an explicit selector visibility flag."""
     updated_json = dict(json_data) if isinstance(json_data, dict) else {}
     current_spec = updated_json.get("spec")
+    if "spec" in updated_json and not isinstance(current_spec, dict):
+        raise HTTPException(
+            status_code=422,
+            detail="Public model JSON spec must be an object",
+        )
     spec = dict(current_spec) if isinstance(current_spec, dict) else {}
     spec["isVisible"] = is_visible
     updated_json["spec"] = spec
@@ -405,6 +410,32 @@ class PublicModelService(BaseService[Kind, ModelCreate, ModelUpdate]):
             ModelAdapter.to_model_dict(model)
             for model in selected_models[skip : skip + limit]
         ]
+
+    def get_model_by_name(
+        self,
+        db: Session,
+        *,
+        name: str,
+        namespace: str = "default",
+        include_hidden: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get an active public model directly by its complete resource identity."""
+        model = (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == 0,
+                Kind.kind == "Model",
+                Kind.namespace == namespace,
+                Kind.name == name,
+                Kind.is_active == True,  # noqa: E712
+            )
+            .first()
+        )
+        if model is None:
+            return None
+        if not include_hidden and not is_public_model_visible(model.json):
+            return None
+        return ModelAdapter.to_model_dict(model)
 
     def count_active_models(self, db: Session, *, current_user: User) -> int:
         """

--- a/backend/app/services/adapters/public_model.py
+++ b/backend/app/services/adapters/public_model.py
@@ -18,6 +18,29 @@ from app.services.model_capabilities import normalize_model_capabilities
 from shared.codex_model_catalog import codex_catalog_model_id_from_config
 
 
+def is_public_model_visible(json_data: Optional[Dict[str, Any]]) -> bool:
+    """Return whether a public model should appear in user model selectors."""
+    if not isinstance(json_data, dict):
+        return True
+    spec = json_data.get("spec")
+    if not isinstance(spec, dict):
+        return True
+    value = spec.get("isVisible")
+    return value if isinstance(value, bool) else True
+
+
+def with_public_model_visibility(
+    json_data: Optional[Dict[str, Any]], is_visible: bool
+) -> Dict[str, Any]:
+    """Return a model CRD payload with an explicit selector visibility flag."""
+    updated_json = dict(json_data) if isinstance(json_data, dict) else {}
+    current_spec = updated_json.get("spec")
+    spec = dict(current_spec) if isinstance(current_spec, dict) else {}
+    spec["isVisible"] = is_visible
+    updated_json["spec"] = spec
+    return updated_json
+
+
 def _split_model_config_protocol(
     config: Dict[str, Any],
 ) -> tuple[Dict[str, Any], Optional[str], Optional[str]]:
@@ -349,10 +372,16 @@ class PublicModelService(BaseService[Kind, ModelCreate, ModelUpdate]):
         return {"created": created, "updated": updated, "skipped": skipped}
 
     def get_models(
-        self, db: Session, *, skip: int = 0, limit: int = 100, current_user: User
+        self,
+        db: Session,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        current_user: User,
+        include_hidden: bool = False,
     ) -> List[Dict[str, Any]]:
         """
-        Get active public models from kinds table (paginated)
+        Get active public models from kinds table (paginated).
         """
         public_models = (
             db.query(Kind)
@@ -363,17 +392,25 @@ class PublicModelService(BaseService[Kind, ModelCreate, ModelUpdate]):
                 Kind.is_active == True,  # noqa: E712
             )
             .order_by(Kind.created_at.desc())
-            .offset(skip)
-            .limit(limit)
             .all()
         )
-        return [ModelAdapter.to_model_dict(pm) for pm in public_models]
+        selected_models = (
+            public_models
+            if include_hidden
+            else [
+                model for model in public_models if is_public_model_visible(model.json)
+            ]
+        )
+        return [
+            ModelAdapter.to_model_dict(model)
+            for model in selected_models[skip : skip + limit]
+        ]
 
     def count_active_models(self, db: Session, *, current_user: User) -> int:
         """
-        Count active public models in kinds table
+        Count visible, active public models in kinds table.
         """
-        return (
+        public_models = (
             db.query(Kind)
             .filter(
                 Kind.user_id == 0,
@@ -381,8 +418,9 @@ class PublicModelService(BaseService[Kind, ModelCreate, ModelUpdate]):
                 Kind.namespace == "default",
                 Kind.is_active == True,
             )
-            .count()
+            .all()
         )  # noqa: E712
+        return sum(1 for model in public_models if is_public_model_visible(model.json))
 
     def list_model_names(
         self, db: Session, *, current_user: User, shell_type: str
@@ -476,7 +514,7 @@ class PublicModelService(BaseService[Kind, ModelCreate, ModelUpdate]):
         )
 
         for m in public_models:
-            if is_model_compatible(m.json):
+            if is_public_model_visible(m.json) and is_model_compatible(m.json):
                 # Only add if not already present (user models take precedence)
                 if m.name not in result_models:
                     display_name = get_model_display_name(m.json)

--- a/backend/app/services/model_aggregation_service.py
+++ b/backend/app/services/model_aggregation_service.py
@@ -855,7 +855,11 @@ class ModelAggregationService:
         elif model_type == ModelType.PUBLIC:
             # Get all public models and find by name
             public_models = public_model_service.get_models(
-                db=db, skip=0, limit=1000, current_user=current_user
+                db=db,
+                skip=0,
+                limit=1000,
+                current_user=current_user,
+                include_hidden=True,
             )
 
             for model_dict in public_models:

--- a/backend/app/services/model_aggregation_service.py
+++ b/backend/app/services/model_aggregation_service.py
@@ -853,41 +853,35 @@ class ModelAggregationService:
                 ).to_full_dict()
 
         elif model_type == ModelType.PUBLIC:
-            # Get all public models and find by name
-            public_models = public_model_service.get_models(
+            model_dict = public_model_service.get_model_by_name(
                 db=db,
-                skip=0,
-                limit=1000,
-                current_user=current_user,
+                name=name,
+                namespace="default",
                 include_hidden=True,
             )
-
-            for model_dict in public_models:
-                if model_dict.get("name") == name:
-                    return UnifiedModel(
-                        name=model_dict.get("name", ""),
-                        model_type=ModelType.PUBLIC,
-                        display_name=model_dict.get("displayName"),
-                        provider=model_dict.get("provider"),
-                        model_id=model_dict.get("model_id"),
-                        config=model_dict.get("config", {}),
-                        is_active=model_dict.get("is_active", True),
-                        model_category_type=model_dict.get(
-                            "model_category_type", "llm"
-                        ),
-                        is_advanced=model_dict.get("is_advanced", False),
-                        model_group=model_dict.get("modelGroup")
-                        or model_dict.get("model_group"),
-                        model_sub_group=model_dict.get("modelSubGroup")
-                        or model_dict.get("model_sub_group"),
-                        context_window=model_dict.get("contextWindow"),
-                        max_output_tokens=model_dict.get("maxOutputTokens"),
-                        cost_index=model_dict.get("costIndex"),
-                        model_capabilities=model_dict.get("modelCapabilities"),
-                        resource_user_id=0,
-                        created_at=model_dict.get("created_at"),
-                        updated_at=model_dict.get("updated_at"),
-                    ).to_full_dict()
+            if model_dict:
+                return UnifiedModel(
+                    name=model_dict.get("name", ""),
+                    model_type=ModelType.PUBLIC,
+                    display_name=model_dict.get("displayName"),
+                    provider=model_dict.get("provider"),
+                    model_id=model_dict.get("model_id"),
+                    config=model_dict.get("config", {}),
+                    is_active=model_dict.get("is_active", True),
+                    model_category_type=model_dict.get("model_category_type", "llm"),
+                    is_advanced=model_dict.get("is_advanced", False),
+                    model_group=model_dict.get("modelGroup")
+                    or model_dict.get("model_group"),
+                    model_sub_group=model_dict.get("modelSubGroup")
+                    or model_dict.get("model_sub_group"),
+                    context_window=model_dict.get("contextWindow"),
+                    max_output_tokens=model_dict.get("maxOutputTokens"),
+                    cost_index=model_dict.get("costIndex"),
+                    model_capabilities=model_dict.get("modelCapabilities"),
+                    resource_user_id=0,
+                    created_at=model_dict.get("created_at"),
+                    updated_at=model_dict.get("updated_at"),
+                ).to_full_dict()
 
         elif model_type == ModelType.RUNTIME:
             if name == CODEX_RUNTIME_MODEL_NAME and is_codex_runtime_model_enabled(

--- a/backend/tests/api/test_admin_public_models.py
+++ b/backend/tests/api/test_admin_public_models.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.api.endpoints.admin.public_models import (
+    create_public_model,
+    update_public_model,
+)
+from app.models.user import User
+from app.schemas.admin import PublicModelCreate, PublicModelUpdate
+
+
+def _model_json(name: str) -> dict:
+    return {
+        "apiVersion": "agent.wecode.io/v1",
+        "kind": "Model",
+        "metadata": {"name": name, "namespace": "default"},
+        "spec": {
+            "modelConfig": {
+                "env": {
+                    "model": "openai",
+                    "model_id": name,
+                }
+            }
+        },
+        "status": {"state": "Available"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_public_model_create_defaults_to_visible(
+    test_db: Session,
+    test_admin_user: User,
+) -> None:
+    response = await create_public_model(
+        model_data=PublicModelCreate(
+            name="default-visible-public-model",
+            json=_model_json("default-visible-public-model"),
+        ),
+        db=test_db,
+        current_user=test_admin_user,
+    )
+
+    assert response.is_visible is True
+    assert response.model_json["spec"]["isVisible"] is True
+
+
+@pytest.mark.asyncio
+async def test_public_model_visibility_can_be_disabled_without_deactivation(
+    test_db: Session,
+    test_admin_user: User,
+) -> None:
+    created = await create_public_model(
+        model_data=PublicModelCreate(
+            name="hidden-public-model",
+            json=_model_json("hidden-public-model"),
+        ),
+        db=test_db,
+        current_user=test_admin_user,
+    )
+
+    response = await update_public_model(
+        model_data=PublicModelUpdate(is_visible=False),
+        model_id=created.id,
+        db=test_db,
+        current_user=test_admin_user,
+    )
+
+    assert response.is_active is True
+    assert response.is_visible is False
+    assert response.model_json["spec"]["isVisible"] is False
+
+
+@pytest.mark.asyncio
+async def test_public_model_config_update_preserves_hidden_state(
+    test_db: Session,
+    test_admin_user: User,
+) -> None:
+    created = await create_public_model(
+        model_data=PublicModelCreate(
+            name="hidden-config-update-model",
+            json=_model_json("hidden-config-update-model"),
+            is_visible=False,
+        ),
+        db=test_db,
+        current_user=test_admin_user,
+    )
+    updated_json = _model_json("hidden-config-update-model")
+    updated_json["spec"]["modelConfig"]["temperature"] = 0.2
+
+    response = await update_public_model(
+        model_data=PublicModelUpdate(json=updated_json),
+        model_id=created.id,
+        db=test_db,
+        current_user=test_admin_user,
+    )
+
+    assert response.is_visible is False
+    assert response.model_json["spec"]["isVisible"] is False
+    assert response.model_json["spec"]["modelConfig"]["temperature"] == 0.2

--- a/backend/tests/api/test_admin_public_models.py
+++ b/backend/tests/api/test_admin_public_models.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from app.api.endpoints.admin.public_models import (
@@ -28,6 +29,14 @@ def _model_json(name: str) -> dict:
         },
         "status": {"state": "Available"},
     }
+
+
+def test_public_model_schema_rejects_non_object_spec() -> None:
+    with pytest.raises(ValidationError, match="spec must be an object"):
+        PublicModelCreate(
+            name="invalid-spec-public-model",
+            json={"kind": "Model", "spec": "invalid"},
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/adapters/test_public_model_visibility.py
+++ b/backend/tests/services/adapters/test_public_model_visibility.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from sqlalchemy.orm import Session
+
+from app.models.kind import Kind
+from app.models.user import User
+from app.services.adapters.public_model import (
+    is_public_model_visible,
+    public_model_service,
+)
+from app.services.chat.config.model_resolver import _find_model_with_namespace
+from app.services.model_aggregation_service import ModelType, model_aggregation_service
+
+
+def _public_model(name: str, *, is_visible: bool | None = None) -> Kind:
+    spec = {
+        "modelConfig": {
+            "env": {
+                "model": "openai",
+                "model_id": name,
+            }
+        }
+    }
+    if is_visible is not None:
+        spec["isVisible"] = is_visible
+    return Kind(
+        user_id=0,
+        kind="Model",
+        name=name,
+        namespace="default",
+        json={
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Model",
+            "metadata": {"name": name, "namespace": "default"},
+            "spec": spec,
+            "status": {"state": "Available"},
+        },
+        is_active=True,
+    )
+
+
+def test_public_model_visibility_defaults_to_true() -> None:
+    model = _public_model("legacy-public-model")
+
+    assert is_public_model_visible(model.json) is True
+
+
+def test_hidden_public_model_is_not_listed_but_remains_runtime_resolvable(
+    test_db: Session,
+    test_user: User,
+) -> None:
+    visible_model = _public_model("visible-public-model", is_visible=True)
+    hidden_model = _public_model("hidden-public-model", is_visible=False)
+    test_db.add_all([visible_model, hidden_model])
+    test_db.commit()
+
+    listed_models = public_model_service.get_models(
+        db=test_db,
+        current_user=test_user,
+        skip=0,
+        limit=100,
+    )
+
+    assert {model["name"] for model in listed_models} == {"visible-public-model"}
+    assert (
+        public_model_service.count_active_models(
+            db=test_db,
+            current_user=test_user,
+        )
+        == 1
+    )
+
+    resolved_model, resolved_spec = _find_model_with_namespace(
+        test_db,
+        "hidden-public-model",
+        test_user.id,
+    )
+
+    assert resolved_model is not None
+    assert resolved_model.id == hidden_model.id
+    assert resolved_spec is not None
+    assert resolved_spec["modelConfig"]["env"]["model_id"] == "hidden-public-model"
+
+    aggregated_model = model_aggregation_service.get_model_by_name_and_type(
+        test_db,
+        test_user,
+        "hidden-public-model",
+        ModelType.PUBLIC,
+    )
+
+    assert aggregated_model is not None
+    assert aggregated_model["name"] == "hidden-public-model"

--- a/backend/tests/services/adapters/test_public_model_visibility.py
+++ b/backend/tests/services/adapters/test_public_model_visibility.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
+
 from sqlalchemy.orm import Session
 
 from app.models.kind import Kind
@@ -92,3 +94,38 @@ def test_hidden_public_model_is_not_listed_but_remains_runtime_resolvable(
 
     assert aggregated_model is not None
     assert aggregated_model["name"] == "hidden-public-model"
+
+
+def test_hidden_public_model_outside_listing_limit_remains_resolvable(
+    test_db: Session,
+    test_user: User,
+) -> None:
+    hidden_model = _public_model("older-hidden-public-model", is_visible=False)
+    hidden_model.created_at = datetime(2025, 1, 1)
+    newer_models = [
+        _public_model(f"newer-public-model-{index}", is_visible=True)
+        for index in range(1000)
+    ]
+    for model in newer_models:
+        model.created_at = datetime(2026, 1, 1)
+    test_db.add_all([hidden_model, *newer_models])
+    test_db.commit()
+
+    capped_models = public_model_service.get_models(
+        db=test_db,
+        current_user=test_user,
+        skip=0,
+        limit=1000,
+        include_hidden=True,
+    )
+    assert hidden_model.name not in {model["name"] for model in capped_models}
+
+    aggregated_model = model_aggregation_service.get_model_by_name_and_type(
+        test_db,
+        test_user,
+        hidden_model.name,
+        ModelType.PUBLIC,
+    )
+
+    assert aggregated_model is not None
+    assert aggregated_model["name"] == hidden_model.name

--- a/docs/en/wegent/reference/yaml-specification.md
+++ b/docs/en/wegent/reference/yaml-specification.md
@@ -162,6 +162,7 @@ metadata:
   name: ClaudeSonnet4
   namespace: default
 spec:
+  isVisible: true
   modelGroup: "Primary"
   modelSubGroup: "Fast"
   modelConfig:
@@ -178,6 +179,7 @@ spec:
 | ---------------------- | ------ | -------- | -------------------------------------------------- |
 | `metadata.name`        | string | Yes      | Unique identifier for the Model                    |
 | `metadata.namespace`   | string | Yes      | Namespace, typically `default`                     |
+| `spec.isVisible`       | boolean | No      | Whether a public model appears in regular users' model selectors. Defaults to `true`; `false` preserves existing references and runtime resolution. |
 | `spec.modelGroup`      | string | No       | First-level display group used by model selectors  |
 | `spec.modelSubGroup`   | string | No       | Second-level display group under `spec.modelGroup` |
 | `spec.modelConfig`     | object | Yes      | Model configuration object                         |

--- a/docs/zh/wegent/reference/yaml-specification.md
+++ b/docs/zh/wegent/reference/yaml-specification.md
@@ -162,6 +162,7 @@ metadata:
   name: ClaudeSonnet4
   namespace: default
 spec:
+  isVisible: true
   modelGroup: "主分组"
   modelSubGroup: "快速"
   modelConfig:
@@ -178,6 +179,7 @@ spec:
 | ---------------------- | ------ | ---- | ---------------------------------- |
 | `metadata.name`        | string | 是   | Model 的唯一标识符                 |
 | `metadata.namespace`   | string | 是   | 命名空间，通常为 `default`         |
+| `spec.isVisible`       | boolean | 否  | 公共模型是否出现在普通用户的模型选择列表中，默认 `true`；设为 `false` 不影响已有引用和运行时解析 |
 | `spec.modelGroup`      | string | 否   | 模型选择器使用的一级展示分组       |
 | `spec.modelSubGroup`   | string | 否   | `spec.modelGroup` 下的二级展示分组 |
 | `spec.modelConfig`     | object | 是   | 模型配置对象                       |

--- a/frontend/e2e/tests/api/admin-public-models-api.spec.ts
+++ b/frontend/e2e/tests/api/admin-public-models-api.spec.ts
@@ -52,7 +52,9 @@ test.describe('Admin - Public Model API Tests', () => {
 
     expect([200, 201]).toContain(response.status)
     if (response.data) {
-      testModelId = (response.data as { id: number }).id
+      const createdModel = response.data as { id: number; is_visible: boolean }
+      testModelId = createdModel.id
+      expect(createdModel.is_visible).toBe(true)
     }
   })
 
@@ -85,10 +87,20 @@ test.describe('Admin - Public Model API Tests', () => {
 
     // Update model
     const updateResponse = await apiClient.adminUpdatePublicModel(testModelId, {
-      is_active: false,
+      is_visible: false,
     })
 
     expect(updateResponse.status).toBe(200)
+    expect((updateResponse.data as { is_active: boolean }).is_active).toBe(true)
+    expect((updateResponse.data as { is_visible: boolean }).is_visible).toBe(false)
+
+    const deactivateResponse = await apiClient.adminUpdatePublicModel(testModelId, {
+      is_active: false,
+    })
+
+    expect(deactivateResponse.status).toBe(200)
+    expect((deactivateResponse.data as { is_active: boolean }).is_active).toBe(false)
+    expect((deactivateResponse.data as { is_visible: boolean }).is_visible).toBe(false)
   })
 
   test('DELETE /api/admin/public-models/:id - should delete public model', async () => {

--- a/frontend/src/__tests__/apis/publicResources.test.ts
+++ b/frontend/src/__tests__/apis/publicResources.test.ts
@@ -70,6 +70,7 @@ const publicVideoModel: AdminPublicModel = {
     },
   },
   is_active: true,
+  is_visible: true,
   is_advanced: false,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/__tests__/features/admin/PublicModelList.visibility.test.ts
+++ b/frontend/src/__tests__/features/admin/PublicModelList.visibility.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getPublicModelVisibilityFromConfig,
+  setPublicModelVisibilityInConfig,
+} from '@/features/admin/components/PublicModelList'
+
+describe('PublicModelList visibility config synchronization', () => {
+  test('reads spec.isVisible from valid JSON', () => {
+    expect(
+      getPublicModelVisibilityFromConfig(
+        JSON.stringify({
+          kind: 'Model',
+          spec: { isVisible: false },
+        })
+      )
+    ).toBe(false)
+  })
+
+  test('writes the switch value into spec.isVisible', () => {
+    const updated = setPublicModelVisibilityInConfig(
+      JSON.stringify({
+        kind: 'Model',
+        spec: { modelType: 'llm', isVisible: true },
+      }),
+      false
+    )
+
+    expect(JSON.parse(updated)).toEqual({
+      kind: 'Model',
+      spec: { modelType: 'llm', isVisible: false },
+    })
+  })
+
+  test('leaves invalid JSON unchanged while editing', () => {
+    const invalidJson = '{"spec":'
+
+    expect(getPublicModelVisibilityFromConfig(invalidJson)).toBeUndefined()
+    expect(setPublicModelVisibilityInConfig(invalidJson, false)).toBe(invalidJson)
+  })
+})

--- a/frontend/src/__tests__/features/admin/PublicModelList.visibility.test.ts
+++ b/frontend/src/__tests__/features/admin/PublicModelList.visibility.test.ts
@@ -4,6 +4,7 @@
 
 import {
   getPublicModelVisibilityFromConfig,
+  parsePublicModelConfig,
   setPublicModelVisibilityInConfig,
 } from '@/features/admin/components/PublicModelList'
 
@@ -37,7 +38,18 @@ describe('PublicModelList visibility config synchronization', () => {
   test('leaves invalid JSON unchanged while editing', () => {
     const invalidJson = '{"spec":'
 
+    expect(parsePublicModelConfig(invalidJson)).toBeNull()
     expect(getPublicModelVisibilityFromConfig(invalidJson)).toBeUndefined()
     expect(setPublicModelVisibilityInConfig(invalidJson, false)).toBe(invalidJson)
   })
+
+  test.each(['null', '"invalid"', '[]', '42'])(
+    'rejects a non-object spec without replacing it: %s',
+    spec => {
+      const config = JSON.stringify({ kind: 'Model', spec: JSON.parse(spec) })
+
+      expect(parsePublicModelConfig(config)).toBeNull()
+      expect(setPublicModelVisibilityInConfig(config, false)).toBe(config)
+    }
+  )
 })

--- a/frontend/src/__tests__/features/settings/components/BotEdit.default-knowledge-bases.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/BotEdit.default-knowledge-bases.test.tsx
@@ -745,4 +745,34 @@ describe('BotEdit default knowledge bases', () => {
       )
     })
   })
+
+  test('preserves an existing model binding when the model is hidden from selection', async () => {
+    mockedGetUnifiedModels.mockResolvedValue({
+      data: [{ name: 'replacement-model', type: 'public', namespace: 'default' }],
+    })
+
+    await renderBotEdit({
+      agent_config: {
+        bind_model: 'hidden-model',
+        bind_model_type: 'public',
+        bind_model_namespace: 'default',
+      },
+    })
+
+    expect(await screen.findByText('hidden-model')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('save-button'))
+
+    await waitFor(() => {
+      expect(mockedUpdateBot).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({
+          agent_config: expect.objectContaining({
+            bind_model: 'hidden-model',
+            bind_model_type: 'public',
+          }),
+        })
+      )
+    })
+  })
 })

--- a/frontend/src/__tests__/features/settings/components/BotEdit.default-knowledge-bases.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/BotEdit.default-knowledge-bases.test.tsx
@@ -775,4 +775,33 @@ describe('BotEdit default knowledge bases', () => {
       )
     })
   })
+
+  test('does not replace a saved model namespace with a same-name model', async () => {
+    mockedGetUnifiedModels.mockResolvedValue({
+      data: [{ name: 'shared-name', type: 'public', namespace: 'default' }],
+    })
+
+    await renderBotEdit({
+      agent_config: {
+        bind_model: 'shared-name',
+        bind_model_type: 'public',
+        bind_model_namespace: 'archived',
+      },
+    })
+
+    fireEvent.click(screen.getByTestId('save-button'))
+
+    await waitFor(() => {
+      expect(mockedUpdateBot).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({
+          agent_config: expect.objectContaining({
+            bind_model: 'shared-name',
+            bind_model_type: 'public',
+            bind_model_namespace: 'archived',
+          }),
+        })
+      )
+    })
+  })
 })

--- a/frontend/src/__tests__/features/settings/components/SimpleTeamEditDialog.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/SimpleTeamEditDialog.test.tsx
@@ -451,6 +451,49 @@ describe('Simple TeamEditDialog', () => {
     })
   })
 
+  it('shows and preserves an existing model that is no longer visible', async () => {
+    const team = makeTeam()
+    const hiddenModelBot = makeBot({
+      agent_config: {
+        bind_model: 'retired-model',
+        bind_model_type: 'public',
+        bind_model_namespace: 'default',
+      },
+    })
+
+    render(
+      <TeamEditDialog
+        open
+        onClose={jest.fn()}
+        teams={[team]}
+        setTeams={jest.fn()}
+        editingTeamId={team.id}
+        bots={[hiddenModelBot]}
+        setBots={jest.fn()}
+        toast={jest.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockedGetUnifiedModels).toHaveBeenCalled()
+      expect(screen.getByTestId('simple-model-select')).toHaveTextContent('retired-model')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mockedUpdateBot).toHaveBeenCalledWith(
+        hiddenModelBot.id,
+        expect.objectContaining({
+          agent_config: {
+            bind_model: 'retired-model',
+            bind_model_type: 'public',
+          },
+        })
+      )
+    })
+  })
+
   it.each([
     { mode: 'image', category: 'image' },
     { mode: 'video', category: 'video' },

--- a/frontend/src/apis/admin.ts
+++ b/frontend/src/apis/admin.ts
@@ -91,6 +91,7 @@ export interface AdminPublicModel {
   display_name: string | null
   json: Record<string, unknown>
   is_active: boolean
+  is_visible: boolean
   is_advanced: boolean
   created_at: string
   updated_at: string
@@ -105,6 +106,7 @@ export interface AdminPublicModelCreate {
   name: string
   namespace?: string
   json: Record<string, unknown>
+  is_visible?: boolean
 }
 
 export interface AdminPublicModelUpdate {
@@ -112,6 +114,7 @@ export interface AdminPublicModelUpdate {
   namespace?: string
   json?: Record<string, unknown>
   is_active?: boolean
+  is_visible?: boolean
   is_advanced?: boolean
 }
 

--- a/frontend/src/features/admin/components/PublicModelList.tsx
+++ b/frontend/src/features/admin/components/PublicModelList.tsx
@@ -42,6 +42,42 @@ import {
 } from '@/apis/admin'
 import UnifiedAddButton from '@/components/common/UnifiedAddButton'
 
+export const getPublicModelVisibilityFromConfig = (value: string): boolean | undefined => {
+  try {
+    const parsed = JSON.parse(value)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return undefined
+    }
+    const spec = (parsed as Record<string, unknown>).spec
+    if (typeof spec !== 'object' || spec === null || Array.isArray(spec)) {
+      return undefined
+    }
+    const isVisible = (spec as Record<string, unknown>).isVisible
+    return typeof isVisible === 'boolean' ? isVisible : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export const setPublicModelVisibilityInConfig = (value: string, isVisible: boolean): string => {
+  try {
+    const parsed = JSON.parse(value)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return value
+    }
+    const config = parsed as Record<string, unknown>
+    const currentSpec = config.spec
+    const spec =
+      typeof currentSpec === 'object' && currentSpec !== null && !Array.isArray(currentSpec)
+        ? { ...(currentSpec as Record<string, unknown>) }
+        : {}
+    spec.isVisible = isVisible
+    return JSON.stringify({ ...config, spec }, null, 2)
+  } catch {
+    return value
+  }
+}
+
 const PublicModelList: React.FC = () => {
   const { t } = useTranslation()
   const { toast } = useToast()
@@ -64,6 +100,7 @@ const PublicModelList: React.FC = () => {
     modelSubGroup: string
     config: string
     is_active: boolean
+    is_visible: boolean
     is_advanced: boolean
     is_wework_available: boolean
   }>({
@@ -73,6 +110,7 @@ const PublicModelList: React.FC = () => {
     modelSubGroup: '',
     config: '{}',
     is_active: true,
+    is_visible: true,
     is_advanced: false,
     is_wework_available: false,
   })
@@ -163,9 +201,28 @@ const PublicModelList: React.FC = () => {
     } else {
       delete spec.isWeworkAvailable
     }
+    spec.isVisible = formData.is_visible
 
     nextConfig.spec = spec
     return nextConfig
+  }
+
+  const handleConfigChange = (value: string) => {
+    const configVisibility = getPublicModelVisibilityFromConfig(value)
+    setFormData(current => ({
+      ...current,
+      config: value,
+      ...(configVisibility === undefined ? {} : { is_visible: configVisibility }),
+    }))
+    validateConfig(value)
+  }
+
+  const handleVisibilityChange = (isVisible: boolean) => {
+    setFormData(current => ({
+      ...current,
+      is_visible: isVisible,
+      config: setPublicModelVisibilityInConfig(current.config, isVisible),
+    }))
   }
 
   const handleCreateModel = async () => {
@@ -193,6 +250,7 @@ const PublicModelList: React.FC = () => {
         name: formData.name.trim(),
         namespace: formData.namespace.trim() || 'default',
         json: config,
+        is_visible: formData.is_visible,
       }
       await adminApis.createPublicModel(createData)
       toast({ title: t('admin:public_models.success.created') })
@@ -235,6 +293,9 @@ const PublicModelList: React.FC = () => {
       updateData.json = config
       if (formData.is_active !== selectedModel.is_active) {
         updateData.is_active = formData.is_active
+      }
+      if (formData.is_visible !== selectedModel.is_visible) {
+        updateData.is_visible = formData.is_visible
       }
       if (formData.is_advanced !== (selectedModel.is_advanced ?? false)) {
         updateData.is_advanced = formData.is_advanced
@@ -285,6 +346,7 @@ const PublicModelList: React.FC = () => {
       modelSubGroup: '',
       config: '{}',
       is_active: true,
+      is_visible: true,
       is_advanced: false,
       is_wework_available: false,
     })
@@ -301,6 +363,7 @@ const PublicModelList: React.FC = () => {
       modelSubGroup: getSpecValue(model.json, 'modelSubGroup'),
       config: JSON.stringify(model.json, null, 2),
       is_active: model.is_active,
+      is_visible: model.is_visible,
       is_advanced: model.is_advanced ?? false,
       is_wework_available: getSpecBooleanValue(model.json, 'isWeworkAvailable'),
     })
@@ -380,6 +443,9 @@ const PublicModelList: React.FC = () => {
                           <Tag variant="success">{t('admin:public_models.status.active')}</Tag>
                         ) : (
                           <Tag variant="error">{t('admin:public_models.status.inactive')}</Tag>
+                        )}
+                        {!model.is_visible && (
+                          <Tag variant="error">{t('admin:public_models.status.hidden')}</Tag>
                         )}
                         {model.is_advanced && (
                           <Tag variant="warning">{t('admin:public_models.status.advanced')}</Tag>
@@ -504,14 +570,27 @@ const PublicModelList: React.FC = () => {
               <Textarea
                 id="config"
                 value={formData.config}
-                onChange={e => {
-                  setFormData({ ...formData, config: e.target.value })
-                  validateConfig(e.target.value)
-                }}
+                onChange={e => handleConfigChange(e.target.value)}
                 placeholder={t('admin:public_models.form.config_placeholder')}
                 className={`font-mono text-sm min-h-[200px] ${configError ? 'border-error' : ''}`}
               />
               {configError && <p className="text-xs text-error">{configError}</p>}
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="create-is-visible">{t('admin:public_models.form.is_visible')}</Label>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-text-muted">
+                  {formData.is_visible
+                    ? t('admin:public_models.status.visible')
+                    : t('admin:public_models.status.hidden')}
+                </span>
+                <Switch
+                  id="create-is-visible"
+                  data-testid="public-model-create-visible-switch"
+                  checked={formData.is_visible}
+                  onCheckedChange={handleVisibilityChange}
+                />
+              </div>
             </div>
             <div className="flex items-center justify-between">
               <Label htmlFor="create-is-wework-available">
@@ -602,10 +681,7 @@ const PublicModelList: React.FC = () => {
               <Textarea
                 id="edit-config"
                 value={formData.config}
-                onChange={e => {
-                  setFormData({ ...formData, config: e.target.value })
-                  validateConfig(e.target.value)
-                }}
+                onChange={e => handleConfigChange(e.target.value)}
                 placeholder={t('admin:public_models.form.config_placeholder')}
                 className={`font-mono text-sm min-h-[200px] ${configError ? 'border-error' : ''}`}
               />
@@ -623,6 +699,22 @@ const PublicModelList: React.FC = () => {
                   id="edit-is-active"
                   checked={formData.is_active}
                   onCheckedChange={checked => setFormData({ ...formData, is_active: checked })}
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="edit-is-visible">{t('admin:public_models.form.is_visible')}</Label>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-text-muted">
+                  {formData.is_visible
+                    ? t('admin:public_models.status.visible')
+                    : t('admin:public_models.status.hidden')}
+                </span>
+                <Switch
+                  id="edit-is-visible"
+                  data-testid="public-model-edit-visible-switch"
+                  checked={formData.is_visible}
+                  onCheckedChange={handleVisibilityChange}
                 />
               </div>
             </div>

--- a/frontend/src/features/admin/components/PublicModelList.tsx
+++ b/frontend/src/features/admin/components/PublicModelList.tsx
@@ -42,40 +42,41 @@ import {
 } from '@/apis/admin'
 import UnifiedAddButton from '@/components/common/UnifiedAddButton'
 
-export const getPublicModelVisibilityFromConfig = (value: string): boolean | undefined => {
+const isJsonObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+export const parsePublicModelConfig = (value: string): Record<string, unknown> | null => {
   try {
-    const parsed = JSON.parse(value)
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      return undefined
+    const parsed: unknown = JSON.parse(value)
+    if (!isJsonObject(parsed)) {
+      return null
     }
-    const spec = (parsed as Record<string, unknown>).spec
-    if (typeof spec !== 'object' || spec === null || Array.isArray(spec)) {
-      return undefined
+    if ('spec' in parsed && !isJsonObject(parsed.spec)) {
+      return null
     }
-    const isVisible = (spec as Record<string, unknown>).isVisible
-    return typeof isVisible === 'boolean' ? isVisible : undefined
+    return parsed
   } catch {
-    return undefined
+    return null
   }
 }
 
+export const getPublicModelVisibilityFromConfig = (value: string): boolean | undefined => {
+  const parsed = parsePublicModelConfig(value)
+  if (!parsed || !isJsonObject(parsed.spec)) {
+    return undefined
+  }
+  const isVisible = parsed.spec.isVisible
+  return typeof isVisible === 'boolean' ? isVisible : undefined
+}
+
 export const setPublicModelVisibilityInConfig = (value: string, isVisible: boolean): string => {
-  try {
-    const parsed = JSON.parse(value)
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      return value
-    }
-    const config = parsed as Record<string, unknown>
-    const currentSpec = config.spec
-    const spec =
-      typeof currentSpec === 'object' && currentSpec !== null && !Array.isArray(currentSpec)
-        ? { ...(currentSpec as Record<string, unknown>) }
-        : {}
-    spec.isVisible = isVisible
-    return JSON.stringify({ ...config, spec }, null, 2)
-  } catch {
+  const config = parsePublicModelConfig(value)
+  if (!config) {
     return value
   }
+  const spec = isJsonObject(config.spec) ? { ...config.spec } : {}
+  spec.isVisible = isVisible
+  return JSON.stringify({ ...config, spec }, null, 2)
 }
 
 const PublicModelList: React.FC = () => {
@@ -143,18 +144,13 @@ const PublicModelList: React.FC = () => {
       setConfigError(t('admin:public_models.errors.config_required'))
       return null
     }
-    try {
-      const parsed = JSON.parse(value)
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        setConfigError(t('admin:public_models.errors.config_invalid_json'))
-        return null
-      }
-      setConfigError('')
-      return parsed as Record<string, unknown>
-    } catch {
+    const parsed = parsePublicModelConfig(value)
+    if (!parsed) {
       setConfigError(t('admin:public_models.errors.config_invalid_json'))
       return null
     }
+    setConfigError('')
+    return parsed
   }
 
   const getSpecValue = (json: Record<string, unknown>, key: 'modelGroup' | 'modelSubGroup') => {
@@ -218,6 +214,9 @@ const PublicModelList: React.FC = () => {
   }
 
   const handleVisibilityChange = (isVisible: boolean) => {
+    if (!validateConfig(formData.config)) {
+      return
+    }
     setFormData(current => ({
       ...current,
       is_visible: isVisible,

--- a/frontend/src/features/settings/components/BotEdit.tsx
+++ b/frontend/src/features/settings/components/BotEdit.tsx
@@ -64,6 +64,7 @@ import {
 import { buildSkillRefsFromSelection } from '../utils/skillRefResolver'
 import { filterVisibleSkills } from '@/utils/skillVisibility'
 import { shellSupportsPreloadSkills } from './team-edit/simple-team-edit-utils'
+import { resolveSelectedModel } from './team-edit/model-select-utils'
 
 /** Agent types supported by the system */
 export type AgentType = 'ClaudeCode' | 'Agno' | 'Dify'
@@ -252,13 +253,14 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
   }, [allowGenerationPrimaryModel, modelCategoryType, models])
   const selectedModelObject = useMemo(
     () =>
-      primaryModels.find(
-        model =>
-          model.name === selectedModel &&
-          model.type === selectedModelType &&
-          (model.namespace || 'default') === (selectedModelNamespace || 'default')
-      ) ?? null,
-    [primaryModels, selectedModel, selectedModelNamespace, selectedModelType]
+      resolveSelectedModel(
+        primaryModels,
+        selectedModel,
+        selectedModelType,
+        selectedModelNamespace,
+        modelCategoryType
+      ),
+    [modelCategoryType, primaryModels, selectedModel, selectedModelNamespace, selectedModelType]
   )
   const secondaryModels = useMemo(
     () => models.filter(model => model.modelCategoryType === 'llm'),
@@ -266,12 +268,13 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
   )
   const selectedSecondaryModelObject = useMemo(
     () =>
-      secondaryModels.find(
-        model =>
-          model.name === selectedSecondaryModel &&
-          model.type === selectedSecondaryModelType &&
-          (model.namespace || 'default') === (selectedSecondaryModelNamespace || 'default')
-      ) ?? null,
+      resolveSelectedModel(
+        secondaryModels,
+        selectedSecondaryModel,
+        selectedSecondaryModelType,
+        selectedSecondaryModelNamespace,
+        'llm'
+      ),
     [
       secondaryModels,
       selectedSecondaryModel,
@@ -525,20 +528,18 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
         if (hasConfig && agentMatches && isPredefined) {
           const savedModelName = getModelFromConfig(baseBot.agent_config)
           const savedModelType = getModelTypeFromConfig(baseBot.agent_config)
-          // Only set the model if it exists in the loaded models list
-          // Match by both name and type if type is specified
+          const savedModelNamespace = getModelNamespaceFromConfig(baseBot.agent_config)
           const foundModel = primaryModelData.find((m: UnifiedModel) => {
             if (savedModelType) {
               return m.name === savedModelName && m.type === savedModelType
             }
             return m.name === savedModelName
           })
-          if (savedModelName && foundModel) {
+          if (savedModelName) {
             setSelectedModel(savedModelName)
-            setSelectedModelType(foundModel.type)
-            setSelectedModelNamespace(foundModel.namespace || 'default')
+            setSelectedModelType(foundModel?.type ?? savedModelType)
+            setSelectedModelNamespace(foundModel?.namespace || savedModelNamespace || 'default')
           } else {
-            // Model not found in list, clear selection
             setSelectedModel('')
             setSelectedModelType(undefined)
             setSelectedModelNamespace(undefined)
@@ -551,14 +552,12 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
             model.name === baseBot?.secondary_model_name &&
             (model.namespace || 'default') === (baseBot?.secondary_model_namespace || 'default')
         )
-        if (secondaryModel) {
-          setSelectedSecondaryModel(secondaryModel.name)
-          setSelectedSecondaryModelType(secondaryModel.type)
-          setSelectedSecondaryModelNamespace(secondaryModel.namespace || 'default')
-        } else if (baseBot?.secondary_model_name) {
-          setSelectedSecondaryModel('')
-          setSelectedSecondaryModelType(undefined)
-          setSelectedSecondaryModelNamespace(undefined)
+        if (baseBot?.secondary_model_name) {
+          setSelectedSecondaryModel(baseBot.secondary_model_name)
+          setSelectedSecondaryModelType(secondaryModel?.type)
+          setSelectedSecondaryModelNamespace(
+            secondaryModel?.namespace || baseBot.secondary_model_namespace || 'default'
+          )
         }
         // Note: Don't clear selectedModel here if agent changed,
         // as it's already cleared in the agent select onChange handler

--- a/frontend/src/features/settings/components/BotEdit.tsx
+++ b/frontend/src/features/settings/components/BotEdit.tsx
@@ -530,10 +530,10 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
           const savedModelType = getModelTypeFromConfig(baseBot.agent_config)
           const savedModelNamespace = getModelNamespaceFromConfig(baseBot.agent_config)
           const foundModel = primaryModelData.find((m: UnifiedModel) => {
-            if (savedModelType) {
-              return m.name === savedModelName && m.type === savedModelType
-            }
-            return m.name === savedModelName
+            const typeMatches = !savedModelType || m.type === savedModelType
+            const namespaceMatches =
+              (m.namespace || 'default') === (savedModelNamespace || 'default')
+            return m.name === savedModelName && typeMatches && namespaceMatches
           })
           if (savedModelName) {
             setSelectedModel(savedModelName)

--- a/frontend/src/features/settings/components/TeamEditDialog.tsx
+++ b/frontend/src/features/settings/components/TeamEditDialog.tsx
@@ -385,11 +385,6 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
   const [simpleModelName, setSimpleModelName] = useState('')
   const [simpleModelType, setSimpleModelType] = useState<ModelTypeEnum | undefined>(undefined)
   const [simpleModelNamespace, setSimpleModelNamespace] = useState<string | undefined>(undefined)
-  const simpleModelSelectionRef = useRef<{
-    name: string
-    type?: ModelTypeEnum
-    namespace?: string
-  }>({ name: '' })
   const [simplePrompt, setSimplePrompt] = useState('')
   const [simpleSelectedSkills, setSimpleSelectedSkills] = useState<string[]>([])
   const [simpleSelectedSkillRefs, setSimpleSelectedSkillRefs] = useState<
@@ -777,20 +772,6 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
         )
         if (!cancelled) {
           setSimpleModels(response.data)
-          const selectedModel = simpleModelSelectionRef.current
-          const selectionStillAvailable =
-            !selectedModel.name ||
-            response.data.some(
-              model =>
-                model.name === selectedModel.name &&
-                (!selectedModel.type || model.type === selectedModel.type) &&
-                (!selectedModel.namespace || model.namespace === selectedModel.namespace)
-            )
-          if (!selectionStillAvailable) {
-            setSimpleModelName('')
-            setSimpleModelType(undefined)
-            setSimpleModelNamespace(undefined)
-          }
         }
       } catch {
         if (!cancelled) {
@@ -822,14 +803,6 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
     toast,
     useSimpleEditor,
   ])
-
-  useEffect(() => {
-    simpleModelSelectionRef.current = {
-      name: simpleModelName,
-      type: simpleModelType,
-      namespace: simpleModelNamespace,
-    }
-  }, [simpleModelName, simpleModelNamespace, simpleModelType])
 
   // Check if mode change needs confirmation
   const needsModeChangeConfirmation = useCallback(() => {
@@ -876,6 +849,17 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
   const handleCancelModeChange = () => {
     setModeChangeDialogVisible(false)
     setPendingMode(null)
+  }
+
+  const handleSimpleBindModeChange = (nextBindMode: TaskType[]) => {
+    if (
+      getModelCategoryTypeForBindMode(bindMode) !== getModelCategoryTypeForBindMode(nextBindMode)
+    ) {
+      setSimpleModelName('')
+      setSimpleModelType(undefined)
+      setSimpleModelNamespace(undefined)
+    }
+    setBindMode(nextBindMode)
   }
 
   const isDifyLeader = useMemo(() => {
@@ -1481,7 +1465,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
                   inputPlaceholder={inputPlaceholder}
                   onInputPlaceholderChange={setInputPlaceholder}
                   bindMode={bindMode}
-                  setBindMode={setBindMode}
+                  setBindMode={handleSimpleBindModeChange}
                   icon={icon}
                   setIcon={setIcon}
                   requiresWorkspace={requiresWorkspace}

--- a/frontend/src/features/settings/components/team-edit/SimpleTeamEditForm.tsx
+++ b/frontend/src/features/settings/components/team-edit/SimpleTeamEditForm.tsx
@@ -37,7 +37,7 @@ import { SimpleConfigGroup, SimpleConfigRow } from './SimpleConfigLayout'
 import QuickPhraseEditor from './QuickPhraseEditor'
 import InputPlaceholderEditor from './InputPlaceholderEditor'
 import TeamBindModeCards from './TeamBindModeCards'
-import { parseModelSelectValue, toModelSelectValue } from './model-select-utils'
+import { parseModelSelectValue, resolveSelectedModel } from './model-select-utils'
 import type { SimpleExecutorMode } from './simple-team-edit-utils'
 
 interface SimpleTeamEditFormProps {
@@ -191,13 +191,9 @@ export default function SimpleTeamEditForm({
   const [skillManagementModalOpen, setSkillManagementModalOpen] = useState(false)
   const [promptFineTuneOpen, setPromptFineTuneOpen] = useState(false)
   const showRequiresWorkspace = bindMode.includes('code')
-  const modelSelectValue = toModelSelectValue(modelName, modelType, modelNamespace)
   const selectedModel = useMemo(
-    () =>
-      models.find(
-        model => toModelSelectValue(model.name, model.type, model.namespace) === modelSelectValue
-      ) ?? null,
-    [modelSelectValue, models]
+    () => resolveSelectedModel(models, modelName, modelType, modelNamespace),
+    [modelName, modelNamespace, modelType, models]
   )
   const cascadeLabels: ModelCascadeLabels = useMemo(
     () => ({

--- a/frontend/src/features/settings/components/team-edit/model-select-utils.ts
+++ b/frontend/src/features/settings/components/team-edit/model-select-utils.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ModelTypeEnum } from '@/apis/models'
+import type { ModelCategoryType, ModelTypeEnum, UnifiedModel } from '@/apis/models'
 
 export function toModelSelectValue(name: string, type?: ModelTypeEnum, namespace?: string): string {
   if (!name) return '__none__'
@@ -24,4 +24,28 @@ export function parseModelSelectValue(value: string): {
     type: (type as ModelTypeEnum) || undefined,
     namespace: namespace || 'default',
   }
+}
+
+export function resolveSelectedModel(
+  models: UnifiedModel[],
+  name: string,
+  type?: ModelTypeEnum,
+  namespace?: string,
+  modelCategoryType?: ModelCategoryType
+): UnifiedModel | null {
+  if (!name) return null
+
+  return (
+    models.find(
+      model =>
+        toModelSelectValue(model.name, model.type, model.namespace) ===
+        toModelSelectValue(name, type, namespace)
+    ) ?? {
+      name,
+      displayName: name,
+      type: type ?? 'public',
+      namespace: namespace ?? 'default',
+      modelCategoryType,
+    }
+  )
 }

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -407,6 +407,8 @@
     "status": {
       "active": "Active",
       "inactive": "Inactive",
+      "visible": "Visible",
+      "hidden": "Offline",
       "advanced": "Advanced",
       "standard": "Standard",
       "wework_available": "wework available",
@@ -431,6 +433,7 @@
       "model_sub_group_placeholder": "Enter secondary group",
       "config": "Model Configuration",
       "config_placeholder": "Enter model configuration as JSON",
+      "is_visible": "Visible to users",
       "is_advanced": "Advanced Model",
       "is_wework_available": "Available in wework"
     },

--- a/frontend/src/i18n/locales/zh-CN/admin.json
+++ b/frontend/src/i18n/locales/zh-CN/admin.json
@@ -407,6 +407,8 @@
     "status": {
       "active": "启用",
       "inactive": "禁用",
+      "visible": "可见",
+      "hidden": "已下线",
       "advanced": "高级",
       "standard": "普通",
       "wework_available": "wework 可用",
@@ -431,6 +433,7 @@
       "model_sub_group_placeholder": "填写二级分组",
       "config": "模型配置",
       "config_placeholder": "请输入 JSON 格式的模型配置",
+      "is_visible": "用户可见",
       "is_advanced": "高级模型",
       "is_wework_available": "在wework中可用"
     },


### PR DESCRIPTION
## Summary

- add a visibility status for public models in the admin UI and API
- hide offline public models from regular model selectors without disabling runtime resolution
- preserve and display hidden models already bound to bots and agents
- document spec.isVisible behavior in the Model YAML reference

## Testing

- backend targeted tests: 5 passed
- frontend targeted tests: 49 passed
- pre-push ESLint, TypeScript, frontend unit tests, Black, isort, Python syntax, settings configuration, and Alembic checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added visibility controls for public models, allowing administrators to show or hide models from regular-user model selectors.
  - Added visibility switches, status labels, and hidden indicators in the admin interface.
  - Hidden models remain available to existing bindings and runtime resolution.
  - Existing model selections are preserved when models are absent from refreshed lists.

- **Bug Fixes**
  - Prevented invalid model specifications from being accepted or overwritten during visibility updates.
  - Prevented saved model bindings from being cleared when models are temporarily unavailable.

- **Documentation**
  - Documented the optional `spec.isVisible` model setting in English and Chinese YAML references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->