### PR TITLE
fix(wework): preserve composer focus across window activation

### DIFF
--- a/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs
+++ b/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs
@@ -744,6 +744,7 @@ async function verifyCloudCheckpoint({
       const otherTaskRowTestId = await verifyShortConversationLayout({
         composerSelector,
         control,
+        restartDesktopApp,
       })
       setPhase('cloud-background-completion-restore')
       await verifyBackgroundCompletionRestore({

--- a/wework/e2e/desktop/modules/conversation-layout.mjs
+++ b/wework/e2e/desktop/modules/conversation-layout.mjs
@@ -74,6 +74,12 @@ async function verifyShortConversationLayout({ composerSelector, control }) {
     text: FRESH_CHAT_COMPLETION_TEXT,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await control.command('click', `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`)
+  await waitForComposerFocus(
+    control,
+    DEFAULT_STEP_TIMEOUT_MS,
+    'Clicking the conversation surface did not restore keyboard focus to the composer'
+  )
 
   const scroller = await getSingleElementMetrics(
     control,
@@ -240,6 +246,25 @@ async function verifyShortConversationLayout({ composerSelector, control }) {
   )
   control.setScenario('fresh_chat')
   return shortConversationTaskRowTestId
+}
+
+async function waitForComposerFocus(control, timeoutMs, failureMessage) {
+  const focusStartedAt = Date.now()
+  let activeElementTestId = ''
+  while (Date.now() - focusStartedAt < timeoutMs) {
+    activeElementTestId = await control.command('getActiveElementTestId', 'body')
+    if (activeElementTestId === 'chat-message-input') return
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  const [focusSnapshot, workbenchSnapshot, composerDiagnostics] = await Promise.all([
+    control.command('getComposerFocusSnapshot', 'body'),
+    control.command('getWorkbenchDebugSnapshot', 'body'),
+    control.command('getComposerDiagnosticsSnapshot', 'body'),
+  ])
+  throw new Error(
+    `${failureMessage}; activeElementTestId=${activeElementTestId}; focus=${focusSnapshot}; ` +
+      `workbench=${workbenchSnapshot}; composerDiagnostics=${composerDiagnostics}`
+  )
 }
 
 async function verifyConversationRenameSpaceDoesNotDrag(control, taskRowTestId) {
@@ -1013,6 +1038,7 @@ export {
   waitForElementWidth,
   waitForElementTop,
   waitForProcessingBlock,
+  waitForComposerFocus,
   verifyViewImageProcessingBlock,
   distanceFromBottom,
   distanceFromTop,

--- a/wework/e2e/desktop/modules/conversation-layout.mjs
+++ b/wework/e2e/desktop/modules/conversation-layout.mjs
@@ -74,17 +74,6 @@ async function verifyShortConversationLayout({ composerSelector, control, restar
     text: FRESH_CHAT_COMPLETION_TEXT,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
-  await restartDesktopApp()
-  await control.command('focusMainWindow', 'body')
-  await control.command('waitFor', '[data-testid="message-assistant"]', {
-    text: FRESH_CHAT_COMPLETION_TEXT,
-    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
-  })
-  await waitForComposerFocus(
-    control,
-    DEFAULT_STEP_TIMEOUT_MS,
-    'Restoring an existing conversation on app startup did not focus the composer'
-  )
   await control.command('click', `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`)
   await waitForComposerFocus(
     control,
@@ -256,6 +245,43 @@ async function verifyShortConversationLayout({ composerSelector, control, restar
     'The late background transcript leaked into the restored conversation'
   )
   control.setScenario('fresh_chat')
+  await restartDesktopApp()
+  await control.command('focusMainWindow', 'body')
+  await ensureTaskRowVisible(control, shortConversationTaskRowTestId)
+  await control.command('clickWhenEnabled', `[data-testid="${shortConversationTaskRowTestId}"]`, {
+    stableMs: COMPOSER_READY_STABILITY_MS,
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: FRESH_CHAT_COMPLETION_TEXT,
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await waitForComposerFocus(
+    control,
+    DEFAULT_STEP_TIMEOUT_MS,
+    'Opening an existing conversation after app startup did not focus the composer'
+  )
+  await control.command(
+    'hover',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"] [data-testid="message-hover-region"]`
+  )
+  await control.command(
+    'click',
+    `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"] [data-testid="copy-message-button"]`
+  )
+  assert.equal(
+    await control.command('getClipboardText', ''),
+    FRESH_CHAT_COMPLETION_TEXT,
+    'The assistant-message copy action did not populate the desktop clipboard'
+  )
+  await control.command('press', 'body', {
+    key: process.platform === 'darwin' ? 'Meta+v' : 'Control+v',
+  })
+  await waitForComposerFocus(
+    control,
+    DEFAULT_STEP_TIMEOUT_MS,
+    'Pasting after copying a message did not transfer keyboard focus to the composer'
+  )
   return shortConversationTaskRowTestId
 }
 

--- a/wework/e2e/desktop/modules/conversation-layout.mjs
+++ b/wework/e2e/desktop/modules/conversation-layout.mjs
@@ -32,7 +32,7 @@ import {
 
 import { captureVerificationScreenshot } from './workspace-flows.mjs'
 
-async function verifyShortConversationLayout({ composerSelector, control }) {
+async function verifyShortConversationLayout({ composerSelector, control, restartDesktopApp }) {
   const taskRowsBeforeConversation = new Set(
     JSON.parse(await control.command('snapshot', 'body')).testIds.filter(testId =>
       testId.startsWith('runtime-local-task-row-')
@@ -74,6 +74,17 @@ async function verifyShortConversationLayout({ composerSelector, control }) {
     text: FRESH_CHAT_COMPLETION_TEXT,
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
   })
+  await restartDesktopApp()
+  await control.command('focusMainWindow', 'body')
+  await control.command('waitFor', '[data-testid="message-assistant"]', {
+    text: FRESH_CHAT_COMPLETION_TEXT,
+    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
+  })
+  await waitForComposerFocus(
+    control,
+    DEFAULT_STEP_TIMEOUT_MS,
+    'Restoring an existing conversation on app startup did not focus the composer'
+  )
   await control.command('click', `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`)
   await waitForComposerFocus(
     control,

--- a/wework/e2e/desktop/modules/conversation-navigation.mjs
+++ b/wework/e2e/desktop/modules/conversation-navigation.mjs
@@ -4,6 +4,7 @@ import {
   getElementMetrics,
   getSingleElementMetrics,
   verifyViewImageProcessingBlock,
+  waitForComposerFocus,
   waitForElementInsideScroller,
   waitForOverflowMetrics,
   waitForSnapshot,
@@ -971,25 +972,6 @@ async function verifyEnvironmentPanelScrollStability(control) {
   await captureVerificationScreenshot(control, 'environment-panel-scroll-03-downward.png')
 }
 
-export async function waitForComposerFocus(control, timeoutMs, failureMessage) {
-  const focusStartedAt = Date.now()
-  let activeElementTestId = ''
-  while (Date.now() - focusStartedAt < timeoutMs) {
-    activeElementTestId = await control.command('getActiveElementTestId', 'body')
-    if (activeElementTestId === 'chat-message-input') return
-    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
-  }
-  const [focusSnapshot, workbenchSnapshot, composerDiagnostics] = await Promise.all([
-    control.command('getComposerFocusSnapshot', 'body'),
-    control.command('getWorkbenchDebugSnapshot', 'body'),
-    control.command('getComposerDiagnosticsSnapshot', 'body'),
-  ])
-  throw new Error(
-    `${failureMessage}; activeElementTestId=${activeElementTestId}; focus=${focusSnapshot}; ` +
-      `workbench=${workbenchSnapshot}; composerDiagnostics=${composerDiagnostics}`
-  )
-}
-
 async function reopenCurrentTurnNavigationTask(
   control,
   composerSelector,
@@ -1531,5 +1513,6 @@ export {
   assertLatestScenarioRequestContains,
   verifyPausedQueueLifecycle,
   verifyLastUserMessageEdit,
+  waitForComposerFocus,
   waitForSuccessfulMatrixSubmission,
 }

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1654,7 +1654,11 @@ last_updated = "2026-07-30T00:00:00Z"`
         timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
       })
       await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
-      await verifyShortConversationLayout({ composerSelector: ACTIVE_COMPOSER_SELECTOR, control })
+      await verifyShortConversationLayout({
+        composerSelector: ACTIVE_COMPOSER_SELECTOR,
+        control,
+        restartDesktopApp,
+      })
       console.log(`Wework desktop short-conversation E2E passed. Evidence: ${resultDir}`)
       return
     }
@@ -3171,6 +3175,7 @@ last_updated = "2026-07-30T00:00:00Z"`
       const secondTaskRowTestId = await verifyShortConversationLayout({
         composerSelector,
         control,
+        restartDesktopApp,
       })
 
       phase = 'edit-last-user-message'

--- a/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
@@ -147,11 +147,18 @@ async function createTask(control, prompt, timeoutMs) {
     snapshot.testIds.filter(testId => testId.startsWith('runtime-local-task-row-'))
   )
   await control.command('fill', COMPOSER, { value: prompt })
-  await control.command('press', COMPOSER, { key: 'Enter' })
+  await control.command('clickWhenEnabled', '[data-testid="send-message-button"]', {
+    timeoutMs,
+  })
   await control.command('waitFor', `${ACTIVE_SURFACE} [data-testid="message-assistant"]`, {
     text: `${prompt}_COMPLETE`,
     timeoutMs,
   })
+  assert.equal(
+    await control.command('getActiveElementTestId', 'body'),
+    'chat-message-input',
+    'The composer did not retain focus after sending a message'
+  )
   return waitForNewTaskRow(control, knownRows, prompt, timeoutMs)
 }
 
@@ -180,10 +187,34 @@ async function verifyMultilineComposerCaret(control, captureScreenshot) {
 
   await control.command('fill', COMPOSER, { value: '' })
   await control.command('click', COMPOSER)
+  assert.equal(
+    await control.command('getActiveElementTestId', 'body'),
+    'chat-message-input',
+    'The composer did not retain DOM focus while the desktop window stayed inactive'
+  )
+  assert.equal(
+    JSON.parse(await control.command('getWindowFocusSnapshot', 'body')).mainFocused,
+    false,
+    'The desktop E2E window unexpectedly became active'
+  )
   const [singleLineCaretMetrics] = JSON.parse(
     await control.command('getElementMetrics', `${COMPOSER} .composer-empty-caret`)
   )
   assert.ok(singleLineCaretMetrics, 'The empty composer did not render its caret')
+  assert.equal(
+    await control.command('getComputedStyleValue', `${COMPOSER} .composer-empty-caret`, {
+      value: 'animation-name',
+    }),
+    'none',
+    'The inactive composer continued animating its empty caret despite retaining DOM focus'
+  )
+  assert.equal(
+    await control.command('getComputedStyleValue', `${COMPOSER} .composer-empty-caret`, {
+      value: 'opacity',
+    }),
+    '0',
+    'The inactive composer continued showing its empty caret'
+  )
   for (let line = 1; line < 12; line += 1) {
     await control.command('press', COMPOSER, { key: 'Shift+Enter' })
   }

--- a/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
@@ -147,9 +147,13 @@ async function createTask(control, prompt, timeoutMs) {
     snapshot.testIds.filter(testId => testId.startsWith('runtime-local-task-row-'))
   )
   await control.command('fill', COMPOSER, { value: prompt })
-  await control.command('clickWhenEnabled', '[data-testid="send-message-button"]', {
-    timeoutMs,
-  })
+  await control.command(
+    'clickWhenEnabled',
+    `${ACTIVE_SURFACE} [data-testid="send-message-button"]`,
+    {
+      timeoutMs,
+    }
+  )
   await control.command('waitFor', `${ACTIVE_SURFACE} [data-testid="message-assistant"]`, {
     text: `${prompt}_COMPLETE`,
     timeoutMs,
@@ -192,29 +196,31 @@ async function verifyMultilineComposerCaret(control, captureScreenshot) {
     'chat-message-input',
     'The composer did not retain DOM focus while the desktop window stayed inactive'
   )
-  assert.equal(
-    JSON.parse(await control.command('getWindowFocusSnapshot', 'body')).mainFocused,
-    false,
-    'The desktop E2E window unexpectedly became active'
-  )
   const [singleLineCaretMetrics] = JSON.parse(
     await control.command('getElementMetrics', `${COMPOSER} .composer-empty-caret`)
   )
   assert.ok(singleLineCaretMetrics, 'The empty composer did not render its caret')
-  assert.equal(
-    await control.command('getComputedStyleValue', `${COMPOSER} .composer-empty-caret`, {
-      value: 'animation-name',
-    }),
-    'none',
-    'The inactive composer continued animating its empty caret despite retaining DOM focus'
-  )
-  assert.equal(
-    await control.command('getComputedStyleValue', `${COMPOSER} .composer-empty-caret`, {
-      value: 'opacity',
-    }),
-    '0',
-    'The inactive composer continued showing its empty caret'
-  )
+  if (process.platform === 'darwin') {
+    assert.equal(
+      JSON.parse(await control.command('getWindowFocusSnapshot', 'body')).mainFocused,
+      false,
+      'The desktop E2E window unexpectedly became active'
+    )
+    assert.equal(
+      await control.command('getComputedStyleValue', `${COMPOSER} .composer-empty-caret`, {
+        value: 'animation-name',
+      }),
+      'none',
+      'The inactive composer continued animating its empty caret despite retaining DOM focus'
+    )
+    assert.equal(
+      await control.command('getComputedStyleValue', `${COMPOSER} .composer-empty-caret`, {
+        value: 'opacity',
+      }),
+      '0',
+      'The inactive composer continued showing its empty caret'
+    )
+  }
   for (let line = 1; line < 12; line += 1) {
     await control.command('press', COMPOSER, { key: 'Shift+Enter' })
   }

--- a/wework/electron/src/dsh-preload.cts
+++ b/wework/electron/src/dsh-preload.cts
@@ -22,6 +22,11 @@ contextBridge.exposeInMainWorld('weworkElectronLifecycle', {
     ipcRenderer.on('system:resume', handler)
     return () => ipcRenderer.off('system:resume', handler)
   },
+  onWindowFocusChanged: (listener: (focused: boolean) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, focused: boolean) => listener(focused)
+    ipcRenderer.on('window:focus-changed', handler)
+    return () => ipcRenderer.off('window:focus-changed', handler)
+  },
 })
 
 contextBridge.exposeInMainWorld('weworkElectronCloudCredentials', {

--- a/wework/electron/src/dsh-preload.test.ts
+++ b/wework/electron/src/dsh-preload.test.ts
@@ -15,5 +15,6 @@ describe('DSH preload', () => {
     expect(source).not.toMatch(/from\s+['"]\.\.?\//)
     expect(source).toContain("location.protocol === 'file:'")
     expect(source).toContain("'weworkElectronCloudCredentials'")
+    expect(source).toContain("'window:focus-changed'")
   })
 })

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -142,6 +142,7 @@ export interface ElectronE2EHost {
   }) => Promise<void>
   dismissPopout: () => void
   dismissSystemDragPanel: () => void
+  focusMainWindow: () => void | Promise<void>
   focusWindow: (windowLabel: string) => void
   hideMainWindow: () => Promise<void>
   dockVisible: () => boolean
@@ -199,6 +200,7 @@ export function createElectronCapabilityRouter(
     completeSystemDragDrop: () => Promise.reject(new Error('System drag is unavailable')),
     dismissPopout: () => undefined,
     dismissSystemDragPanel: () => undefined,
+    focusMainWindow: () => undefined,
     focusWindow: () => undefined,
     hideMainWindow: () => Promise.reject(new Error('Main window backgrounding is unavailable')),
     dockVisible: () => true,
@@ -488,7 +490,8 @@ export function createElectronCapabilityRouter(
   router.register('e2e.activateRuntimeTaskNotification', params => {
     desktopServices.openRuntimeTask(stringParam(params, 'taskAddressId'))
   })
-  router.register('e2e.focusMainWindow', () => {
+  router.register('e2e.focusMainWindow', async () => {
+    await e2eHost.focusMainWindow()
     const target = requiredWindow(window)
     if (target.isMinimized()) target.restore()
     target.show()

--- a/wework/electron/src/host/window-layout.test.ts
+++ b/wework/electron/src/host/window-layout.test.ts
@@ -13,6 +13,7 @@ describe('Electron window layout', () => {
 
   test('uses an inset native titlebar on macOS so traffic lights overlay the DSH titlebar', () => {
     expect(desktopWindowFrameOptions('darwin')).toEqual({
+      acceptFirstMouse: true,
       frame: true,
       titleBarStyle: 'hiddenInset',
       trafficLightPosition: { x: 14, y: 12 },

--- a/wework/electron/src/host/window-layout.ts
+++ b/wework/electron/src/host/window-layout.ts
@@ -21,9 +21,13 @@ export function primaryDshBounds({ width, height }: WindowContentSize): WindowVi
 
 export function desktopWindowFrameOptions(
   platform: NodeJS.Platform = process.platform
-): Pick<BrowserWindowConstructorOptions, 'frame' | 'titleBarStyle' | 'trafficLightPosition'> {
+): Pick<
+  BrowserWindowConstructorOptions,
+  'acceptFirstMouse' | 'frame' | 'titleBarStyle' | 'trafficLightPosition'
+> {
   if (platform === 'darwin') {
     return {
+      acceptFirstMouse: true,
       frame: true,
       titleBarStyle: 'hiddenInset',
       trafficLightPosition: { x: 14, y: 12 },

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -909,6 +909,12 @@ async function createWindow(startupTheme: StartupSplashTheme): Promise<void> {
   startupSplashWindow.on('closed', () => {
     startupSplashWindow = null
   })
+  mainWindow.on('focus', () => {
+    mainWindow?.webContents.send('window:focus-changed', true)
+  })
+  mainWindow.on('blur', () => {
+    mainWindow?.webContents.send('window:focus-changed', false)
+  })
   mainWindow.on('resize', layoutPrimaryView)
   mainWindow.on('close', event => {
     if (quitting) return
@@ -1374,6 +1380,7 @@ async function configureDesktopRuntime(): Promise<void> {
                   : (workspaceWindows.get(windowLabel)?.webContents ?? null),
           cancelCloseToTray: cancelMainWindowClose,
           closeToTray: closeMainWindowToTray,
+          focusMainWindow: reactivateMainWindow,
           focusWindow: windowLabel => {
             const target =
               windowLabel === 'main' ? mainWindow : (workspaceWindows.get(windowLabel) ?? null)
@@ -1390,6 +1397,10 @@ async function configureDesktopRuntime(): Promise<void> {
               capturePath: process.env.WEWORK_E2E_STARTUP_SPLASH_CAPTURE?.trim(),
             })
             logStartupStep('startup-splash-close', 'completed')
+            if (!keepE2EWindowInBackground) {
+              mainWindow.focus()
+              mainWindow.webContents.focus()
+            }
             scheduleComputerUseStartup()
           },
           rendererStartupFailed: () => {

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.test.tsx
@@ -357,8 +357,10 @@ describe('ComposerProseMirrorEditor', () => {
     expect(screen.getByTestId('composer-editor').querySelector('.composer-empty-caret')).toBeNull()
   })
 
-  test('renders the measurable empty caret in Electron', () => {
+  test('shows the measurable empty caret only while the Electron window is focused', () => {
     const previousRuntimeConfig = window.__WEWORK_RUNTIME_CONFIG__
+    let documentFocused = true
+    const hasFocus = vi.spyOn(document, 'hasFocus').mockImplementation(() => documentFocused)
     window.__WEWORK_RUNTIME_CONFIG__ = {
       ...previousRuntimeConfig,
       desktopHost: 'electron',
@@ -370,7 +372,28 @@ describe('ComposerProseMirrorEditor', () => {
       expect(
         screen.getByTestId('composer-editor').querySelector('.composer-empty-caret')
       ).toHaveAttribute('aria-hidden', 'true')
+
+      const editor = screen.getByTestId('composer-editor')
+      editor.focus()
+      expect(editor).toHaveAttribute('data-composer-focus-visible')
+
+      documentFocused = false
+      act(() => window.dispatchEvent(new Event('blur')))
+      expect(editor).not.toHaveAttribute('data-composer-focus-visible')
+      expect(editor).toHaveFocus()
+
+      documentFocused = true
+      act(() => window.dispatchEvent(new Event('focus')))
+      expect(editor).toHaveFocus()
+      expect(editor).toHaveAttribute('data-composer-focus-visible')
+
+      const otherButton = document.createElement('button')
+      document.body.append(otherButton)
+      otherButton.focus()
+      expect(editor).not.toHaveAttribute('data-composer-focus-visible')
+      otherButton.remove()
     } finally {
+      hasFocus.mockRestore()
       window.__WEWORK_RUNTIME_CONFIG__ = previousRuntimeConfig
     }
   })

--- a/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
+++ b/wework/src/components/chat/composer/ComposerProseMirrorEditor.tsx
@@ -19,6 +19,7 @@ import { keymap } from 'prosemirror-keymap'
 import { Slice, type Node as ProseMirrorNode } from 'prosemirror-model'
 import { AllSelection, EditorState, Plugin, TextSelection } from 'prosemirror-state'
 import { Decoration, DecorationSet, EditorView } from 'prosemirror-view'
+import { isMainWindowFocused, subscribeMainWindowFocus } from '@/desktop/windowFocus'
 import type { PluginReference } from '@/features/plugins/pluginNavigation'
 import { isElectronRuntime } from '@/lib/runtime-environment'
 import { ComposerMentionNodeView } from './ComposerMentionNodeView'
@@ -313,15 +314,24 @@ export const ComposerProseMirrorEditor = forwardRef<
           return false
         },
         focus() {
+          view.dom.toggleAttribute('data-composer-focus-visible', isMainWindowFocused())
           callbacksRef.current.onFocus()
           return false
         },
         blur() {
+          view.dom.removeAttribute('data-composer-focus-visible')
           callbacksRef.current.onBlur?.()
           return false
         },
       },
     })
+    const unsubscribeWindowFocus = subscribeMainWindowFocus(focused => {
+      view.dom.toggleAttribute('data-composer-focus-visible', focused && view.hasFocus())
+    })
+    view.dom.toggleAttribute(
+      'data-composer-focus-visible',
+      isMainWindowFocused() && view.hasFocus()
+    )
 
     const handleKeyDownCapture = (event: KeyboardEvent) => {
       const diagnosticKey = diagnosticKeyboardKey(event.key)
@@ -435,6 +445,7 @@ export const ComposerProseMirrorEditor = forwardRef<
       view.dom.removeEventListener('keydown', handleKeyDownCapture, true)
       view.dom.removeEventListener('beforeinput', handleBeforeInputCapture, true)
       view.dom.removeEventListener('copy', handleCopyCapture, true)
+      unsubscribeWindowFocus()
       view.destroy()
     }
   }, [])

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -250,6 +250,7 @@ export function ComposerToolbar({
                 type="submit"
                 data-composer-primary-action="true"
                 data-testid={sendButtonTestId}
+                onMouseDown={event => event.preventDefault()}
                 className="flex h-8 w-8 items-center justify-center rounded-l-full hover:bg-text-primary/90"
                 aria-label={t('workbench.send_after_turn', '当前回复结束后发送')}
               >
@@ -315,6 +316,7 @@ export function ComposerToolbar({
               data-composer-primary-action="true"
               data-testid={sendButtonTestId}
               disabled={!canSend}
+              onMouseDown={event => event.preventDefault()}
               className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-text-primary p-0 text-background disabled:cursor-not-allowed disabled:bg-text-muted/45"
               aria-label={t('workbench.send_message', '发送消息')}
             >

--- a/wework/src/components/layout/BufferedChatInput.test.tsx
+++ b/wework/src/components/layout/BufferedChatInput.test.tsx
@@ -250,16 +250,25 @@ describe('BufferedChatInput', () => {
     function Harness() {
       const [value, setValue] = useState('accepted message')
       return (
-        <BufferedChatInput value={value} onChange={setValue} onSubmit={onSubmit} disabled={false} />
+        <BufferedChatInput
+          value={value}
+          onChange={setValue}
+          onSubmit={onSubmit}
+          disabled={false}
+          variant="desktop"
+        />
       )
     }
 
     render(<Harness />)
+    const input = screen.getByTestId('chat-message-input')
+    await userEvent.click(input)
     await userEvent.click(screen.getByTestId('send-message-button'))
     resolveSubmission(true)
 
     await waitFor(() => {
-      expect(screen.getByTestId('chat-message-input')).toHaveValue('')
+      expect(input).toHaveValue('')
+      expect(input).toHaveFocus()
     })
   })
 

--- a/wework/src/components/layout/BufferedChatInput.tsx
+++ b/wework/src/components/layout/BufferedChatInput.tsx
@@ -6,6 +6,7 @@ import {
   type ChatSubmitOptions,
 } from '@/components/chat/ChatInput'
 import { recordComposerDiagnostic } from '@/components/chat/composer/composerDiagnostics'
+import { subscribeMainWindowFocus } from '@/desktop/windowFocus'
 import {
   consumeWorkbenchComposerFocusRequest,
   hasWorkbenchComposerFocusRequest,
@@ -19,6 +20,7 @@ export interface BufferedChatInputInsertion {
 }
 
 interface BufferedChatInputProps extends ChatInputProps {
+  autoFocus?: boolean
   insertion?: BufferedChatInputInsertion | null
   onDraftEdit?: () => void
 }
@@ -29,6 +31,7 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   value,
   onChange,
   onSubmit,
+  autoFocus,
   insertion,
   onDraftEdit,
   onCompositionStart: onParentCompositionStart,
@@ -61,17 +64,18 @@ export const BufferedChatInput = memo(function BufferedChatInput({
   const scopeKeyRef = useRef(scopeKey)
   scopeKeyRef.current = scopeKey
 
+  const focusComposer = useCallback(() => {
+    const composer = composerRef.current
+    if (!composer) return false
+    const element = composer.element
+    const pane = element?.closest<HTMLElement>('[data-active-workbench-pane]')
+    if (pane?.dataset.activeWorkbenchPane !== 'true') return false
+    if (element?.closest('[hidden], [aria-hidden="true"]')) return false
+    composer.focus()
+    return true
+  }, [])
+
   useLayoutEffect(() => {
-    const focusComposer = () => {
-      const composer = composerRef.current
-      if (!composer) return false
-      const element = composer.element
-      const pane = element?.closest<HTMLElement>('[data-active-workbench-pane]')
-      if (pane?.dataset.activeWorkbenchPane !== 'true') return false
-      if (element?.closest('[hidden], [aria-hidden="true"]')) return false
-      composer.focus()
-      return true
-    }
     const focusRequestedComposer = (event: Event) => {
       const detail = (event as CustomEvent<WorkbenchComposerFocusDetail>).detail
       if (props.disabled || !scopeKey || detail?.scopeKey !== scopeKey) return
@@ -91,7 +95,28 @@ export const BufferedChatInput = memo(function BufferedChatInput({
     return () => {
       window.removeEventListener(WORKBENCH_COMPOSER_FOCUS_EVENT, focusRequestedComposer)
     }
-  }, [props.disabled, scopeKey])
+  }, [focusComposer, props.disabled, scopeKey])
+
+  useEffect(() => {
+    if (!autoFocus || props.disabled) return
+    focusComposer()
+    return subscribeMainWindowFocus(focused => {
+      if (!focused) return
+      const activeElement = document.activeElement
+      const composerElement = composerRef.current?.element
+      if (
+        activeElement &&
+        activeElement !== document.body &&
+        activeElement !== document.documentElement &&
+        activeElement !== composerElement
+      ) {
+        return
+      }
+      window.requestAnimationFrame(() => {
+        focusComposer()
+      })
+    })
+  }, [autoFocus, focusComposer, props.disabled, scopeKey])
 
   const setComposerValue = useCallback((nextValue: string, cursor: number) => {
     programmaticUpdateDepthRef.current += 1

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -213,6 +213,7 @@ describe('DesktopSidebar', () => {
     experimentalFeatures.enabled = true
     window.history.replaceState({}, '', '/')
     localStorage.clear()
+    vi.stubEnv('VITE_WEGENT_BACKEND_URL', '')
     enableElectron()
     setActiveKeybindings([])
     Element.prototype.scrollIntoView = vi.fn()

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2301,6 +2301,23 @@ describe('DesktopWorkbenchLayout', () => {
     )
   }
 
+  test('focuses a restored conversation when its composer mounts', async () => {
+    const { composer } = renderFocusableConversation()
+
+    await waitFor(() => expect(composer).toHaveFocus())
+  })
+
+  test('refocuses a restored conversation when the app window becomes active', async () => {
+    const { composer } = renderFocusableConversation()
+
+    await waitFor(() => expect(composer).toHaveFocus())
+    composer.blur()
+    window.dispatchEvent(new Event('blur'))
+    window.dispatchEvent(new Event('focus'))
+
+    await waitFor(() => expect(composer).toHaveFocus())
+  })
+
   test('focuses the composer from a non-interactive conversation click', async () => {
     const { composer } = renderFocusableConversation()
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2339,6 +2339,41 @@ describe('DesktopWorkbenchLayout', () => {
     expect(composer).not.toHaveFocus()
   })
 
+  test('focuses the composer before pasting after a message copy action', async () => {
+    const { composer, hoverRegion } = renderFocusableConversation()
+
+    composer.blur()
+    fireEvent.pointerEnter(hoverRegion)
+    const copyButton = await screen.findByTestId('copy-message-button')
+    await userEvent.click(copyButton)
+    expect(composer).not.toHaveFocus()
+
+    fireEvent.keyDown(document.body, { key: 'v', metaKey: true })
+
+    expect(composer).toHaveFocus()
+    fireEvent.paste(composer, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => (type === 'text/plain' ? 'Selectable response' : ''),
+        types: ['text/plain'],
+      },
+    })
+    expect(composer).toHaveValue('Selectable response')
+  })
+
+  test('keeps paste shortcuts in an explicitly focused editor', () => {
+    const { composer } = renderFocusableConversation()
+    const editor = document.createElement('textarea')
+    document.body.append(editor)
+    editor.focus()
+
+    fireEvent.keyDown(editor, { key: 'v', metaKey: true })
+
+    expect(editor).toHaveFocus()
+    expect(composer).not.toHaveFocus()
+    editor.remove()
+  })
+
   test('does not focus the composer while conversation text is selected', async () => {
     const { composer, messageText } = renderFocusableConversation()
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2246,7 +2246,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('project-work-button')).not.toBeInTheDocument()
   })
 
-  test('focuses the composer from the conversation surface without stealing interactions', async () => {
+  function renderFocusableConversation() {
     const onlineDevice = {
       id: 1,
       device_id: 'device-1',
@@ -2285,33 +2285,57 @@ describe('DesktopWorkbenchLayout', () => {
         ]}
       />
     )
+    return {
+      composer: screen.getByTestId('chat-message-input'),
+      hoverRegion: screen.getByTestId('message-hover-region'),
+      messageText: screen.getByText('Selectable response'),
+    }
+  }
 
-    const composer = screen.getByTestId('chat-message-input')
+  async function waitForComposerFocusRequest() {
+    await act(
+      () =>
+        new Promise<void>(resolvePromise => {
+          window.requestAnimationFrame(() => resolvePromise())
+        })
+    )
+  }
+
+  test('focuses the composer from a non-interactive conversation click', async () => {
+    const { composer } = renderFocusableConversation()
+
     composer.blur()
-
     fireEvent.click(screen.getByTestId('desktop-chat-scroll-content'))
 
     await waitFor(() => expect(composer).toHaveFocus())
+  })
+
+  test('does not focus the composer from a conversation action click', async () => {
+    const { composer, hoverRegion } = renderFocusableConversation()
 
     composer.blur()
-    const hoverRegion = screen.getByTestId('message-hover-region')
     fireEvent.pointerEnter(hoverRegion)
     const copyButton = await screen.findByTestId('copy-message-button')
-
     await userEvent.click(copyButton)
+    await waitForComposerFocusRequest()
 
     expect(composer).not.toHaveFocus()
+  })
 
-    const messageText = screen.getByText('Selectable response')
+  test('does not focus the composer while conversation text is selected', async () => {
+    const { composer, messageText } = renderFocusableConversation()
+
+    composer.blur()
     const selection = window.getSelection()
     const range = document.createRange()
     range.selectNodeContents(messageText)
     selection?.removeAllRanges()
     selection?.addRange(range)
-
     fireEvent.click(messageText)
+    await waitForComposerFocusRequest()
 
     expect(composer).not.toHaveFocus()
+    expect(selection?.toString()).toBe('Selectable response')
     selection?.removeAllRanges()
   })
 

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2246,6 +2246,75 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('project-work-button')).not.toBeInTheDocument()
   })
 
+  test('focuses the composer from the conversation surface without stealing interactions', async () => {
+    const onlineDevice = {
+      id: 1,
+      device_id: 'device-1',
+      name: 'Runtime Device',
+      status: 'online' as const,
+      is_default: true,
+      device_type: 'cloud' as const,
+      bind_shell: 'claudecode',
+      executor_version: '1.8.5',
+    }
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{
+          ...baseProps.state,
+          devices: [onlineDevice],
+          standaloneDeviceId: 'device-1',
+        }}
+        projectWork={{
+          ...baseProps.projectWork,
+          devices: [onlineDevice],
+          currentStandaloneDeviceId: 'device-1',
+        }}
+        projectChat={{
+          ...baseProps.projectChat,
+          scopeKey: 'standalone:device-1',
+        }}
+        messages={[
+          {
+            id: 'message-1',
+            role: 'assistant',
+            content: 'Selectable response',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    const composer = screen.getByTestId('chat-message-input')
+    composer.blur()
+
+    fireEvent.click(screen.getByTestId('desktop-chat-scroll-content'))
+
+    await waitFor(() => expect(composer).toHaveFocus())
+
+    composer.blur()
+    const hoverRegion = screen.getByTestId('message-hover-region')
+    fireEvent.pointerEnter(hoverRegion)
+    const copyButton = await screen.findByTestId('copy-message-button')
+
+    await userEvent.click(copyButton)
+
+    expect(composer).not.toHaveFocus()
+
+    const messageText = screen.getByText('Selectable response')
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.selectNodeContents(messageText)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    fireEvent.click(messageText)
+
+    expect(composer).not.toHaveFocus()
+    selection?.removeAllRanges()
+  })
+
   test('renders subagent status below the top bar without shifting messages', () => {
     mockDesktopWorkbenchMainWidth(1024)
     render(

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1,5 +1,6 @@
 import {
   memo,
+  type MouseEvent as ReactMouseEvent,
   useCallback,
   useEffect,
   useEffectEvent,
@@ -289,6 +290,23 @@ const DOCKED_ENVIRONMENT_INFO_WIDTH = 320
 const MIN_CHAT_COLUMN_WIDTH_FOR_DOCKED_ENVIRONMENT_INFO = 680
 const COLLAPSED_RIGHT_TITLEBAR_ACTIONS_CLEARANCE = '5rem'
 const MACOS_COLLAPSED_SIDEBAR_CONTROL_ALIGNMENT_CLASS = 'pl-2'
+const CONVERSATION_COMPOSER_FOCUS_EXCLUSION_SELECTOR = [
+  'a',
+  'button',
+  'input',
+  'textarea',
+  'select',
+  'label',
+  'summary',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="textbox"]',
+  '[role="menuitem"]',
+  '[role="menuitemradio"]',
+  '[role="option"]',
+  '[role="slider"]',
+].join(', ')
 
 interface SelectedAssistantPlan {
   blockId: string
@@ -3325,6 +3343,28 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     (selectedText: string) => openTemporaryChatTab(selectedText),
     [openTemporaryChatTab]
   )
+  const focusComposerFromConversationClick = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (
+        event.defaultPrevented ||
+        !paneActive ||
+        !paneVisible ||
+        !workbenchVisible ||
+        !(event.target instanceof Element) ||
+        event.target.closest(CONVERSATION_COMPOSER_FOCUS_EXCLUSION_SELECTOR)
+      ) {
+        return
+      }
+      const selection = window.getSelection()
+      if (selection && !selection.isCollapsed) return
+      const composer = event.currentTarget.querySelector<HTMLElement>(
+        '[data-testid="chat-message-input"][contenteditable="true"]'
+      )
+      if (!composer) return
+      requestWorkbenchComposerFocus(paneSession.scopeKey)
+    },
+    [paneActive, paneSession.scopeKey, paneVisible, workbenchVisible]
+  )
   const routeEmbeddedBrowserOpenRequest = useCallback(
     (request: EmbeddedBrowserOpenRequest) => {
       const states = browserStatesRef.current
@@ -4484,7 +4524,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                   )}
                 </div>
               ) : hasConversation ? (
-                <div className="relative flex min-h-full min-w-0 shrink-0 flex-col">
+                <div
+                  className="relative flex min-h-full min-w-0 shrink-0 flex-col"
+                  onClick={focusComposerFromConversationClick}
+                >
                   <ScrollableMessageArea
                     messages={paneMessages}
                     loading={paneSession.transcriptLoading}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -312,6 +312,12 @@ const CONVERSATION_COMPOSER_FOCUS_EXCLUSION_SELECTOR = [
   '[role="tab"]',
 ].join(', ')
 
+function isConversationPasteShortcut(event: KeyboardEvent) {
+  const primaryPressed =
+    getPlatform() === 'mac' ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+  return primaryPressed && !event.altKey && event.key.toLowerCase() === 'v'
+}
+
 interface SelectedAssistantPlan {
   blockId: string
   subtaskId: string
@@ -1610,6 +1616,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const isDesktop = isDesktopRuntime()
   const workbenchMainRef = useRef<HTMLElement | null>(null)
   const workbenchScrollRef = useRef<HTMLDivElement | null>(null)
+  const conversationSurfaceRef = useRef<HTMLDivElement | null>(null)
   const [measuredWorkbenchContentWidth, setMeasuredWorkbenchContentWidth] = useState(0)
   const workbenchResizeObserverRef = useRef<ResizeObserver | null>(null)
   const setWorkbenchMainRef = useCallback((element: HTMLElement | null) => {
@@ -3369,6 +3376,33 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     },
     [paneActive, paneSession.scopeKey, paneVisible, workbenchVisible]
   )
+  useEffect(() => {
+    if (!hasConversation || !paneActive || !paneVisible || !workbenchVisible) return
+
+    const focusComposerForPasteShortcut = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing || !isConversationPasteShortcut(event)) {
+        return
+      }
+      const conversationSurface = conversationSurfaceRef.current
+      if (!conversationSurface) return
+      const activeElement = document.activeElement
+      if (isEditableShortcutTarget(activeElement)) return
+      if (
+        activeElement &&
+        activeElement !== document.body &&
+        activeElement !== document.documentElement &&
+        !conversationSurface.contains(activeElement)
+      ) {
+        return
+      }
+      conversationSurface
+        .querySelector<HTMLElement>('[data-testid="chat-message-input"][contenteditable="true"]')
+        ?.focus({ preventScroll: true })
+    }
+
+    window.addEventListener('keydown', focusComposerForPasteShortcut)
+    return () => window.removeEventListener('keydown', focusComposerForPasteShortcut)
+  }, [hasConversation, paneActive, paneVisible, workbenchVisible])
   const routeEmbeddedBrowserOpenRequest = useCallback(
     (request: EmbeddedBrowserOpenRequest) => {
       const states = browserStatesRef.current
@@ -4529,6 +4563,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                 </div>
               ) : hasConversation ? (
                 <div
+                  ref={conversationSurfaceRef}
                   className="relative flex min-h-full min-w-0 shrink-0 flex-col"
                   onClick={focusComposerFromConversationClick}
                 >

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -306,6 +306,10 @@ const CONVERSATION_COMPOSER_FOCUS_EXCLUSION_SELECTOR = [
   '[role="menuitemradio"]',
   '[role="option"]',
   '[role="slider"]',
+  '[role="checkbox"]',
+  '[role="radio"]',
+  '[role="switch"]',
+  '[role="tab"]',
 ].join(', ')
 
 interface SelectedAssistantPlan {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -158,8 +158,12 @@ import {
   listLocalHarnessModelOptions,
   type LocalHarnessModelOption,
 } from '@/features/local-harness/localHarnessModels'
+import { getRuntimeTaskChatScopeKey } from '@/features/workbench/workbenchProviderHelpers'
 import { getWeworkDevInstanceInfo } from '@/lib/wework-dev-instance'
-import { WORKBENCH_NEW_CHAT_FOCUS_EVENT } from '@/lib/workbenchComposerFocus'
+import {
+  requestWorkbenchComposerFocus,
+  WORKBENCH_NEW_CHAT_FOCUS_EVENT,
+} from '@/lib/workbenchComposerFocus'
 import {
   DEFAULT_EMBEDDED_BROWSER_LABEL,
   closeEmbeddedBrowser,
@@ -1200,6 +1204,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         onRuntimeTaskCreated: address => {
           onRuntimeTaskCreated(sourcePaneKey, address)
           cloudSubmission.onRuntimeTaskCreated(address)
+          requestWorkbenchComposerFocus(getRuntimeTaskChatScopeKey(address))
         },
         onRuntimeTaskReady: () => {
           if (supervisorConfig) {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -4692,6 +4692,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                                         />
                                       )}
                                       <BufferedChatInput
+                                        autoFocus
                                         insertion={conversationSelectionInsertion}
                                         value={paneSession.input}
                                         onChange={paneSession.setInput}

--- a/wework/src/components/sites/SitesWorkspace.test.tsx
+++ b/wework/src/components/sites/SitesWorkspace.test.tsx
@@ -775,7 +775,7 @@ describe('SitesWorkspace', () => {
     render(<SitesWorkspace api={api} onCreate={vi.fn()} />)
 
     expect(await screen.findByTestId('environment-variables-dialog')).toBeInTheDocument()
-    expect(api.getEnvironmentVariables).toHaveBeenCalledWith('site-1')
+    await waitFor(() => expect(api.getEnvironmentVariables).toHaveBeenCalledWith('site-1'))
   })
 
   test('keeps the edit dialog open when metadata saving fails', async () => {

--- a/wework/src/desktop/systemResume.ts
+++ b/wework/src/desktop/systemResume.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     weworkElectronLifecycle?: {
       onSystemResume(listener: () => void): () => void
+      onWindowFocusChanged?(listener: (focused: boolean) => void): () => void
     }
   }
 }

--- a/wework/src/desktop/windowFocus.test.ts
+++ b/wework/src/desktop/windowFocus.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
+import { isMainWindowFocused, subscribeMainWindowFocus } from './windowFocus'
+
+vi.mock('@/api/dsh/desktopHost', () => ({
+  invokeDesktopHost: vi.fn(),
+}))
+
+const invokeDesktopHostMock = vi.mocked(invokeDesktopHost)
+
+describe('windowFocus', () => {
+  beforeEach(() => {
+    invokeDesktopHostMock.mockReset()
+    delete window.weworkElectronLifecycle
+  })
+
+  test('reads and follows the native Electron window focus state', async () => {
+    let nativeListener: ((focused: boolean) => void) | null = null
+    const unsubscribeNative = vi.fn()
+    window.weworkElectronLifecycle = {
+      onSystemResume: vi.fn(() => () => undefined),
+      onWindowFocusChanged: vi.fn(listener => {
+        nativeListener = listener
+        return unsubscribeNative
+      }),
+    }
+    invokeDesktopHostMock.mockResolvedValue({ focused: false })
+    const listener = vi.fn()
+
+    const unsubscribe = subscribeMainWindowFocus(listener)
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(false))
+
+    nativeListener?.(true)
+    expect(isMainWindowFocused()).toBe(true)
+    expect(listener).toHaveBeenLastCalledWith(true)
+
+    unsubscribe()
+    expect(unsubscribeNative).toHaveBeenCalledOnce()
+  })
+})

--- a/wework/src/desktop/windowFocus.ts
+++ b/wework/src/desktop/windowFocus.ts
@@ -1,8 +1,13 @@
+import { invokeDesktopHost } from '@/api/dsh/desktopHost'
+
 export const WEWORK_MAIN_WINDOW_FOCUS_CHANGED_EVENT = 'wework-main-window-focus-changed'
 
 const listeners = new Set<(focused: boolean) => void>()
 let currentFocused = true
 let initialized = false
+let focusRevision = 0
+let initializationGeneration = 0
+let unsubscribeNativeFocus: (() => void) | null = null
 
 function publishFocused(focused: boolean) {
   if (focused === currentFocused) return
@@ -15,16 +20,38 @@ function publishFocused(focused: boolean) {
 function ensureListenerInstalled() {
   if (initialized) return
   initialized = true
+  const generation = ++initializationGeneration
   publishFocused(document.hasFocus())
   window.addEventListener('focus', handleFocus)
   window.addEventListener('blur', handleBlur)
+  const subscribeNativeFocus = window.weworkElectronLifecycle?.onWindowFocusChanged
+  if (!subscribeNativeFocus) return
+  unsubscribeNativeFocus = subscribeNativeFocus(focused => {
+    focusRevision += 1
+    publishFocused(focused)
+  })
+  const revision = focusRevision
+  void invokeDesktopHost<{ focused?: boolean }>('window.getState')
+    .then(state => {
+      if (
+        initialized &&
+        generation === initializationGeneration &&
+        revision === focusRevision &&
+        typeof state.focused === 'boolean'
+      ) {
+        publishFocused(state.focused)
+      }
+    })
+    .catch(() => undefined)
 }
 
 function handleFocus() {
+  focusRevision += 1
   publishFocused(true)
 }
 
 function handleBlur() {
+  focusRevision += 1
   publishFocused(false)
 }
 
@@ -40,7 +67,10 @@ export function subscribeMainWindowFocus(callback: (focused: boolean) => void): 
     if (listeners.size === 0 && initialized) {
       window.removeEventListener('focus', handleFocus)
       window.removeEventListener('blur', handleBlur)
+      unsubscribeNativeFocus?.()
+      unsubscribeNativeFocus = null
       initialized = false
+      initializationGeneration += 1
     }
   }
 }

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -820,6 +820,10 @@ button:disabled {
     background: currentcolor;
     vertical-align: text-bottom;
     pointer-events: none;
+    opacity: 0;
+  }
+
+  .composer-prosemirror-editor[data-composer-focus-visible] .composer-empty-caret {
     animation: local-skill-caret-blink 1s step-end infinite;
   }
 


### PR DESCRIPTION
## Summary

- restore macOS first-click delivery for Electron windows with `acceptFirstMouse`
- hide the synthetic empty composer caret while the Wework window is inactive
- preserve composer focus when sending from the desktop toolbar without triggering blur/draft races
- focus the newly mounted composer after the first message creates a runtime task
- add unit and desktop E2E regression coverage

## Root cause

The former Tauri window enabled `acceptFirstMouse`, but the Electron migration omitted the equivalent option. The synthetic empty caret also kept animating while the desktop window was inactive, which made the composer look active even though paste input still belonged to another window.

## Verification

- pre-push Wework quality checks (ESLint, renderer TypeScript, Electron TypeScript, full renderer and Electron unit suites)
- focused composer and workbench tests
- `split-workbench` desktop Electron E2E
- isolated Electron `ai:verify` startup and active-element check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composer focus retention after sending messages, creating runtime tasks, and clicking non-interactive conversation areas.
  * Prevented unintended focus changes when clicking send controls or other interactive elements.
  * Improved empty-caret behavior so it appears and blinks only when the composer is visibly focused.
  * Improved caret behavior when the desktop window is inactive.
  * macOS windows now accept the first mouse click as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->