### PR TITLE
fix(wework): stop failed dev reload loops

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -233,6 +233,14 @@ uses this marker as the published build ID, so the page reloads only after the
 marker changes instead of treating an intermediate `index.html` write as a
 loadable generation.
 
+Automatic reload is enabled only in desktop renderers that expose the Wework
+Electron preload capabilities. Opening the Core DSH URL directly in the system
+default browser must not start the hot-reload poller. When a desktop renderer
+observes a newly published build, it records that build ID before attempting a
+reload. If the new page fails to load and the old document remains alive, the
+same build must not trigger another reload. A later build with a new ID still
+reloads normally.
+
 In development hot-reload mode, static resources under `/wework/app/` must use
 `Cache-Control: no-store`. In addition to hashed assets, this tree contains
 fixed-name `plugins/*.js` bundles. Serving those files with the production

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -186,6 +186,11 @@ renderer 可能仍在请求上一代哈希资源，提前删除会在新产物�
 写入 `.wework-build-id`。Core DSH 使用这个标记作为已发布构建 ID，页面只在标记
 变化后刷新，不能把 `index.html` 的中间写入状态当成可加载版本。
 
+自动刷新只在带有 Wework Electron preload 能力的桌面 renderer 中启用。直接在
+系统默认浏览器访问 Core DSH 地址时不得启动热更新轮询。桌面 renderer 发现新的
+已发布构建后，必须先记录该构建 ID，再尝试刷新；如果新页面加载失败并且旧页面仍然
+存活，同一个构建不得重复触发刷新。后续构建发布新的 ID 后仍应正常刷新。
+
 开发热更新模式下，`/wework/app/` 下的静态资源必须返回
 `Cache-Control: no-store`。除哈希资源外，该目录还包含固定文件名的
 `plugins/*.js`；如果这些文件使用生产环境的长期 immutable 缓存，刷新后会把旧插件

--- a/wework/dsh/app-wework/index-hot-reload.test.mjs
+++ b/wework/dsh/app-wework/index-hot-reload.test.mjs
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import vm from 'node:vm'
 import { injectDevelopmentReload, weworkAssetCacheControl, weworkIndexInjection } from './index.js'
 
 test('injects reload polling only into the original development application', () => {
@@ -12,7 +13,49 @@ test('injects reload polling only into the original development application', ()
   const developmentHtml = injectDevelopmentReload(html, { WEWORK_APP_HOT_RELOAD: '1' }, 'build-1')
   assert.match(developmentHtml, /x-wework-app-build-id/)
   assert.match(developmentHtml, /"build-1"/)
+  assert.match(developmentHtml, /window\.weworkElectronFiles/)
   assert.match(developmentHtml, /window\.location\.reload/)
+})
+
+test('does not poll for application builds outside Electron', () => {
+  const intervals = []
+  runDevelopmentReloadScript({
+    buildId: 'build-1',
+    intervals,
+    window: { location: { reload: () => assert.fail('unexpected reload') } },
+  })
+
+  assert.deepEqual(intervals, [])
+})
+
+test('attempts to reload each completed build only once when loading fails', async () => {
+  const intervals = []
+  const responses = ['build-2', 'build-2', 'build-3', 'build-3']
+  let reloads = 0
+  runDevelopmentReloadScript({
+    buildId: 'build-1',
+    intervals,
+    window: {
+      location: {
+        reload: () => {
+          reloads += 1
+        },
+      },
+      weworkElectronFiles: {},
+    },
+    fetch: async () => ({
+      headers: { get: () => responses.shift() ?? null },
+    }),
+  })
+
+  assert.equal(intervals.length, 1)
+  await intervals[0]()
+  await intervals[0]()
+  assert.equal(reloads, 1)
+
+  await intervals[0]()
+  await intervals[0]()
+  assert.equal(reloads, 2)
 })
 
 test('disables application asset caching while development hot reload is active', () => {
@@ -52,3 +95,20 @@ test('reads the current application assets and build id for every page injection
     await rm(directory, { recursive: true, force: true })
   }
 })
+
+function runDevelopmentReloadScript({ buildId, fetch, intervals, window }) {
+  const html = injectDevelopmentReload(
+    '<html><head></head><body></body></html>',
+    { WEWORK_APP_HOT_RELOAD: '1' },
+    buildId
+  )
+  const script = html.match(/<script>(.*)<\/script>/s)?.[1]
+  assert.ok(script)
+  vm.runInNewContext(script, {
+    fetch,
+    setInterval: callback => {
+      intervals.push(callback)
+    },
+    window,
+  })
+}

--- a/wework/dsh/app-wework/index.js
+++ b/wework/dsh/app-wework/index.js
@@ -151,11 +151,11 @@ export function coreDshDeepLinkLocation(value) {
 
 export function injectDevelopmentReload(html, environment, buildId) {
   if (environment.WEWORK_APP_HOT_RELOAD !== '1') return html
-  const script = `<script>(()=>{const current=${escapeJsonForHtml(
+  const script = `<script>(()=>{if(!window.weworkElectronFiles)return;let current=${escapeJsonForHtml(
     buildId
   )};let checking=false;setInterval(async()=>{if(checking)return;checking=true;try{const response=await fetch(${JSON.stringify(
     `${APP_BASE_PATH}/`
-  )},{method:'HEAD',cache:'no-store'});const next=response.headers.get('x-wework-app-build-id');if(next&&next!==current)window.location.reload()}catch{}finally{checking=false}},500)})()</script>`
+  )},{method:'HEAD',cache:'no-store'});const next=response.headers.get('x-wework-app-build-id');if(next&&next!==current){current=next;window.location.reload()}}catch{}finally{checking=false}},500)})()</script>`
   return html.includes('</head>') ? html.replace('</head>', `${script}</head>`) : `${script}${html}`
 }
 


### PR DESCRIPTION
## Summary

- limit Wework dev hot-reload polling to Electron renderers so a Core DSH URL opened in the system browser stays stable
- acknowledge a published build before reloading so a failed page load cannot retry the same build forever
- document the hot-reload failure and browser-boundary invariants

## Verification

- `node --test dsh/app-wework/*.test.mjs` (17 passed)
- `pnpm --filter wework test scripts/desktop-resource-migration.test.mjs` (36 passed)
- `pnpm --filter wework exec prettier --check ...`
- `pnpm --filter wework exec eslint ...`
- `AI_VERIFIED=1 git push` pre-push checks (ESLint, unit tests, DSH tests)
- isolated real Electron verification with `pnpm --filter wework ai:verify start`: Core DSH loaded at `wework-dsh-root`, local executor online, no runtime error; session stopped after verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited development hot reload to the desktop application, preventing polling when the Core DSH address is opened directly in a system browser.
  * Prevented repeated reload attempts for the same published build when a refreshed page fails to load.
  * Later builds with a new build ID continue to trigger reloads normally.

* **Documentation**
  * Updated English and Chinese macOS release guides to describe the revised auto-refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->