### PR TITLE
feat(api): implement team resolution via shared permissions and enhan…

### DIFF
--- a/backend/app/api/endpoints/openapi_responses.py
+++ b/backend/app/api/endpoints/openapi_responses.py
@@ -461,6 +461,16 @@ async def create_response(
         model_info["team_name"],
     )
     if not team:
+        logger.warning(
+            "[OPENAPI] Team resolution failed: caller_user_id=%s, "
+            "caller_username=%s, team_namespace=%s, team_name=%s, "
+            "api_key_name=%s",
+            current_user.id,
+            current_user.user_name,
+            model_info["namespace"],
+            model_info["team_name"],
+            api_key_name,
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Team '{model_info['namespace']}#{model_info['team_name']}' not found or not accessible",

--- a/backend/app/services/readers/kinds.py
+++ b/backend/app/services/readers/kinds.py
@@ -54,6 +54,50 @@ PUBLIC_FALLBACK_KINDS: Set[KindType] = {
 }
 
 
+def _get_team_by_share_permission(
+    db: Session,
+    *,
+    user_id: int,
+    namespace: str,
+    name: str,
+) -> Optional[Kind]:
+    """Resolve direct or entity-derived Team sharing with the unified policy."""
+    from app.schemas.share import MemberRole
+    from app.services.share.team_share_service import team_share_service
+
+    candidates = (
+        db.query(Kind)
+        .filter(
+            Kind.user_id.notin_((0, user_id)),
+            Kind.kind == KindType.TEAM.value,
+            Kind.namespace == namespace,
+            Kind.name == name,
+            Kind.is_active == True,
+        )
+        .order_by(Kind.updated_at.desc(), Kind.id.desc())
+        .all()
+    )
+    for team in candidates:
+        if team_share_service.check_permission(
+            db,
+            team.id,
+            user_id,
+            MemberRole.Reporter,
+        ):
+            logger.info(
+                "[KindReader] Team resolved via unified share permission: "
+                "user_id=%s, team_id=%s, team_owner_user_id=%s, "
+                "namespace=%s, name=%s",
+                user_id,
+                team.id,
+                team.user_id,
+                namespace,
+                name,
+            )
+            return team
+    return None
+
+
 # =============================================================================
 # Interface
 # =============================================================================
@@ -165,6 +209,8 @@ class IKindReader(ABC):
         from app.services.readers.shared_teams import sharedTeamReader
 
         if namespace == "default":
+            shared_team_ids: List[int] = []
+
             # First, query user's own Team
             if user_id != 0:
                 result = self.get_personal(db, user_id, KindType.TEAM, namespace, name)
@@ -188,6 +234,15 @@ class IKindReader(ABC):
                     )
                     if team:
                         return team
+
+                team = _get_team_by_share_permission(
+                    db,
+                    user_id=user_id,
+                    namespace=namespace,
+                    name=name,
+                )
+                if team:
+                    return team
 
             # If not found, check public Teams (user_id=0)
             public_team = self.get_public(db, KindType.TEAM, namespace, name)

--- a/backend/app/services/readers/shared_teams.py
+++ b/backend/app/services/readers/shared_teams.py
@@ -23,10 +23,18 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.resource_member import MemberStatus, ResourceMember
+from app.models.resource_member import (
+    APPROVED_MEMBER_STATUS_VALUES,
+    ResourceMember,
+)
 from app.models.share_link import ResourceType
 
 logger = logging.getLogger(__name__)
+
+TEAM_RESOURCE_TYPE_VALUES = (
+    ResourceType.TEAM.value,
+    ResourceType.TEAM.name,
+)
 
 
 # =============================================================================
