### PR TITLE
fix(wework): stabilize differential update progress

### DIFF
--- a/wework/electron/src/host/app-update-service.test.ts
+++ b/wework/electron/src/host/app-update-service.test.ts
@@ -53,6 +53,7 @@ describe('AppUpdateService', () => {
     expect(updater.setFeedURL).toHaveBeenCalledWith({
       provider: 'generic',
       url: 'https://example.com/wework-updater',
+      useMultipleRangeRequest: false,
     })
   })
 

--- a/wework/electron/src/host/app-update-service.ts
+++ b/wework/electron/src/host/app-update-service.ts
@@ -52,7 +52,11 @@ export class AppUpdateService {
 
     this.updater.allowPrerelease = channel === 'beta'
     this.updater.channel = channel === 'beta' ? 'beta' : 'latest'
-    this.updater.setFeedURL({ provider: 'generic', url: this.updateBaseUrl })
+    this.updater.setFeedURL({
+      provider: 'generic',
+      url: this.updateBaseUrl,
+      useMultipleRangeRequest: false,
+    })
     this.pendingVersion = null
     this.downloadedVersion = null
     this.downloadPromise = null

--- a/wework/src/features/app-update/AppUpdateProvider.test.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.test.tsx
@@ -116,7 +116,7 @@ describe('AppUpdateProvider', () => {
     })
 
     expect(appUpdate?.autoUpdateEnabled).toBe(true)
-    expect(downloadPendingWeworkUpdate).toHaveBeenCalledWith()
+    expect(downloadPendingWeworkUpdate).toHaveBeenCalledWith(expect.any(Function))
     expect(appUpdate?.downloadProgress).toBeNull()
     expect(appUpdate?.status).toBe('available')
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
@@ -133,15 +133,19 @@ describe('AppUpdateProvider', () => {
   test('waits for an active background download before asking for restart confirmation', async () => {
     let appUpdate: AppUpdateContextValue | null = null
     let finishDownload: (() => void) | undefined
+    let reportProgress:
+      | ((progress: { downloadedBytes: number; totalBytes: number | null }) => void)
+      | undefined
     let updateRequest: Promise<void> | undefined
     vi.mocked(checkForWeworkUpdate).mockResolvedValue({
       currentVersion: '0.1.0',
       version: '0.2.0',
     })
     vi.mocked(downloadPendingWeworkUpdate).mockImplementation(
-      () =>
+      onProgress =>
         new Promise(resolve => {
           finishDownload = resolve
+          reportProgress = onProgress
         })
     )
 
@@ -167,6 +171,11 @@ describe('AppUpdateProvider', () => {
     expect(appUpdate?.status).toBe('downloading')
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(downloadPendingWeworkUpdate).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      reportProgress?.({ downloadedBytes: 50, totalBytes: 100 })
+    })
+    expect(appUpdate?.downloadProgress).toEqual({ downloadedBytes: 50, totalBytes: 100 })
 
     if (!finishDownload) {
       throw new Error('Background download resolver was not initialized')
@@ -235,7 +244,7 @@ describe('AppUpdateProvider', () => {
     })
 
     expect(localStorage.getItem(APP_UPDATE_AUTO_DOWNLOAD_KEY)).toBe('true')
-    expect(downloadPendingWeworkUpdate).toHaveBeenCalledWith()
+    expect(downloadPendingWeworkUpdate).toHaveBeenCalledWith(expect.any(Function))
     expect(appUpdate?.downloadProgress).toBeNull()
   })
 

--- a/wework/src/features/app-update/AppUpdateProvider.tsx
+++ b/wework/src/features/app-update/AppUpdateProvider.tsx
@@ -100,6 +100,7 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
   const activeDownloadRef = useRef<{
     version: string
     promise: Promise<void>
+    progressListeners: Set<(progress: WeworkUpdateDownloadProgress) => void>
   } | null>(null)
   const simulationTimerRef = useRef<number | null>(null)
   const installedReleaseNotes =
@@ -118,21 +119,33 @@ export function AppUpdateProvider({ children }: { children: ReactNode }) {
       update: WeworkUpdateInfo,
       onProgress?: (progress: WeworkUpdateDownloadProgress) => void
     ): Promise<void> => {
-      if (activeDownloadRef.current?.version === update.version) {
-        return activeDownloadRef.current.promise
+      const activeDownload = activeDownloadRef.current
+      if (activeDownload?.version === update.version) {
+        if (!onProgress) return activeDownload.promise
+
+        activeDownload.progressListeners.add(onProgress)
+        return activeDownload.promise.finally(() => {
+          activeDownload.progressListeners.delete(onProgress)
+        })
       }
 
-      const promise = onProgress
-        ? downloadPendingWeworkUpdate(onProgress)
-        : downloadPendingWeworkUpdate()
-      activeDownloadRef.current = { version: update.version, promise }
+      const progressListeners = new Set<(progress: WeworkUpdateDownloadProgress) => void>()
+      if (onProgress) progressListeners.add(onProgress)
+      const promise = downloadPendingWeworkUpdate(progress => {
+        progressListeners.forEach(listener => listener(progress))
+      })
+      activeDownloadRef.current = { version: update.version, promise, progressListeners }
       const clearActiveDownload = () => {
         if (activeDownloadRef.current?.promise === promise) {
           activeDownloadRef.current = null
         }
       }
       void promise.then(clearActiveDownload, clearActiveDownload)
-      return promise
+      if (!onProgress) return promise
+
+      return promise.finally(() => {
+        progressListeners.delete(onProgress)
+      })
     },
     []
   )


### PR DESCRIPTION
## Summary

- disable multi-range requests while preserving differential updates
- keep progress listeners attached when a foreground install joins an active background download
- cover updater configuration and joined-download progress with focused tests

## Root cause

GitHub's update endpoint returned HTTP 501 for the updater's multi-range request, so `electron-updater` fell back to the full package. Separately, background auto-downloads started without a progress callback; when the user opened the updater, the existing promise was reused without attaching a callback, leaving the progress UI unchanged.

## Verification

- built an isolated Wework 0.3.9 app and pointed it at the real GitHub 0.4.0 updater feed
- preloaded the old package/blockmap in an isolated updater cache
- observed differential calculation and download completion without `Cannot download differentially` or `fallback to full download`
- observed UI progress advancing through 21%, 37%, 44%, 68%, 70%, 79%, 85%, and 92%, followed by the restart confirmation
- pre-push checks passed: ESLint, renderer TypeScript, Electron TypeScript, renderer unit tests, and Electron unit tests

Task: WORK-359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download progress is now reported to all active update-download requests, including downloads shared across multiple parts of the app.

* **Bug Fixes**
  * Improved update feed configuration for more reliable update downloads.
  * Update progress remains visible while a background download is still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->