@@ -72,11 +80,11 @@ class SharedTeamReader(ISharedTeamReader):
         return (
             db.query(ResourceMember)
             .filter(
-                ResourceMember.resource_type == ResourceType.TEAM,
+                ResourceMember.resource_type.in_(TEAM_RESOURCE_TYPE_VALUES),
                 ResourceMember.resource_id == team_id,
                 ResourceMember.entity_type == "user",
                 ResourceMember.entity_id == str(user_id),
-                ResourceMember.status == MemberStatus.APPROVED,
+                ResourceMember.status.in_(APPROVED_MEMBER_STATUS_VALUES),
             )
             .first()
             is not None
@@ -86,10 +94,10 @@ class SharedTeamReader(ISharedTeamReader):
         results = (
             db.query(ResourceMember.resource_id)
             .filter(
-                ResourceMember.resource_type == ResourceType.TEAM,
+                ResourceMember.resource_type.in_(TEAM_RESOURCE_TYPE_VALUES),
                 ResourceMember.entity_type == "user",
                 ResourceMember.entity_id == str(user_id),
-                ResourceMember.status == MemberStatus.APPROVED,
+                ResourceMember.status.in_(APPROVED_MEMBER_STATUS_VALUES),
             )
             .all()
         )
@@ -101,11 +109,11 @@ class SharedTeamReader(ISharedTeamReader):
         return (
             db.query(ResourceMember)
             .filter(
-                ResourceMember.resource_type == ResourceType.TEAM,
+                ResourceMember.resource_type.in_(TEAM_RESOURCE_TYPE_VALUES),
                 ResourceMember.resource_id == team_id,
                 ResourceMember.entity_type == "user",
                 ResourceMember.entity_id == str(user_id),
-                ResourceMember.status == MemberStatus.APPROVED,
+                ResourceMember.status.in_(APPROVED_MEMBER_STATUS_VALUES),
             )
             .first()
         )

--- a/backend/tests/api/test_openapi_responses.py
+++ b/backend/tests/api/test_openapi_responses.py
@@ -26,6 +26,7 @@ from app.api.endpoints.openapi_responses import (
 )
 from app.models.api_key import KEY_TYPE_PERSONAL, APIKey
 from app.models.kind import Kind
+from app.models.namespace import Namespace
 from app.models.resource_member import MemberStatus, ResourceMember, ResourceRole
 from app.models.share_link import ResourceType
 from app.models.subtask import SenderType, Subtask, SubtaskRole, SubtaskStatus
@@ -414,7 +415,11 @@ class TestOpenAPIResponsesCreate:
         assert "Invalid model format" in response.json()["detail"]
 
     def test_create_response_team_not_found(
-        self, test_client: TestClient, test_api_key
+        self,
+        test_client: TestClient,
+        test_api_key,
+        test_user: User,
+        caplog: pytest.LogCaptureFixture,
     ):
         """Test create response fails when team not found."""
         response = test_client.post(
@@ -425,6 +430,10 @@ class TestOpenAPIResponsesCreate:
 
         assert response.status_code == 404
         assert "not found" in response.json()["detail"]
+        assert "[OPENAPI] Team resolution failed" in caplog.text
+        assert f"caller_user_id={test_user.id}" in caplog.text
+        assert "team_namespace=default" in caplog.text
+        assert "team_name=nonexistent-team" in caplog.text
 
     def test_create_response_invalid_previous_response_id_format(
         self, test_client: TestClient, test_api_key, test_team: Kind, test_bot: Kind
@@ -534,6 +543,116 @@ class TestOpenAPIResponsesCreate:
         )
 
         assert response.status_code == 401
+
+    @patch("app.api.endpoints.openapi_responses._create_non_streaming_response_unified")
+    def test_create_response_allows_shared_team_api_key(
+        self,
+        mock_create_sync,
+        test_client: TestClient,
+        test_db: Session,
+        test_admin_user: User,
+        test_admin_api_key,
+        test_team: Kind,
+        test_bot: Kind,
+        test_model: Kind,
+        test_public_shell: Kind,
+    ):
+        """An API key owner can invoke a directly shared Team."""
+        from app.schemas.openapi_response import ResponseObject
+
+        member = ResourceMember(
+            resource_type=ResourceType.TEAM.value,
+            resource_id=test_team.id,
+            entity_type="user",
+            entity_id=str(test_admin_user.id),
+            role=ResourceRole.Reporter.value,
+            status=MemberStatus.APPROVED.value,
+        )
+        test_db.add(member)
+        test_db.commit()
+        mock_create_sync.return_value = ResponseObject(
+            id="resp_123",
+            created_at=int(datetime.now().timestamp()),
+            status="completed",
+            model="default#test-team",
+            output=[],
+        )
+
+        response = test_client.post(
+            "/api/v1/responses",
+            headers={"X-API-Key": test_admin_api_key[0]},
+            json={"model": "default#test-team", "input": "Hello"},
+        )
+
+        assert response.status_code == 200
+        assert mock_create_sync.call_args.kwargs["user"].id == test_admin_user.id
+        assert mock_create_sync.call_args.kwargs["team"].id == test_team.id
+
+    @patch("app.api.endpoints.openapi_responses._create_non_streaming_response_unified")
+    def test_create_response_allows_namespace_shared_team_api_key(
+        self,
+        mock_create_sync,
+        test_client: TestClient,
+        test_db: Session,
+        test_admin_user: User,
+        test_admin_api_key,
+        test_team: Kind,
+        test_bot: Kind,
+        test_model: Kind,
+        test_public_shell: Kind,
+    ):
+        """A namespace member can invoke a Team granted to that namespace."""
+        from app.schemas.openapi_response import ResponseObject
+
+        namespace = Namespace(
+            name="openapi-shared-team-namespace",
+            display_name="OpenAPI shared Team namespace",
+            owner_user_id=test_team.user_id,
+            visibility="internal",
+            description="",
+            level="group",
+            is_active=True,
+        )
+        test_db.add(namespace)
+        test_db.flush()
+        test_db.add_all(
+            [
+                ResourceMember(
+                    resource_type="Namespace",
+                    resource_id=namespace.id,
+                    entity_type="user",
+                    entity_id=str(test_admin_user.id),
+                    role=ResourceRole.Reporter.value,
+                    status=MemberStatus.APPROVED.value,
+                ),
+                ResourceMember(
+                    resource_type=ResourceType.TEAM.value,
+                    resource_id=test_team.id,
+                    entity_type="namespace",
+                    entity_id=str(namespace.id),
+                    role=ResourceRole.Reporter.value,
+                    status=MemberStatus.APPROVED.value,
+                ),
+            ]
+        )
+        test_db.commit()
+        mock_create_sync.return_value = ResponseObject(
+            id="resp_123",
+            created_at=int(datetime.now().timestamp()),
+            status="completed",
+            model="default#test-team",
+            output=[],
+        )
+
+        response = test_client.post(
+            "/api/v1/responses",
+            headers={"X-API-Key": test_admin_api_key[0]},
+            json={"model": "default#test-team", "input": "Hello"},
+        )
+
+        assert response.status_code == 200
+        assert mock_create_sync.call_args.kwargs["user"].id == test_admin_user.id
+        assert mock_create_sync.call_args.kwargs["team"].id == test_team.id
 
     @patch("app.api.endpoints.openapi_responses._create_non_streaming_response_unified")
     def test_create_response_sync_success(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API keys can now access Teams shared directly with the key owner.
  - API keys can access Teams shared with their namespace.
  - Team sharing permissions are recognized consistently across supported resource and membership status formats.

- **Bug Fixes**
  - Improved Team resolution when access is granted through shared permissions, preventing valid requests from incorrectly returning “not found.”
  - Added clearer diagnostics when Team resolution fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->