### PR TITLE
fix(wework-mobile): align remote task experience

### DIFF
--- a/wework-mobile/App.tsx
+++ b/wework-mobile/App.tsx
@@ -39,6 +39,7 @@ export default function App() {
           <RuntimeApplication
             config={auth.config}
             onLogout={auth.logout}
+            userId={auth.user?.id ?? 0}
             userLabel={auth.user?.full_name || auth.user?.user_name || ''}
           />
         ) : (
@@ -58,19 +59,20 @@ export default function App() {
 function RuntimeApplication({
   config,
   onLogout,
+  userId,
   userLabel,
 }: {
   config: RuntimeSessionConfig
   onLogout: () => Promise<void>
+  userId: number
   userLabel: string
 }) {
-  const runtime = useMobileRuntime(config)
+  const runtime = useMobileRuntime(config, userId)
   const theme = useTheme()
   const glassColorScheme: GlassColorScheme = theme.dark ? 'dark' : 'light'
   const [projectVisible, setProjectVisible] = useState(false)
   const [settingsVisible, setSettingsVisible] = useState(false)
   const [search, setSearch] = useState('')
-  const [filterDeviceId, setFilterDeviceId] = useState<string | null>(null)
   const [conversationEntryRevision, setConversationEntryRevision] = useState(0)
 
   const workspaces = useMemo(
@@ -100,6 +102,7 @@ function RuntimeApplication({
           <RuntimeStack.Screen name="conversationList" options={{ animation: 'none' }}>
             {({ navigation }) => (
               <ConversationListScreen
+                allDevicesSelected={runtime.allDevicesSelected}
                 conversations={runtime.conversations}
                 currentAddress={runtime.currentAddress}
                 devices={runtime.devices}
@@ -111,18 +114,20 @@ function RuntimeApplication({
                 onNewProject={() => setProjectVisible(true)}
                 onOpenCurrentConversation={() => navigation.navigate('conversation')}
                 onSearch={setSearch}
+                onRefresh={runtime.refresh}
+                onSelectAllDevices={runtime.selectAllDevices}
                 onSelectConversation={item => {
                   setConversationEntryRevision(current => current + 1)
                   void runtime.openConversation(item)
                   navigation.navigate('conversation')
                 }}
                 onSelectDevice={deviceId => {
-                  setFilterDeviceId(deviceId)
                   runtime.selectDevice(deviceId)
                 }}
                 onSettings={() => setSettingsVisible(true)}
                 search={search}
-                selectedDeviceId={filterDeviceId ?? runtime.selectedDeviceId}
+                refreshing={runtime.refreshing}
+                selectedDeviceId={runtime.selectedDeviceId}
                 workspaces={workspaces}
               />
             )}
@@ -148,13 +153,16 @@ function RuntimeApplication({
                   entryRevision={conversationEntryRevision}
                   gitRef={runtime.gitRef}
                   isNew={isNewConversation}
+                  hasMoreMessagesBefore={runtime.hasMoreMessagesBefore}
                   loading={runtime.loading}
+                  loadingMoreMessagesBefore={runtime.loadingMoreMessagesBefore}
                   messages={runtime.messages}
                   model={runtime.selectedModel}
                   modelOptions={runtime.selectedModelOptions}
                   permissionMode={runtime.permissionMode}
                   onBack={navigation.goBack}
                   onLoadApps={runtime.loadComposerApps}
+                  onLoadMoreMessagesBefore={runtime.loadMoreMessagesBefore}
                   onMore={() => setSettingsVisible(true)}
                   onNewConversation={() =>
                     runtime.startNewConversation(runtime.selectedWorkspace ?? undefined)

--- a/wework-mobile/app.json
+++ b/wework-mobile/app.json
@@ -11,6 +11,7 @@
       "supportsTablet": true,
       "icon": "./assets/icon.png",
       "bundleIdentifier": "com.wecode.wegent",
+      "buildNumber": "2",
       "appleTeamId": "27XH7KRW54"
     },
     "android": {

--- a/wework-mobile/app.json
+++ b/wework-mobile/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
-    "name": "Wegent",
+    "name": "WeWork",
     "slug": "wework-mobile",
-    "scheme": "wegent",
+    "scheme": "wework",
     "version": "0.1.0",
     "icon": "./assets/icon.png",
     "orientation": "portrait",
@@ -10,7 +10,7 @@
     "ios": {
       "supportsTablet": true,
       "icon": "./assets/icon.png",
-      "bundleIdentifier": "com.wecode.wegent",
+      "bundleIdentifier": "io.wecode.wework",
       "buildNumber": "2",
       "appleTeamId": "27XH7KRW54"
     },
@@ -29,8 +29,8 @@
       [
         "expo-image-picker",
         {
-          "photosPermission": "允许 Wegent 选择照片并作为会话附件发送。",
-          "cameraPermission": "允许 Wegent 拍摄照片并作为会话附件发送。",
+          "photosPermission": "允许 WeWork 选择照片并作为会话附件发送。",
+          "cameraPermission": "允许 WeWork 拍摄照片并作为会话附件发送。",
           "microphonePermission": false
         }
       ]

--- a/wework-mobile/app.json
+++ b/wework-mobile/app.json
@@ -12,7 +12,10 @@
       "icon": "./assets/icon.png",
       "bundleIdentifier": "io.wecode.wework",
       "buildNumber": "2",
-      "appleTeamId": "27XH7KRW54"
+      "appleTeamId": "27XH7KRW54",
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.wecode.wegent",

--- a/wework-mobile/ios/Podfile.lock
+++ b/wework-mobile/ios/Podfile.lock
@@ -1980,6 +1980,28 @@ PODS:
     - React-utils (= 0.86.3)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.86.3)
+  - ReactNativeEnrichedMarkdown (1.0.2):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - RNScreens (4.26.2):
     - hermes-engine
     - RCTRequired
@@ -2126,6 +2148,7 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - "ReactCommon/turbomodule/core (from `../node_modules/.pnpm/react-native@0.86.3_@babel+core@7.29.7_@types+react@19.2.18_react@19.2.3/node_modules/react-native/ReactCommon`)"
   - "ReactNativeDependencies (from `../node_modules/.pnpm/react-native@0.86.3_@babel+core@7.29.7_@types+react@19.2.18_react@19.2.3/node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)"
+  - "ReactNativeEnrichedMarkdown (from `../node_modules/.pnpm/react-native-enriched-markdown@1.0.2_react-native@0.86.3_@babel+core@7.29.7_@types+reac_4830e9e0b1a3d9baf33b0e2fe0c8906c/node_modules/react-native-enriched-markdown`)"
   - "RNScreens (from `../node_modules/.pnpm/react-native-screens@4.26.2_react-native@0.86.3_@babel+core@7.29.7_@types+react@19.2.18_react@19.2.3__react@19.2.3/node_modules/react-native-screens`)"
   - "Yoga (from `../node_modules/.pnpm/react-native@0.86.3_@babel+core@7.29.7_@types+react@19.2.18_react@19.2.3/node_modules/react-native/ReactCommon/yoga`)"
 
@@ -2321,6 +2344,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/.pnpm/react-native@0.86.3_@babel+core@7.29.7_@types+react@19.2.18_react@19.2.3/node_modules/react-native/ReactCommon"
   ReactNativeDependencies:
     :podspec: "../node_modules/.pnpm/react-native@0.86.3_@babel+core@7.29.7_@types+react@19.2.18_react@19.2.3/node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec"
+  ReactNativeEnrichedMarkdown:
+    :path: "../node_modules/.pnpm/react-native-enriched-markdown@1.0.2_react-native@0.86.3_@babel+core@7.29.7_@types+reac_4830e9e0b1a3d9baf33b0e2fe0c8906c/node_modules/react-native-enriched-markdown"
   RNScreens:
     :path: "../node_modules/.pnpm/react-native-screens@4.26.2_react-native@0.86.3_@babel+core@7.29.7_@types+react@19.2.18_react@19.2.3__react@19.2.3/node_modules/react-native-screens"
   Yoga:
@@ -2341,7 +2366,7 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: c26f14275017370cc8a4b7b43a0e23361f2053a5
   ExpoLinearGradient: 903b3f5fe566c666ff78b2599add51d094483613
   ExpoLogBox: 80957303325cd4439137765c90a87d7f22aaf2ff
-  ExpoModulesCore: 6a62c9764da606de49c01ddc49a042b571954d18
+  ExpoModulesCore: dfb2dad6e3950673187429ac859cd882caf49fa1
   ExpoModulesJSI: 1529d4289b9a3647d8901a27b41f1af173598b45
   ExpoModulesWorklets: 57a11e6ae984c2680e7967b785ded96199caed8c
   ExpoSecureStore: cc7c4f560528e7a644b1342b0cc2790576e677e1
@@ -2422,6 +2447,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 94e244d9dad16ba7e854e1f14bc24a2550fbe45f
   ReactCommon: 02f6a489d5eb4ab79d7deba5cd4434e0ba351a07
   ReactNativeDependencies: 6738e602b46fd24aa453cd58267ec3bb8bf29d27
+  ReactNativeEnrichedMarkdown: 24c39048b683a3637149e76dd60cd3db21981385
   RNScreens: 7118cd7715c226856125b5bece3c4d9abec90356
   Yoga: 18b74b3ade30bebc1904004dfaceae1dd02a330a
 

--- a/wework-mobile/ios/Wegent.xcodeproj/project.pbxproj
+++ b/wework-mobile/ios/Wegent.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		13B07F961A680F5B00A75B9A /* Wegent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wegent.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07F961A680F5B00A75B9A /* WeWork.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeWork.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Wegent/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Wegent/Info.plist; sourceTree = "<group>"; };
 		5A2657F051519FE8599AA323 /* libPods-Wegent.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Wegent.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,7 +100,7 @@
 		83CBBA001A601CBA00E9B192 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				13B07F961A680F5B00A75B9A /* Wegent.app */,
+				13B07F961A680F5B00A75B9A /* WeWork.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -153,8 +153,8 @@
 			dependencies = (
 			);
 			name = Wegent;
-			productName = Wegent;
-			productReference = 13B07F961A680F5B00A75B9A /* Wegent.app */;
+			productName = WeWork;
+			productReference = 13B07F961A680F5B00A75B9A /* WeWork.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -375,8 +375,8 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.wecode.wegent;
-				PRODUCT_NAME = Wegent;
+				PRODUCT_BUNDLE_IDENTIFIER = io.wecode.wework;
+				PRODUCT_NAME = WeWork;
 				SWIFT_OBJC_BRIDGING_HEADER = "Wegent/Wegent-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -410,8 +410,8 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = com.wecode.wegent;
-				PRODUCT_NAME = Wegent;
+				PRODUCT_BUNDLE_IDENTIFIER = io.wecode.wework;
+				PRODUCT_NAME = WeWork;
 				SWIFT_OBJC_BRIDGING_HEADER = "Wegent/Wegent-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/wework-mobile/ios/Wegent.xcodeproj/project.pbxproj
+++ b/wework-mobile/ios/Wegent.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 				CODE_SIGN_ENTITLEMENTS = Wegent/Wegent.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 27XH7KRW54;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -368,7 +368,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.4;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -394,7 +394,7 @@
 				CODE_SIGN_ENTITLEMENTS = Wegent/Wegent.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 27XH7KRW54;
 				INFOPLIST_FILE = Wegent/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
@@ -403,7 +403,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.4;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/wework-mobile/ios/Wegent/Info.plist
+++ b/wework-mobile/ios/Wegent/Info.plist
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/wework-mobile/ios/Wegent/Info.plist
+++ b/wework-mobile/ios/Wegent/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Wegent</string>
+	<string>WeWork</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -27,8 +27,8 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>wegent</string>
-				<string>com.wecode.wegent</string>
+				<string>wework</string>
+				<string>io.wecode.wework</string>
 			</array>
 		</dict>
 	</array>
@@ -46,11 +46,11 @@
 		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>允许 Wegent 拍摄照片并作为会话附件发送。</string>
+	<string>允许 WeWork 拍摄照片并作为会话附件发送。</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>允许 Wegent 选择照片并作为会话附件发送。</string>
+	<string>允许 WeWork 选择照片并作为会话附件发送。</string>
 	<key>RCTMetroPort</key>
 	<string>$(RCT_METRO_PORT)</string>
 	<key>RCTNewArchEnabled</key>

--- a/wework-mobile/ios/Wegent/Info.plist
+++ b/wework-mobile/ios/Wegent/Info.plist
@@ -34,6 +34,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>2</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/wework-mobile/package.json
+++ b/wework-mobile/package.json
@@ -2,6 +2,10 @@
   "name": "wework-mobile",
   "version": "0.1.0",
   "private": true,
+  "enriched-markdown": {
+    "enableCodeHighlight": true,
+    "enableMath": false
+  },
   "main": "index.ts",
   "scripts": {
     "start": "expo start",
@@ -38,7 +42,7 @@
     "punycode": "^2.3.1",
     "react": "19.2.3",
     "react-native": "0.86.3",
-    "react-native-markdown-display": "^7.0.2",
+    "react-native-enriched-markdown": "1.0.2",
     "react-native-paper": "^5.15.3",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.26.2",

--- a/wework-mobile/pnpm-lock.yaml
+++ b/wework-mobile/pnpm-lock.yaml
@@ -77,9 +77,9 @@ importers:
       react-native:
         specifier: 0.86.3
         version: 0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3)
-      react-native-markdown-display:
-        specifier: ^7.0.2
-        version: 7.0.2(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      react-native-enriched-markdown:
+        specifier: 1.0.2
+        version: 1.0.2(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-paper:
         specifier: ^5.15.3
         version: 5.15.3(react-native-safe-area-context@5.7.0(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
@@ -1030,9 +1030,6 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  argparse@1.0.7:
-    resolution: {integrity: sha512-svfNOD2ovohwmmIi/Y1NtBuc53G8RhPLeIMBwB0uTK8pXV1yu0+ZVzj+XHFDFWAPYflfOvPLQxjUB8WpnObhjg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1144,9 +1141,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-lite@1.0.30001810:
     resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
@@ -1265,13 +1259,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
-    engines: {node: '>=4'}
-
-  css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1353,9 +1340,6 @@ packages:
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
-
-  entities@2.0.0:
-    resolution: {integrity: sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -1842,9 +1826,6 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
-  linkify-it@2.0.0:
-    resolution: {integrity: sha512-3L7EpPkNqG2N5XIqqDLjuqPHmTX6VdjXtOmYUr/Iv8W+jDlDMlyXbnWvLhWlikGtgPKgBS2vtpV8QOcrpULoUQ==}
-
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -1876,15 +1857,8 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
-  markdown-it@10.0.0:
-    resolution: {integrity: sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==}
-    hasBin: true
-
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
-
-  mdurl@1.0.1:
-    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -2040,10 +2014,6 @@ packages:
     resolution: {integrity: sha512-aH9RkoZc7w/90HBamFxTw8ZLFr05wXS+iOnvmrgo53Ep8Pyrm5FieQSaPIVROkfFVQISeD/zo92fes26TOwe+A==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -2113,9 +2083,6 @@ packages:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
 
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2144,9 +2111,6 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2168,9 +2132,6 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
   react-is@16.7.0:
     resolution: {integrity: sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==}
 
@@ -2180,14 +2141,15 @@ packages:
   react-is@19.2.8:
     resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
 
-  react-native-fit-image@1.5.5:
-    resolution: {integrity: sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==}
-
-  react-native-markdown-display@7.0.2:
-    resolution: {integrity: sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==}
+  react-native-enriched-markdown@1.0.2:
+    resolution: {integrity: sha512-zvVM4W1VMV/cYAKUTYoVheadOGHLbny2kALFn0vi5av/WFa0JSYboeeq/vPRqS5dc8qvUTjXwVlrkhrcuinNQA==}
     peerDependencies:
-      react: '>=16.2.0'
-      react-native: '>=0.50.4'
+      katex: '>=0.16.0'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      katex:
+        optional: true
 
   react-native-paper@5.15.3:
     resolution: {integrity: sha512-GEyNTmWElIZgnYw09AjjCNupRYzCmP79uAAyGSyCEUZz7KBz1wtJcC0wVUkozR1Rn3PK/td/9LlR6+F1hzmYvA==}
@@ -2386,9 +2348,6 @@ packages:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2523,9 +2482,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uc.micro@1.0.5:
-    resolution: {integrity: sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -3965,10 +3921,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.7:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   asap@2.0.6: {}
@@ -4121,8 +4073,6 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  camelize@1.0.1: {}
-
   caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
@@ -4259,14 +4209,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.1
 
-  css-color-keywords@1.0.0: {}
-
-  css-to-react-native@3.2.0:
-    dependencies:
-      camelize: 1.0.1
-      css-color-keywords: 1.0.0
-      postcss-value-parser: 4.2.0
-
   csstype@3.2.3: {}
 
   debug@2.6.9:
@@ -4322,8 +4264,6 @@ snapshots:
       - utf-8-validate
 
   engine.io-parser@5.2.3: {}
-
-  entities@2.0.0: {}
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -4754,10 +4694,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
-  linkify-it@2.0.0:
-    dependencies:
-      uc.micro: 1.0.5
-
   lodash.debounce@4.0.8: {}
 
   lodash.throttle@4.1.1: {}
@@ -4786,17 +4722,7 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
-  markdown-it@10.0.0:
-    dependencies:
-      argparse: 1.0.7
-      entities: 2.0.0
-      linkify-it: 2.0.0
-      mdurl: 1.0.1
-      uc.micro: 1.0.5
-
   marky@1.3.0: {}
-
-  mdurl@1.0.1: {}
 
   memoize-one@5.2.1: {}
 
@@ -5039,8 +4965,6 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
 
-  object-assign@4.1.1: {}
-
   obug@2.1.4: {}
 
   on-finished@2.3.0:
@@ -5102,8 +5026,6 @@ snapshots:
 
   pngjs@3.4.0: {}
 
-  postcss-value-parser@4.2.0: {}
-
   postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
@@ -5131,12 +5053,6 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   punycode@2.3.1: {}
 
   query-string@7.1.3:
@@ -5160,26 +5076,16 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  react-is@16.13.1: {}
-
   react-is@16.7.0: {}
 
   react-is@18.0.0: {}
 
   react-is@19.2.8: {}
 
-  react-native-fit-image@1.5.5:
+  react-native-enriched-markdown@1.0.2(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
     dependencies:
-      prop-types: 15.8.1
-
-  react-native-markdown-display@7.0.2(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
-    dependencies:
-      css-to-react-native: 3.2.0
-      markdown-it: 10.0.0
-      prop-types: 15.8.1
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3)
-      react-native-fit-image: 1.5.5
 
   react-native-paper@5.15.3(react-native-safe-area-context@5.7.0(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -5423,8 +5329,6 @@ snapshots:
 
   split-on-first@1.1.0: {}
 
-  sprintf-js@1.0.3: {}
-
   stackback@0.0.2: {}
 
   stackframe@1.3.4: {}
@@ -5536,8 +5440,6 @@ snapshots:
   type-fest@0.7.1: {}
 
   typescript@6.0.3: {}
-
-  uc.micro@1.0.5: {}
 
   undici-types@8.3.0: {}
 

--- a/wework-mobile/pnpm-workspace.yaml
+++ b/wework-mobile/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - .
+allowBuilds:
+  react-native-enriched-markdown: true

--- a/wework-mobile/src/auth/authSessionStore.test.ts
+++ b/wework-mobile/src/auth/authSessionStore.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let stored: string | null = null
+let pendingWrite: Promise<void> | null = null
+
+vi.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked',
+  deleteItemAsync: vi.fn(async () => {
+    stored = null
+  }),
+  getItemAsync: vi.fn(async () => stored),
+  setItemAsync: vi.fn(async (_key: string, value: string) => {
+    await pendingWrite
+    stored = value
+  }),
+}))
+
+import { clearAuthSession, loadAuthSession, saveAuthSession } from './authSessionStore'
+
+describe('authSessionStore', () => {
+  beforeEach(() => {
+    stored = null
+    pendingWrite = null
+  })
+
+  it('restores the authenticated shell before background token refresh', async () => {
+    await saveAuthSession({
+      backend: {
+        backendUrl: 'https://wegent.example',
+        apiBaseUrl: 'https://wegent.example/api',
+        socketBaseUrl: 'wss://wegent.example',
+        socketPath: '/socket.io',
+      },
+      accessToken: 'cached-access-token',
+      accessTokenExpiresAt: 1_800_000_000_000,
+      user: { id: 7, user_name: 'hongyu9' },
+    })
+
+    await expect(loadAuthSession()).resolves.toMatchObject({
+      accessToken: 'cached-access-token',
+      user: { id: 7 },
+    })
+    await clearAuthSession()
+    await expect(loadAuthSession()).resolves.toBeNull()
+  })
+
+  it('drops malformed sessions instead of exposing another account cache', async () => {
+    stored = JSON.stringify({ accessToken: 'broken' })
+
+    await expect(loadAuthSession()).resolves.toBeNull()
+    expect(stored).toBeNull()
+  })
+
+  it('serializes logout after an in-flight session write', async () => {
+    let releaseWrite: () => void = () => undefined
+    pendingWrite = new Promise<void>(resolve => {
+      releaseWrite = resolve
+    })
+    const saving = saveAuthSession({
+      backend: {
+        backendUrl: 'https://wegent.example',
+        apiBaseUrl: 'https://wegent.example/api',
+        socketBaseUrl: 'wss://wegent.example',
+        socketPath: '/socket.io',
+      },
+      accessToken: 'stale-access-token',
+      accessTokenExpiresAt: null,
+      user: { id: 7, user_name: 'hongyu9' },
+    })
+    const clearing = clearAuthSession()
+
+    releaseWrite()
+    await Promise.all([saving, clearing])
+
+    await expect(loadAuthSession()).resolves.toBeNull()
+  })
+})

--- a/wework-mobile/src/auth/authSessionStore.ts
+++ b/wework-mobile/src/auth/authSessionStore.ts
@@ -1,0 +1,73 @@
+import * as SecureStore from 'expo-secure-store'
+
+import type { WegentUser } from './authClient'
+import type { BackendConfig } from '@/services/backendConfig'
+
+const AUTH_SESSION_KEY = 'wegent.mobile.auth-session.v1'
+let pendingMutation: Promise<void> = Promise.resolve()
+
+export interface CachedAuthSession {
+  backend: BackendConfig
+  accessToken: string
+  accessTokenExpiresAt: number | null
+  user: WegentUser
+}
+
+export async function loadAuthSession(): Promise<CachedAuthSession | null> {
+  await pendingMutation
+  const raw = await SecureStore.getItemAsync(AUTH_SESSION_KEY)
+  if (!raw) return null
+  try {
+    const session = parseAuthSession(JSON.parse(raw))
+    if (session) return session
+    await clearAuthSession()
+    return null
+  } catch {
+    await clearAuthSession()
+    return null
+  }
+}
+
+export function saveAuthSession(session: CachedAuthSession): Promise<void> {
+  return queueMutation(() =>
+    SecureStore.setItemAsync(AUTH_SESSION_KEY, JSON.stringify(session), {
+      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    })
+  )
+}
+
+export function clearAuthSession(): Promise<void> {
+  return queueMutation(() => SecureStore.deleteItemAsync(AUTH_SESSION_KEY))
+}
+
+function queueMutation(operation: () => Promise<void>): Promise<void> {
+  const next = pendingMutation.then(operation, operation)
+  pendingMutation = next.catch(() => undefined)
+  return next
+}
+
+function parseAuthSession(value: unknown): CachedAuthSession | null {
+  if (!isRecord(value)) return null
+  const backend = value.backend
+  const user = value.user
+  if (
+    !isRecord(backend) ||
+    !isRecord(user) ||
+    typeof backend.backendUrl !== 'string' ||
+    typeof backend.apiBaseUrl !== 'string' ||
+    typeof backend.socketBaseUrl !== 'string' ||
+    typeof backend.socketPath !== 'string' ||
+    typeof value.accessToken !== 'string' ||
+    !value.accessToken ||
+    (value.accessTokenExpiresAt !== null && typeof value.accessTokenExpiresAt !== 'number') ||
+    typeof user.id !== 'number' ||
+    typeof user.user_name !== 'string'
+  ) {
+    return null
+  }
+  return value as unknown as CachedAuthSession
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/wework-mobile/src/auth/useWegentAuth.ts
+++ b/wework-mobile/src/auth/useWegentAuth.ts
@@ -8,6 +8,12 @@ import {
   jwtExpiry,
   type WegentUser,
 } from './authClient'
+import {
+  clearAuthSession,
+  loadAuthSession,
+  saveAuthSession,
+  type CachedAuthSession,
+} from './authSessionStore'
 import { DeviceCredentialService } from './deviceCredentials'
 import {
   checkBackendHealth,
@@ -58,9 +64,17 @@ export function useWegentAuth(): WegentAuthState {
     ): Promise<boolean> => {
       const currentUser = await fetchCurrentUser(config, token)
       if (activeGeneration.current !== generation) return false
+      const session: CachedAuthSession = {
+        backend: config,
+        accessToken: token,
+        accessTokenExpiresAt: explicitExpiry ?? jwtExpiry(token),
+        user: currentUser,
+      }
+      await saveAuthSession(session)
+      if (activeGeneration.current !== generation) return false
       setBackend(config)
       setAccessToken(token)
-      setAccessTokenExpiresAt(explicitExpiry ?? jwtExpiry(token))
+      setAccessTokenExpiresAt(session.accessTokenExpiresAt)
       setUser(currentUser)
       setError(null)
       setStatus('authenticated')
@@ -83,32 +97,51 @@ export function useWegentAuth(): WegentAuthState {
       )
     } catch (cause) {
       if (activeGeneration.current !== generation) return false
-      setAccessToken(null)
-      setAccessTokenExpiresAt(null)
-      setUser(null)
-      setStatus('unauthenticated')
       setError(messageFrom(cause))
+      if (!accessToken || !user) {
+        setAccessToken(null)
+        setAccessTokenExpiresAt(null)
+        setUser(null)
+        setStatus('unauthenticated')
+      }
       return false
     }
-  }, [applyToken, backend])
+  }, [accessToken, applyToken, backend, user])
 
   useEffect(() => {
     const generation = activeGeneration.current
     void (async () => {
+      let cachedSession: CachedAuthSession | null = null
       try {
-        const backendUrl = (await loadBackendAddress()) ?? configuredBackendUrl()
+        const [storedBackendUrl, storedSession] = await Promise.all([
+          loadBackendAddress(),
+          loadAuthSession(),
+        ])
+        const backendUrl =
+          storedBackendUrl ?? configuredBackendUrl() ?? storedSession?.backend.backendUrl
         if (activeGeneration.current !== generation) return
         setBackendInput(backendUrl ?? '')
         if (!backendUrl) {
           setStatus('unauthenticated')
           return
         }
+        cachedSession =
+          storedSession?.backend.backendUrl === backendUrl.replace(/\/+$/, '')
+            ? storedSession
+            : null
+        if (cachedSession) {
+          setBackend(cachedSession.backend)
+          setAccessToken(cachedSession.accessToken)
+          setAccessTokenExpiresAt(cachedSession.accessTokenExpiresAt)
+          setUser(cachedSession.user)
+          setStatus('authenticated')
+        }
         const config = await resolveBackendConfig(backendUrl)
         await checkBackendHealth(config)
         if (activeGeneration.current !== generation) return
         setBackend(config)
         if (!(await credentials.hasRefreshCredential(config.apiBaseUrl))) {
-          setStatus('unauthenticated')
+          if (!cachedSession) setStatus('unauthenticated')
           return
         }
         const result = await credentials.refreshAccessToken(config.apiBaseUrl)
@@ -121,8 +154,8 @@ export function useWegentAuth(): WegentAuthState {
         )
       } catch (cause) {
         if (activeGeneration.current !== generation) return
-        setStatus('error')
         setError(messageFrom(cause))
+        if (!cachedSession) setStatus('error')
       }
     })()
   }, [applyToken])
@@ -200,7 +233,7 @@ export function useWegentAuth(): WegentAuthState {
   const logout = useCallback(async (): Promise<void> => {
     activeGeneration.current += 1
     WebBrowser.dismissBrowser()
-    await credentials.clear()
+    await Promise.all([credentials.clear(), clearAuthSession()])
     setAccessToken(null)
     setAccessTokenExpiresAt(null)
     setUser(null)

--- a/wework-mobile/src/components/AssistantMarkdown.tsx
+++ b/wework-mobile/src/components/AssistantMarkdown.tsx
@@ -1,139 +1,213 @@
 import { useMemo } from 'react'
-import { Image, Platform, StyleSheet, Text } from 'react-native'
-import Markdown, { type RenderRules } from 'react-native-markdown-display'
+import {
+  EnrichedMarkdownText,
+  type AccessibilityLabels,
+  type MarkdownStyle,
+} from 'react-native-enriched-markdown'
+import { Linking, StyleSheet } from 'react-native'
 import { useTheme } from 'react-native-paper'
 
 interface AssistantMarkdownProps {
   children: string
   muted?: boolean
+  streaming?: boolean
 }
 
-export function AssistantMarkdown({ children, muted = false }: AssistantMarkdownProps) {
+const ACCESSIBILITY_LABELS: AccessibilityLabels = {
+  list: {
+    bulletPoint: '项目符号',
+    nestedBulletPoint: '嵌套项目符号',
+    orderedItem: '列表第 {n} 项',
+    nestedOrderedItem: '嵌套列表第 {n} 项',
+  },
+  blockquote: { quote: '引用', nestedQuote: '嵌套引用' },
+  table: { row: '第 {n} 行：{content}' },
+  rotor: { headings: '标题', links: '链接', images: '图片' },
+}
+
+const MARKDOWN_FLAGS = { latexMath: false } as const
+const STREAMING_CONFIG = { tableMode: 'progressive', codeBlockMode: 'progressive' } as const
+
+export function AssistantMarkdown({
+  children,
+  muted = false,
+  streaming = false,
+}: AssistantMarkdownProps) {
   const theme = useTheme()
-  const rules = useMemo<RenderRules>(
-    () => ({
-      image: (node, _children, _parents, styles) => {
-        const source = String(node.attributes.src ?? '')
-        const alt = String(node.attributes.alt ?? '图片')
-        if (!isRenderableImageSource(source)) {
-          return (
-            <Text key={node.key} style={styles.text}>
-              {alt}
-            </Text>
-          )
-        }
-        return (
-          <Image
-            accessibilityLabel={alt}
-            accessible
-            key={node.key}
-            resizeMode="contain"
-            source={{ uri: source }}
-            style={styles.image}
-          />
-        )
+  const markdownStyle = useMemo<MarkdownStyle>(() => {
+    const textColor = muted ? theme.colors.onSurfaceVariant : theme.colors.onBackground
+    const subtleSurface = theme.colors.elevation.level2
+    return {
+      paragraph: {
+        color: textColor,
+        fontSize: muted ? 15 : 17,
+        lineHeight: muted ? 23 : 27,
+        marginTop: 0,
+        marginBottom: muted ? 8 : 12,
       },
-    }),
-    []
-  )
-  const styles = useMemo(
-    () =>
-      StyleSheet.create({
-        body: {
-          color: theme.colors.onBackground,
-          fontSize: muted ? 15 : 17,
-          lineHeight: muted ? 23 : 27,
-          opacity: muted ? 0.72 : 1,
-        },
-        paragraph: { marginTop: 0, marginBottom: 12 },
-        heading1: { fontSize: 20, lineHeight: 28, fontWeight: '600', marginBottom: 12 },
-        heading2: { fontSize: 18, lineHeight: 26, fontWeight: '600', marginBottom: 10 },
-        heading3: { fontSize: 17, lineHeight: 25, fontWeight: '600', marginBottom: 8 },
-        heading4: { fontSize: 17, lineHeight: 25, fontWeight: '600', marginBottom: 8 },
-        heading5: { fontSize: 16, lineHeight: 24, fontWeight: '600', marginBottom: 7 },
-        heading6: {
-          color: theme.colors.onSurfaceVariant,
-          fontSize: 15,
-          lineHeight: 23,
-          fontWeight: '600',
-          marginBottom: 7,
-        },
-        strong: { fontWeight: '600' },
-        em: { fontStyle: 'italic' },
-        s: { textDecorationLine: 'line-through' },
-        hr: { height: StyleSheet.hairlineWidth, backgroundColor: theme.colors.outlineVariant },
-        blockquote: {
-          borderColor: theme.colors.outline,
-          borderLeftWidth: 3,
-          marginLeft: 0,
-          marginBottom: 12,
-          paddingLeft: 12,
-          opacity: 0.8,
-        },
-        bullet_list: { marginBottom: 12 },
-        ordered_list: { marginBottom: 12 },
-        list_item: { marginBottom: 2 },
-        bullet_list_icon: { marginLeft: 4, marginRight: 10, fontSize: 19, lineHeight: 27 },
-        bullet_list_content: { flex: 1 },
-        ordered_list_icon: { marginLeft: 2, marginRight: 8, lineHeight: 27 },
-        ordered_list_content: { flex: 1 },
-        code_inline: {
-          color: theme.colors.onSurfaceVariant,
-          backgroundColor: theme.colors.surfaceVariant,
-          borderRadius: 4,
-          paddingHorizontal: 5,
-          paddingVertical: 1,
-          fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-          fontSize: muted ? 14 : 15,
-        },
-        code_block: {
-          color: theme.colors.onSurfaceVariant,
-          backgroundColor: theme.colors.surfaceVariant,
-          borderColor: theme.colors.outlineVariant,
-          borderWidth: StyleSheet.hairlineWidth,
-          borderRadius: 10,
-          padding: 12,
-          fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-          fontSize: 14,
-          lineHeight: 21,
-        },
-        fence: {
-          color: theme.colors.onSurfaceVariant,
-          backgroundColor: theme.colors.surfaceVariant,
-          borderColor: theme.colors.outlineVariant,
-          borderWidth: StyleSheet.hairlineWidth,
-          borderRadius: 10,
-          padding: 12,
-          fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-          fontSize: 14,
-          lineHeight: 21,
-        },
-        table: {
-          borderColor: theme.colors.outlineVariant,
-          borderWidth: StyleSheet.hairlineWidth,
-          borderRadius: 6,
-          marginBottom: 14,
-        },
-        tr: {
-          borderBottomColor: theme.colors.outlineVariant,
-          borderBottomWidth: StyleSheet.hairlineWidth,
-          flexDirection: 'row',
-        },
-        th: { flex: 1, padding: 7, backgroundColor: theme.colors.surfaceVariant },
-        td: { flex: 1, padding: 7 },
-        link: { color: theme.colors.primary, textDecorationLine: 'underline' },
-        image: { width: '100%', height: 240, borderRadius: 10 },
-      }),
-    [muted, theme.colors]
-  )
+      h1: {
+        color: textColor,
+        fontSize: muted ? 18 : 22,
+        lineHeight: muted ? 26 : 30,
+        fontWeight: '600',
+        marginTop: 8,
+        marginBottom: 12,
+      },
+      h2: {
+        color: textColor,
+        fontSize: muted ? 17 : 20,
+        lineHeight: muted ? 25 : 28,
+        fontWeight: '600',
+        marginTop: 8,
+        marginBottom: 10,
+      },
+      h3: {
+        color: textColor,
+        fontSize: muted ? 16 : 18,
+        lineHeight: muted ? 24 : 26,
+        fontWeight: '600',
+        marginTop: 6,
+        marginBottom: 8,
+      },
+      h4: { color: textColor, fontSize: 17, lineHeight: 25, fontWeight: '600' },
+      h5: { color: textColor, fontSize: 16, lineHeight: 24, fontWeight: '600' },
+      h6: {
+        color: theme.colors.onSurfaceVariant,
+        fontSize: 15,
+        lineHeight: 23,
+        fontWeight: '600',
+      },
+      strong: { color: textColor },
+      em: { color: textColor },
+      list: {
+        color: textColor,
+        fontSize: muted ? 15 : 17,
+        lineHeight: muted ? 23 : 27,
+        marginTop: 0,
+        marginBottom: muted ? 8 : 12,
+        marginLeft: 20,
+        markerMinWidth: 16,
+        gapWidth: 8,
+        itemSpacing: muted ? 2 : 6,
+        bulletSize: muted ? 4 : 5,
+        bulletColor: theme.colors.onSurfaceVariant,
+        markerColor: theme.colors.onSurfaceVariant,
+      },
+      code: {
+        color: theme.colors.onSurface,
+        backgroundColor: subtleSurface,
+        borderColor: theme.colors.outlineVariant,
+        fontSize: muted ? 14 : 15,
+      },
+      codeBlock: {
+        color: theme.colors.onSurface,
+        backgroundColor: subtleSurface,
+        borderColor: theme.colors.outlineVariant,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderRadius: 10,
+        padding: 12,
+        fontSize: 14,
+        lineHeight: 21,
+        marginTop: 2,
+        marginBottom: 14,
+        syntaxColors: theme.dark
+          ? {
+              keyword: '#c792ea',
+              string: '#c3e88d',
+              number: '#f78c6c',
+              constant: '#ffcb6b',
+              comment: '#8a9aa9',
+              function: '#82aaff',
+              type: '#ffcb6b',
+              property: '#89ddff',
+              tag: '#f07178',
+              attribute: '#c3e88d',
+            }
+          : {
+              keyword: '#7c3aed',
+              string: '#15803d',
+              number: '#c2410c',
+              constant: '#a16207',
+              comment: '#64748b',
+              function: '#1d4ed8',
+              type: '#a16207',
+              property: '#0369a1',
+              tag: '#be123c',
+              attribute: '#15803d',
+            },
+      },
+      blockquote: {
+        color: theme.colors.onSurfaceVariant,
+        borderColor: theme.colors.outline,
+        borderWidth: 3,
+        gapWidth: 12,
+        backgroundColor: theme.colors.elevation.level1,
+        borderRadius: 8,
+        padding: 10,
+        marginTop: 0,
+        marginBottom: 12,
+        fontSize: muted ? 15 : 17,
+        lineHeight: muted ? 23 : 27,
+      },
+      link: { color: theme.colors.primary, underline: true },
+      thematicBreak: {
+        color: theme.colors.outlineVariant,
+        height: StyleSheet.hairlineWidth,
+        marginTop: 8,
+        marginBottom: 14,
+      },
+      table: {
+        color: textColor,
+        fontSize: 15,
+        lineHeight: 22,
+        headerBackgroundColor: subtleSurface,
+        headerTextColor: textColor,
+        rowEvenBackgroundColor: theme.colors.background,
+        rowOddBackgroundColor: theme.colors.elevation.level1,
+        borderColor: theme.colors.outlineVariant,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderRadius: 8,
+        cellPaddingHorizontal: 10,
+        cellPaddingVertical: 8,
+        marginBottom: 14,
+      },
+      taskList: {
+        checkedColor: theme.colors.primary,
+        borderColor: theme.colors.outline,
+        checkmarkColor: theme.colors.onPrimary,
+        checkedTextColor: theme.colors.onSurfaceVariant,
+        checkboxSize: 17,
+        checkboxBorderRadius: 4,
+      },
+      image: { maxHeight: 320, resizeMode: 'contain', borderRadius: 10, marginBottom: 14 },
+    }
+  }, [muted, theme.colors, theme.dark])
 
   return (
-    <Markdown rules={rules} style={styles}>
-      {children}
-    </Markdown>
+    <EnrichedMarkdownText
+      accessibilityLabels={ACCESSIBILITY_LABELS}
+      containerStyle={styles.container}
+      enableTaskListItemToggle={false}
+      flavor="github"
+      lineBreakStrategyIOS="standard"
+      markdown={children}
+      markdownStyle={markdownStyle}
+      md4cFlags={MARKDOWN_FLAGS}
+      onLinkPress={({ url }) => {
+        void Linking.openURL(url).catch(error =>
+          console.warn('Failed to open Markdown link', error)
+        )
+      }}
+      selectable={false}
+      streamingAnimation={streaming}
+      streamingConfig={STREAMING_CONFIG}
+      testID="assistant-markdown"
+      textBreakStrategy="highQuality"
+      writingDirection="first-strong"
+    />
   )
 }
 
-function isRenderableImageSource(source: string): boolean {
-  return /^(https?:\/\/|data:image\/)/i.test(source)
-}
+const styles = StyleSheet.create({
+  container: { width: '100%' },
+})

--- a/wework-mobile/src/components/ConversationListScreen.tsx
+++ b/wework-mobile/src/components/ConversationListScreen.tsx
@@ -2,7 +2,7 @@ import Ionicons from '@expo/vector-icons/Ionicons'
 import { useIsFocused } from '@react-navigation/native'
 import type { GlassColorScheme } from 'expo-glass-effect'
 import { useEffect, useMemo, useState } from 'react'
-import { FlatList, Platform, Pressable, StyleSheet, View } from 'react-native'
+import { FlatList, Platform, Pressable, RefreshControl, StyleSheet, View } from 'react-native'
 import { ActivityIndicator, Portal, Text, useTheme, type MD3Theme } from 'react-native-paper'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
@@ -29,10 +29,14 @@ interface ConversationListScreenProps {
   workspaces: Array<{ projectName: string; workspace: RuntimeDeviceWorkspace }>
   currentAddress: RuntimeTaskAddress | null
   selectedDeviceId: string | null
+  allDevicesSelected: boolean
   search: string
   loading: boolean
+  refreshing: boolean
   onSearch: (value: string) => void
+  onRefresh: () => Promise<void>
   onSelectDevice: (deviceId: string) => void
+  onSelectAllDevices: () => void
   onSelectConversation: (item: ConversationItem) => void
   onNewConversation: (workspace?: RuntimeDeviceWorkspace) => void
   onNewProject: () => void
@@ -41,7 +45,13 @@ interface ConversationListScreenProps {
 }
 
 type DrawerItem =
-  | { key: 'projects-title'; type: 'projects-title' }
+  | {
+      key: 'projects-title' | 'tasks-title'
+      type: 'section'
+      section: DrawerSection
+      title: '项目' | '任务'
+      expanded: boolean
+    }
   | {
       key: string
       type: 'project'
@@ -51,6 +61,8 @@ type DrawerItem =
     }
   | { key: string; type: 'conversation'; conversation: ConversationItem }
   | { key: 'empty'; type: 'empty' }
+
+type DrawerSection = 'projects' | 'tasks'
 
 const BOTTOM_CONTROL_HEIGHT = 52
 const SEARCH_LINE_HEIGHT = 22
@@ -66,6 +78,7 @@ export function ConversationListScreen(props: ConversationListScreenProps) {
   const glassColorScheme: GlassColorScheme = theme.dark ? 'dark' : 'light'
   const [actionsVisible, setActionsVisible] = useState(false)
   const [showAllDevices, setShowAllDevices] = useState(false)
+  const [collapsedSections, setCollapsedSections] = useState<Set<DrawerSection>>(() => new Set())
   const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(() => new Set())
   const onlineDeviceIds = useMemo(
     () =>
@@ -76,10 +89,11 @@ export function ConversationListScreen(props: ConversationListScreenProps) {
   )
   const onlineDevices = props.devices.filter(device => onlineDeviceIds.has(device.device_id))
   const displayedDevices = showAllDevices ? onlineDevicesFirst(props.devices) : onlineDevices
-  const selectedDeviceId =
-    onlineDevices.find(device => device.device_id === props.selectedDeviceId)?.device_id ??
-    onlineDevices[0]?.device_id ??
-    null
+  const selectedDeviceId = props.allDevicesSelected
+    ? null
+    : (onlineDevices.find(device => device.device_id === props.selectedDeviceId)?.device_id ??
+      onlineDevices[0]?.device_id ??
+      null)
   const query = props.search.trim().toLocaleLowerCase()
 
   const filteredConversations = props.conversations.filter(item => {
@@ -98,37 +112,58 @@ export function ConversationListScreen(props: ConversationListScreenProps) {
   )
 
   const drawerItems = useMemo<DrawerItem[]>(() => {
-    const items: DrawerItem[] = [{ key: 'projects-title', type: 'projects-title' }]
+    const projectsExpanded = !collapsedSections.has('projects')
+    const tasksExpanded = !collapsedSections.has('tasks')
+    const items: DrawerItem[] = [
+      {
+        key: 'projects-title',
+        type: 'section',
+        section: 'projects',
+        title: '项目',
+        expanded: projectsExpanded,
+      },
+    ]
     const projectNames = new Set<string>()
     visibleWorkspaces.forEach(({ projectName }) => projectNames.add(projectName))
     filteredConversations.forEach(item => {
       if (item.projectName) projectNames.add(item.projectName)
     })
 
-    for (const projectName of projectNames) {
-      const workspace = visibleWorkspaces.find(item => item.projectName === projectName)?.workspace
-      const expanded = !collapsedProjects.has(projectName)
-      items.push({
-        key: `project:${projectName}`,
-        type: 'project',
-        name: projectName,
-        workspace,
-        expanded,
-      })
-      if (!expanded) continue
-      for (const conversation of filteredConversations.filter(
-        item => item.projectName === projectName
-      )) {
+    if (projectsExpanded) {
+      for (const projectName of projectNames) {
+        const workspace = visibleWorkspaces.find(
+          item => item.projectName === projectName
+        )?.workspace
+        const expanded = !collapsedProjects.has(projectName)
         items.push({
-          key: `conversation:${conversation.address.deviceId}:${conversation.address.taskId}`,
-          type: 'conversation',
-          conversation,
+          key: `project:${projectName}`,
+          type: 'project',
+          name: projectName,
+          workspace,
+          expanded,
         })
+        if (!expanded) continue
+        for (const conversation of filteredConversations.filter(
+          item => item.projectName === projectName
+        )) {
+          items.push({
+            key: `conversation:${conversation.address.deviceId}:${conversation.address.taskId}`,
+            type: 'conversation',
+            conversation,
+          })
+        }
       }
     }
 
     const standaloneConversations = filteredConversations.filter(item => !item.projectName)
-    if (projectNames.size === 0 || standaloneConversations.length > 0) {
+    items.push({
+      key: 'tasks-title',
+      type: 'section',
+      section: 'tasks',
+      title: '任务',
+      expanded: tasksExpanded,
+    })
+    if (tasksExpanded) {
       for (const conversation of standaloneConversations) {
         items.push({
           key: `conversation:${conversation.address.deviceId}:${conversation.address.taskId}`,
@@ -138,9 +173,20 @@ export function ConversationListScreen(props: ConversationListScreenProps) {
       }
     }
 
-    if (items.length === 1) items.push({ key: 'empty', type: 'empty' })
+    if (projectNames.size === 0 && standaloneConversations.length === 0) {
+      items.push({ key: 'empty', type: 'empty' })
+    }
     return items
-  }, [collapsedProjects, filteredConversations, visibleWorkspaces])
+  }, [collapsedProjects, collapsedSections, filteredConversations, visibleWorkspaces])
+
+  const toggleSection = (section: DrawerSection) => {
+    setCollapsedSections(current => {
+      const next = new Set(current)
+      if (next.has(section)) next.delete(section)
+      else next.add(section)
+      return next
+    })
+  }
 
   const toggleProject = (projectName: string) => {
     setCollapsedProjects(current => {
@@ -237,6 +283,15 @@ export function ConversationListScreen(props: ConversationListScreenProps) {
                   }}
                   testID="drawer-settings"
                 />
+                <DrawerAction
+                  icon={showAllDevices ? 'eye-off-outline' : 'eye-outline'}
+                  label={showAllDevices ? '仅显示在线设备' : '显示全部设备'}
+                  onPress={() => {
+                    setActionsVisible(false)
+                    setShowAllDevices(current => !current)
+                  }}
+                  testID="drawer-toggle-offline-devices"
+                />
               </LiquidGlassSurface>
             </Pressable>
           </Pressable>
@@ -250,15 +305,23 @@ export function ConversationListScreen(props: ConversationListScreenProps) {
         keyExtractor={device => device.device_id}
         ListHeaderComponent={
           <LiquidGlassButton
-            accessibilityLabel={showAllDevices ? '仅显示在线设备' : '显示全部设备'}
+            accessibilityLabel="显示所有设备任务"
             colorScheme={glassColorScheme}
             contentStyle={styles.allDevicePill}
-            fallbackStyle={styles.glassFallback}
-            onPress={() => setShowAllDevices(current => !current)}
+            fallbackStyle={
+              props.allDevicesSelected ? styles.selectedGlassFallback : styles.glassFallback
+            }
+            glassEffectStyle={props.allDevicesSelected ? 'clear' : 'regular'}
+            onPress={props.onSelectAllDevices}
             style={styles.deviceGlass}
             testID="device-option-all"
+            tintColor={props.allDevicesSelected ? theme.colors.primary : undefined}
           >
-            <Text style={styles.deviceText}>{showAllDevices ? '仅在线' : '全部'}</Text>
+            <Text
+              style={[styles.deviceText, props.allDevicesSelected && styles.deviceTextSelected]}
+            >
+              全部
+            </Text>
           </LiquidGlassButton>
         }
         renderItem={({ item: device }) => {
@@ -306,12 +369,37 @@ export function ConversationListScreen(props: ConversationListScreenProps) {
           keyExtractor={item => item.key}
           keyboardDismissMode="interactive"
           keyboardShouldPersistTaps="handled"
+          refreshControl={
+            <RefreshControl
+              onRefresh={() => void props.onRefresh()}
+              refreshing={props.refreshing}
+              testID="conversation-list-refresh"
+              tintColor={theme.colors.onSurfaceVariant}
+            />
+          }
           renderItem={({ item }) => {
-            if (item.type === 'projects-title') {
+            if (item.type === 'section') {
               return (
-                <Text style={styles.sectionTitle} variant="titleMedium">
-                  项目
-                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityState={{ expanded: item.expanded }}
+                  onPress={() => toggleSection(item.section)}
+                  style={({ pressed }) => [
+                    styles.sectionHeader,
+                    item.section === 'tasks' && styles.tasksSectionHeader,
+                    pressed && styles.rowPressed,
+                  ]}
+                  testID={`section-${item.section}-toggle`}
+                >
+                  <Text style={styles.sectionTitle} variant="titleMedium">
+                    {item.title}
+                  </Text>
+                  <Ionicons
+                    color={theme.colors.onSurfaceVariant}
+                    name={item.expanded ? 'chevron-down' : 'chevron-forward'}
+                    size={18}
+                  />
+                </Pressable>
               )
             }
             if (item.type === 'project') {
@@ -569,12 +657,17 @@ function createStyles(colors: MD3Theme['colors']) {
     deviceTextSelected: { color: colors.onPrimary },
     loader: { flex: 1 },
     list: { paddingTop: 12, paddingBottom: 104, flexGrow: 1 },
-    sectionTitle: {
-      color: colors.onBackground,
-      fontWeight: '600',
-      marginHorizontal: 24,
-      marginBottom: 10,
+    sectionHeader: {
+      minHeight: 44,
+      marginHorizontal: 16,
+      paddingHorizontal: 8,
+      borderRadius: 12,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
     },
+    tasksSectionHeader: { marginTop: 32 },
+    sectionTitle: { color: colors.onBackground, fontWeight: '600' },
     projectRow: {
       minHeight: 52,
       marginBottom: 6,

--- a/wework-mobile/src/components/ConversationScreen.tsx
+++ b/wework-mobile/src/components/ConversationScreen.tsx
@@ -59,8 +59,10 @@ interface ConversationScreenProps {
   devices: DeviceInfo[]
   entryRevision: number
   gitRef: string | null
+  hasMoreMessagesBefore: boolean
   isNew: boolean
   loading: boolean
+  loadingMoreMessagesBefore: boolean
   messages: ChatMessage[]
   model: UnifiedModel | null
   modelOptions: ModelOptions
@@ -74,6 +76,7 @@ interface ConversationScreenProps {
   workspaces: ConversationWorkspaceChoice[]
   onBack: () => void
   onLoadApps: () => Promise<RuntimeComposerApp[]>
+  onLoadMoreMessagesBefore: () => Promise<void>
   onMore: () => void
   onNewConversation: () => void
   onOpenAdvancedModel: () => void
@@ -244,8 +247,11 @@ export function ConversationScreen(props: ConversationScreenProps) {
           bottomInset={messageBottomInset}
           conversationId={conversationKey}
           entryRevision={props.entryRevision}
+          hasMoreBefore={props.hasMoreMessagesBefore}
           loading={props.loading}
+          loadingMoreBefore={props.loadingMoreMessagesBefore}
           messages={props.messages}
+          onLoadMoreBefore={props.onLoadMoreMessagesBefore}
           topInset={messageTopInset}
         />
       )}

--- a/wework-mobile/src/components/MessageList.tsx
+++ b/wework-mobile/src/components/MessageList.tsx
@@ -17,23 +17,23 @@ import {
   isNearMessageListBottom,
   messageListBottomOffset,
   reduceMessageListFollow,
+  shouldLoadEarlierMessages,
 } from '@/domain/messageListScroll'
-import {
-  buildMessageDisplayRows,
-  buildThinkingPreview,
-  type MessageDisplayRow,
-  type ToolActivityKind,
-} from '@/domain/messagePresentation'
-import type { ChatFileChangesSummary, ChatMessage, ChatToolBlock } from '@/types/runtime'
+import { buildThinkingPreview } from '@/domain/messagePresentation'
+import type { ChatFileChangesSummary, ChatMessage } from '@/types/runtime'
 import { AssistantMarkdown } from './AssistantMarkdown'
 import { MessageContextMenu, type MessageMenuAnchor } from './MessageContextMenu'
+import { ProcessingTimeline } from './ProcessingTimeline'
 
 interface MessageListProps {
   bottomInset: number
   conversationId: string
   entryRevision: number
+  hasMoreBefore: boolean
   messages: ChatMessage[]
   loading: boolean
+  loadingMoreBefore: boolean
+  onLoadMoreBefore: () => Promise<void>
   topInset: number
 }
 
@@ -46,8 +46,11 @@ export function MessageList({
   bottomInset,
   conversationId,
   entryRevision,
+  hasMoreBefore,
   messages,
   loading,
+  loadingMoreBefore,
+  onLoadMoreBefore,
   topInset,
 }: MessageListProps) {
   const listRef = useRef<FlatList<ChatMessage>>(null)
@@ -109,14 +112,27 @@ export function MessageList({
     [scrollToLatest]
   )
 
-  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    if (!userDraggingRef.current) return
-    followsLatestRef.current = reduceMessageListFollow(followsLatestRef.current, {
-      type: 'scroll-position-changed',
-      metrics: event.nativeEvent,
-      userInitiated: true,
-    })
-  }, [])
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (!userDraggingRef.current) return
+      followsLatestRef.current = reduceMessageListFollow(followsLatestRef.current, {
+        type: 'scroll-position-changed',
+        metrics: event.nativeEvent,
+        userInitiated: true,
+      })
+      if (
+        shouldLoadEarlierMessages(
+          event.nativeEvent,
+          hasMoreBefore,
+          loadingMoreBefore,
+          userDraggingRef.current
+        )
+      ) {
+        void onLoadMoreBefore()
+      }
+    },
+    [hasMoreBefore, loadingMoreBefore, onLoadMoreBefore]
+  )
 
   const handleScrollBeginDrag = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
     userDraggingRef.current = true
@@ -161,6 +177,13 @@ export function MessageList({
         keyboardDismissMode="interactive"
         keyboardShouldPersistTaps="handled"
         keyExtractor={message => message.id}
+        ListHeaderComponent={
+          loadingMoreBefore ? (
+            <View style={styles.olderMessagesLoader} testID="older-messages-loader">
+              <ActivityIndicator size="small" />
+            </View>
+          ) : null
+        }
         ListFooterComponent={messages.length > 0 ? <View style={{ height: bottomInset }} /> : null}
         ListEmptyComponent={
           <View style={styles.empty}>
@@ -176,6 +199,7 @@ export function MessageList({
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}
         onScrollEndDrag={handleScrollEndDrag}
+        maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
         ref={listRef}
         renderItem={({ item }) => <Message message={item} onLongPress={openMessageMenu} />}
         scrollEventThrottle={16}
@@ -224,7 +248,6 @@ function Message({
     )
   }
 
-  const displayRows = buildMessageDisplayRows(message.blocks, message.content)
   const thinkingPreview =
     message.status === 'streaming'
       ? buildThinkingPreview(message.streamingThinkingContent ?? '')
@@ -238,10 +261,12 @@ function Message({
       style={({ pressed }) => [styles.assistant, pressed && styles.messagePressed]}
       testID={`message-${message.id}`}
     >
-      {displayRows.map(row => (
-        <ProcessingRow key={row.id} row={row} />
-      ))}
-      {message.content ? <AssistantMarkdown>{message.content}</AssistantMarkdown> : null}
+      <ProcessingTimeline message={message} />
+      {message.content ? (
+        <AssistantMarkdown streaming={message.status === 'streaming'}>
+          {message.content}
+        </AssistantMarkdown>
+      ) : null}
       {message.status === 'completed' && message.fileChanges ? (
         <FileChangesSummary summary={message.fileChanges} />
       ) : null}
@@ -249,7 +274,7 @@ function Message({
       {(message.status === 'pending' || message.status === 'streaming') &&
       !message.content &&
       !thinkingPreview &&
-      !displayRows.length ? (
+      !message.blocks?.length ? (
         <ActivityIndicator size={16} style={styles.streaming} />
       ) : null}
       {message.error ? (
@@ -272,81 +297,6 @@ function ThinkingIndicator({ preview }: { preview: string }) {
     >
       思考中 · {preview}
     </Text>
-  )
-}
-
-function ProcessingRow({ row }: { row: MessageDisplayRow }) {
-  const theme = useTheme()
-  if (row.type === 'tool-group') return <ToolActivityGroup row={row} />
-  if (row.type === 'tool') {
-    return (
-      <View style={styles.activityRow} testID={`tool-block-${row.block.id}`}>
-        <ActivityIndicator size={16} />
-        <Text style={{ color: theme.colors.onSurfaceVariant }} variant="bodyMedium">
-          {activeToolLabel(row.block, row.kind)}
-        </Text>
-      </View>
-    )
-  }
-
-  const { block } = row
-  if (!block.content.trim()) return null
-  if (block.type === 'error') {
-    return (
-      <Text style={[styles.error, { color: theme.colors.error }]} variant="bodyMedium">
-        {block.content}
-      </Text>
-    )
-  }
-  return <AssistantMarkdown muted={block.type === 'guidance'}>{block.content}</AssistantMarkdown>
-}
-
-function ToolActivityGroup({ row }: { row: Extract<MessageDisplayRow, { type: 'tool-group' }> }) {
-  const theme = useTheme()
-  const [expanded, setExpanded] = useState(false)
-  const color = row.failed ? theme.colors.error : theme.colors.onSurfaceVariant
-  return (
-    <View style={styles.activityGroup}>
-      <Pressable
-        accessibilityRole="button"
-        onPress={() => setExpanded(current => !current)}
-        style={styles.activityRow}
-        testID={`tool-group-toggle-${row.id}`}
-      >
-        <Ionicons color={color} name={activityIcon(row.kind)} size={20} />
-        <Text numberOfLines={1} style={[styles.activityLabel, { color }]} variant="bodyLarge">
-          {row.label}
-        </Text>
-        <Ionicons color={color} name={expanded ? 'chevron-down' : 'chevron-forward'} size={18} />
-      </Pressable>
-      {expanded ? (
-        <View
-          style={[styles.activityDetails, { borderLeftColor: theme.colors.outlineVariant }]}
-          testID={`tool-group-details-${row.id}`}
-        >
-          {row.blocks.map(block => (
-            <ToolActivityDetail block={block} key={block.id} />
-          ))}
-        </View>
-      ) : null}
-    </View>
-  )
-}
-
-function ToolActivityDetail({ block }: { block: ChatToolBlock }) {
-  const theme = useTheme()
-  const detail = toolDetail(block)
-  return (
-    <View style={styles.activityDetailRow}>
-      <Ionicons
-        color={block.status === 'error' ? theme.colors.error : theme.colors.onSurfaceVariant}
-        name={block.status === 'error' ? 'alert-circle-outline' : 'checkmark-circle-outline'}
-        size={16}
-      />
-      <Text numberOfLines={2} style={{ color: theme.colors.onSurfaceVariant }} variant="bodyMedium">
-        {detail}
-      </Text>
-    </View>
   )
 }
 
@@ -412,45 +362,6 @@ function FileChangesSummary({ summary }: { summary: ChatFileChangesSummary }) {
   )
 }
 
-function activityIcon(kind: ToolActivityKind): keyof typeof Ionicons.glyphMap {
-  switch (kind) {
-    case 'web':
-      return 'globe-outline'
-    case 'file':
-      return 'document-text-outline'
-    case 'search':
-      return 'search-outline'
-    case 'command':
-      return 'terminal-outline'
-    case 'create':
-      return 'add-circle-outline'
-    case 'edit':
-      return 'pencil-outline'
-    case 'guidance':
-      return 'chatbubble-ellipses-outline'
-    case 'tool':
-      return 'construct-outline'
-  }
-}
-
-function activeToolLabel(block: ChatToolBlock, kind: ToolActivityKind): string {
-  if (kind === 'web') return '正在搜索网页'
-  if (kind === 'search') return '正在搜索代码'
-  if (kind === 'file') return '正在读取文件'
-  if (kind === 'command') return '正在运行命令'
-  if (kind === 'edit') return '正在编辑文件'
-  if (kind === 'create') return '正在创建文件'
-  return `正在使用 ${block.toolName}`
-}
-
-function toolDetail(block: ChatToolBlock): string {
-  for (const key of ['query', 'pattern', 'command', 'path', 'file_path']) {
-    const value = block.toolInput?.[key]
-    if (typeof value === 'string' && value.trim()) return value.trim()
-  }
-  return block.toolName
-}
-
 function compactCount(value: number): string {
   if (Math.abs(value) < 10_000) return String(value)
   return `${Number((value / 10_000).toFixed(1))}万`
@@ -462,6 +373,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 18,
   },
   messageSeparator: { height: 22 },
+  olderMessagesLoader: { minHeight: 36, alignItems: 'center', justifyContent: 'center' },
   emptyContent: { flexGrow: 1 },
   empty: {
     flex: 1,
@@ -481,27 +393,6 @@ const styles = StyleSheet.create({
   assistant: { width: '100%' },
   messagePressed: { opacity: 0.82 },
   thinkingIndicator: { opacity: 0.62, marginBottom: 10 },
-  activityGroup: { marginBottom: 10 },
-  activityRow: {
-    alignSelf: 'flex-start',
-    flexDirection: 'row',
-    alignItems: 'center',
-    minHeight: 32,
-    gap: 8,
-  },
-  activityLabel: { flexShrink: 1, opacity: 0.78 },
-  activityDetails: {
-    marginLeft: 10,
-    paddingLeft: 14,
-    borderLeftWidth: StyleSheet.hairlineWidth,
-    gap: 6,
-    paddingVertical: 4,
-  },
-  activityDetailRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
   fileChangesContainer: { alignItems: 'center', marginTop: 10, marginBottom: 12 },
   fileChangesPill: {
     minHeight: 34,

--- a/wework-mobile/src/components/ProcessingTimeline.tsx
+++ b/wework-mobile/src/components/ProcessingTimeline.tsx
@@ -1,0 +1,579 @@
+import Ionicons from '@expo/vector-icons/Ionicons'
+import { useState } from 'react'
+import { ActivityIndicator, Image, Pressable, StyleSheet, View } from 'react-native'
+import { Text, useTheme } from 'react-native-paper'
+
+import {
+  buildMessageDisplaySegments,
+  fileChangeLabel,
+  generatedImagesFromBlocks,
+  processingActivityStats,
+  processingDurationLabel,
+  processingSegmentTitle,
+  shouldCollapseCompletedProcessing,
+  type GeneratedImageArtifact,
+  type MessageDisplayRow,
+  type MessageDisplaySegment,
+  type ToolActivityKind,
+} from '@/domain/messagePresentation'
+import type {
+  ChatFileChangesBlock,
+  ChatMessage,
+  ChatProcessingBlock,
+  ChatToolBlock,
+} from '@/types/runtime'
+import { AssistantMarkdown } from './AssistantMarkdown'
+
+export function ProcessingTimeline({ message }: { message: ChatMessage }) {
+  const segments = buildMessageDisplaySegments(message.blocks, message.content)
+  const rows = segments.flatMap(segment => segment.rows)
+  const images = generatedImagesFromBlocks(message.blocks)
+  const [expanded, setExpanded] = useState(false)
+  if (!rows.length && !images.length) return null
+
+  const collapsed = shouldCollapseCompletedProcessing(message.blocks, message.content, rows)
+  const timeline = !rows.length ? null : !collapsed ? (
+    <View style={styles.timeline} testID={`processing-timeline-${message.id}`}>
+      {segments.map(segment => (
+        <ProcessingSegment key={segment.id} segment={segment} />
+      ))}
+    </View>
+  ) : (
+    <View style={styles.completedTimeline} testID={`completed-processing-${message.id}`}>
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => setExpanded(current => !current)}
+        style={styles.completedHeader}
+        testID={`completed-processing-toggle-${message.id}`}
+      >
+        <Text style={styles.completedLabel} variant="bodyMedium">
+          {processingDurationLabel(message.blocks, message.createdAt, message.completedAt)}
+        </Text>
+        <Ionicons name={expanded ? 'chevron-down' : 'chevron-forward'} size={16} />
+      </Pressable>
+      {expanded ? (
+        <View style={styles.completedContent} testID={`completed-processing-content-${message.id}`}>
+          {segments.map(segment => (
+            <ProcessingSegment key={segment.id} segment={segment} />
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+
+  return (
+    <>
+      {timeline}
+      {images.length ? <GeneratedImageGallery images={images} /> : null}
+    </>
+  )
+}
+
+function ProcessingSegment({ segment }: { segment: MessageDisplaySegment }) {
+  if (segment.kind === 'tool') return <ToolProcessingSegment rows={segment.rows} />
+  return (
+    <View style={styles.narrativeSegment}>
+      {segment.rows.map(row => (
+        <ProcessingRow key={row.id} row={row} />
+      ))}
+    </View>
+  )
+}
+
+function ToolProcessingSegment({ rows }: { rows: MessageDisplayRow[] }) {
+  const theme = useTheme()
+  const [expanded, setExpanded] = useState(false)
+  const stats = processingActivityStats(rows)
+  const running = rows.some(isProcessingRowRunning)
+  const lockedOpen = rows.some(isRequestUserInputRow)
+  const contentExpanded = lockedOpen || expanded
+  const color = theme.colors.onSurfaceVariant
+  const details = (
+    <View style={styles.segmentDetails} testID="processing-segment-details">
+      {rows.map(row => (
+        <ProcessingRow initialGroupExpanded key={row.id} row={row} />
+      ))}
+    </View>
+  )
+
+  return (
+    <View style={styles.toolSegment} testID="processing-tool-segment">
+      <Pressable
+        accessibilityRole={lockedOpen || running ? undefined : 'button'}
+        disabled={lockedOpen || running}
+        onPress={() => setExpanded(current => !current)}
+        style={styles.segmentHeader}
+        testID="processing-segment-toggle"
+      >
+        <Ionicons
+          color={color}
+          name={contentExpanded ? 'chevron-down' : 'chevron-forward'}
+          size={15}
+        />
+        <Text numberOfLines={1} style={[styles.segmentTitle, { color }]} variant="bodyMedium">
+          {processingSegmentTitle(rows)}
+        </Text>
+        <ProcessingStats color={color} stats={stats} />
+        {running ? <ActivityIndicator size={14} /> : null}
+      </Pressable>
+      {contentExpanded ? (
+        details
+      ) : running ? (
+        <View style={styles.livePreview}>{details}</View>
+      ) : null}
+    </View>
+  )
+}
+
+function ProcessingStats({
+  color,
+  stats,
+}: {
+  color: string
+  stats: ReturnType<typeof processingActivityStats>
+}) {
+  const items: Array<{
+    count: number
+    icon: keyof typeof Ionicons.glyphMap
+    key: keyof typeof stats
+  }> = [
+    { key: 'command', count: stats.command, icon: 'terminal-outline' },
+    { key: 'file', count: stats.file, icon: 'document-text-outline' },
+    { key: 'search', count: stats.search, icon: 'search-outline' },
+    { key: 'edit', count: stats.edit, icon: 'pencil-outline' },
+    { key: 'other', count: stats.other, icon: 'construct-outline' },
+  ]
+  return (
+    <View style={styles.processingStats}>
+      {items
+        .filter(item => item.count > 0)
+        .map(item => (
+          <View key={item.key} style={styles.processingStat}>
+            <Ionicons color={color} name={item.icon} size={16} />
+            <Text style={{ color }} variant="bodySmall">
+              {item.count}
+            </Text>
+          </View>
+        ))}
+    </View>
+  )
+}
+
+function isProcessingRowRunning(row: MessageDisplayRow): boolean {
+  if (row.type === 'tool-group') {
+    return row.blocks.some(block => block.status !== 'done' && block.status !== 'error')
+  }
+  return row.block.status !== 'done' && row.block.status !== 'error'
+}
+
+function isRequestUserInputRow(row: MessageDisplayRow): boolean {
+  return row.type === 'tool' && asRecord(row.block.renderPayload).kind === 'request_user_input'
+}
+
+function GeneratedImageGallery({ images }: { images: GeneratedImageArtifact[] }) {
+  return (
+    <View style={styles.generatedImageGallery} testID="generated-image-gallery">
+      {images.map(image => (
+        <Image
+          accessibilityLabel={image.alt}
+          key={image.id}
+          resizeMode="contain"
+          source={{ uri: image.uri }}
+          style={styles.generatedImage}
+          testID="generated-image"
+        />
+      ))}
+    </View>
+  )
+}
+
+function ProcessingRow({
+  initialGroupExpanded = false,
+  row,
+}: {
+  initialGroupExpanded?: boolean
+  row: MessageDisplayRow
+}) {
+  const theme = useTheme()
+  if (row.type === 'tool-group') {
+    return <ToolActivityGroup initialExpanded={initialGroupExpanded} row={row} />
+  }
+  if (row.type === 'file-changes') return <FileChangesActivityGroup block={row.block} />
+  if (row.type === 'tool') return <ToolActivity block={row.block} kind={row.kind} />
+
+  const { block } = row
+  if (!block.content.trim()) return null
+  if (block.type === 'error') {
+    return (
+      <Text style={[styles.error, { color: theme.colors.error }]} variant="bodyMedium">
+        {block.content}
+      </Text>
+    )
+  }
+  return <AssistantMarkdown muted={block.type === 'guidance'}>{block.content}</AssistantMarkdown>
+}
+
+function ToolActivityGroup({
+  initialExpanded,
+  row,
+}: {
+  initialExpanded: boolean
+  row: Extract<MessageDisplayRow, { type: 'tool-group' }>
+}) {
+  const theme = useTheme()
+  const [expanded, setExpanded] = useState(initialExpanded)
+  const color = row.failed ? theme.colors.error : theme.colors.onSurfaceVariant
+  return (
+    <View style={styles.activityGroup}>
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => setExpanded(current => !current)}
+        style={styles.activityRow}
+        testID={`tool-group-toggle-${row.id}`}
+      >
+        <Ionicons color={color} name={activityIcon(row.kind)} size={17} />
+        <Text numberOfLines={1} style={[styles.activityLabel, { color }]} variant="bodyMedium">
+          {row.label}
+        </Text>
+        {row.kind === 'guidance' ? null : (
+          <Ionicons color={color} name={expanded ? 'chevron-down' : 'chevron-forward'} size={16} />
+        )}
+      </Pressable>
+      {expanded ? (
+        <View
+          style={[styles.activityDetails, { borderLeftColor: theme.colors.outlineVariant }]}
+          testID={`tool-group-details-${row.id}`}
+        >
+          {row.blocks.map(block => (
+            <ToolActivityDetail block={block} key={block.id} />
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+function ToolActivity({ block, kind }: { block: ChatToolBlock; kind: ToolActivityKind }) {
+  const theme = useTheme()
+  const running = block.status !== 'done' && block.status !== 'error'
+  const color = block.status === 'error' ? theme.colors.error : theme.colors.onSurfaceVariant
+  const payload = asRecord(block.renderPayload)
+  const requestQuestion = requestUserInputQuestion(payload)
+  if (isContextCompactionName(block.toolName)) return <ContextCompactionActivity block={block} />
+  return (
+    <View style={styles.standaloneTool} testID={`tool-block-${block.id}`}>
+      <View style={styles.activityRow}>
+        {running ? (
+          <ActivityIndicator size={16} />
+        ) : (
+          <Ionicons
+            color={color}
+            name={block.status === 'error' ? 'alert-circle-outline' : activityIcon(kind)}
+            size={18}
+          />
+        )}
+        <Text style={[styles.activityLabel, { color }]} variant="bodyMedium">
+          {toolStatusLabel(block, kind)}
+        </Text>
+      </View>
+      {requestQuestion ? (
+        <View
+          style={[styles.requestCard, { backgroundColor: theme.colors.elevation.level1 }]}
+          testID="request-user-input-card"
+        >
+          <Text variant="titleSmall">{requestQuestion.header}</Text>
+          <Text variant="bodyMedium">{requestQuestion.question}</Text>
+          {requestQuestion.options.map(option => (
+            <View key={option} style={styles.requestOption}>
+              <Text variant="bodyMedium">{option}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+function ContextCompactionActivity({ block }: { block: ChatToolBlock }) {
+  const theme = useTheme()
+  const color = block.status === 'error' ? theme.colors.error : theme.colors.onSurfaceVariant
+  return (
+    <View style={styles.contextCompaction} testID="context-compaction-indicator">
+      <View style={[styles.contextDivider, { backgroundColor: theme.colors.outlineVariant }]} />
+      <Ionicons color={color} name="archive-outline" size={17} />
+      <Text style={[styles.contextLabel, { color }]} variant="bodyMedium">
+        {toolStatusLabel(block, 'tool')}
+      </Text>
+      <View style={[styles.contextDivider, { backgroundColor: theme.colors.outlineVariant }]} />
+    </View>
+  )
+}
+
+function ToolActivityDetail({ block }: { block: ChatToolBlock }) {
+  const theme = useTheme()
+  const error = block.status === 'error'
+  return (
+    <View style={styles.activityDetailRow}>
+      <Ionicons
+        color={error ? theme.colors.error : theme.colors.onSurfaceVariant}
+        name={error ? 'alert-circle-outline' : 'checkmark-circle-outline'}
+        size={16}
+      />
+      <Text numberOfLines={3} style={{ color: theme.colors.onSurfaceVariant }} variant="bodyMedium">
+        {toolDetail(block)}
+      </Text>
+    </View>
+  )
+}
+
+function FileChangesActivityGroup({ block }: { block: ChatFileChangesBlock }) {
+  const theme = useTheme()
+  const [expanded, setExpanded] = useState(false)
+  const running = block.status !== 'done' && block.status !== 'error'
+  return (
+    <View style={styles.fileActivity} testID={`process-file-changes-${block.id}`}>
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => setExpanded(current => !current)}
+        style={styles.activityRow}
+        testID={`file-changes-activity-toggle-${block.id}`}
+      >
+        <Text style={{ color: theme.colors.onSurfaceVariant }} variant="bodyMedium">
+          编辑 {block.fileChanges.fileCount} 个文件
+        </Text>
+        <Ionicons color={theme.colors.onSurfaceVariant} name="pencil-outline" size={17} />
+        <Text style={{ color: theme.colors.onSurfaceVariant }} variant="bodySmall">
+          {block.fileChanges.fileCount}
+        </Text>
+        <Ionicons
+          color={theme.colors.onSurfaceVariant}
+          name={expanded ? 'chevron-down' : 'chevron-forward'}
+          size={16}
+        />
+      </Pressable>
+      {expanded
+        ? block.fileChanges.files.map(file => (
+            <View style={styles.fileActivityRow} key={`${file.oldPath ?? ''}:${file.path}`}>
+              <Ionicons
+                color={theme.colors.onSurfaceVariant}
+                name="document-text-outline"
+                size={17}
+              />
+              <Text
+                numberOfLines={1}
+                style={[styles.fileActivityLabel, { color: theme.colors.onSurfaceVariant }]}
+                variant="bodyMedium"
+              >
+                {fileChangeLabel(file, running)}
+              </Text>
+              {!file.binary ? (
+                <View style={styles.fileStats}>
+                  <Text style={styles.additions} variant="bodySmall">
+                    +{file.additions}
+                  </Text>
+                  <Text style={styles.deletions} variant="bodySmall">
+                    −{file.deletions}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          ))
+        : null}
+    </View>
+  )
+}
+
+function activityIcon(kind: ToolActivityKind): keyof typeof Ionicons.glyphMap {
+  if (kind === 'web') return 'globe-outline'
+  if (kind === 'file') return 'document-text-outline'
+  if (kind === 'search') return 'search-outline'
+  if (kind === 'command') return 'terminal-outline'
+  if (kind === 'create') return 'add-circle-outline'
+  if (kind === 'edit') return 'pencil-outline'
+  if (kind === 'guidance') return 'chatbubble-ellipses-outline'
+  return 'construct-outline'
+}
+
+function toolStatusLabel(block: ChatToolBlock, kind: ToolActivityKind): string {
+  const running = block.status !== 'done' && block.status !== 'error'
+  const failed = block.status === 'error'
+  const normalizedName = block.toolName.trim().toLowerCase()
+  if (normalizedName === 'runtime_reconnecting') return '连接中断，正在重连…'
+  if (isContextCompactionName(normalizedName)) {
+    return failed ? '上下文压缩失败' : running ? '正在自动压缩上下文' : '上下文已自动压缩'
+  }
+  if (normalizedName === 'image_generation') {
+    return failed ? '生成图片失败' : running ? '正在生成图片' : '已生成图片'
+  }
+  if (kind === 'web') return failed ? '搜索网页失败' : running ? '正在搜索网页' : '已搜索网页'
+  if (kind === 'search') return failed ? '搜索代码失败' : running ? '正在搜索代码' : '已搜索代码'
+  if (kind === 'file') return failed ? '读取文件失败' : running ? '正在读取文件' : '已读取文件'
+  if (kind === 'command') return failed ? '运行命令失败' : running ? '正在运行命令' : '已运行命令'
+  if (kind === 'edit') return failed ? '编辑文件失败' : running ? '正在编辑文件' : '已编辑文件'
+  if (kind === 'create') return failed ? '新增文件失败' : running ? '正在新增文件' : '已新增文件'
+  if (kind === 'guidance') return failed ? '引导对话失败' : running ? '正在引导对话' : '已引导对话'
+  const name = readableToolName(block.toolName)
+  return failed ? `调用 ${name} 失败` : running ? `正在调用 ${name}` : `已调用 ${name}`
+}
+
+function toolDetail(block: ChatToolBlock): string {
+  const paths = toolFilePaths(block)
+  if (paths.length) return paths.join('、')
+  for (const key of [
+    'query',
+    'pattern',
+    'command',
+    'cmd',
+    'commandLine',
+    'path',
+    'file_path',
+    'filePath',
+    'code',
+  ]) {
+    const value = block.toolInput?.[key]
+    if (typeof value === 'string' && value.trim()) return firstLine(value.trim())
+  }
+  return readableToolName(block.toolName)
+}
+
+function toolFilePaths(block: ChatToolBlock): string[] {
+  const input = block.toolInput
+  if (!input) return []
+  for (const key of [
+    'file_path',
+    'filePath',
+    'filepath',
+    'path',
+    'file',
+    'filename',
+    'target_file',
+    'targetFile',
+    'notebook_path',
+    'notebookPath',
+  ]) {
+    const value = input[key]
+    if (typeof value === 'string' && value.trim()) return [value.trim()]
+  }
+  const patch = ['patch', 'input', 'arguments', 'content'].find(
+    key => typeof input[key] === 'string'
+  )
+  const patchText = patch ? input[patch] : undefined
+  if (typeof patchText !== 'string') return []
+  const paths = new Set<string>()
+  for (const line of patchText.split('\n')) {
+    const match = line.match(/^\*\*\* (?:Add|Delete|Update) File:\s*(.+)$/)
+    if (match?.[1]?.trim()) paths.add(match[1].trim())
+  }
+  return [...paths]
+}
+
+function requestUserInputQuestion(payload: Record<string, unknown>): {
+  header: string
+  question: string
+  options: string[]
+} | null {
+  if (payload.kind !== 'request_user_input' || !Array.isArray(payload.questions)) return null
+  const question = asRecord(payload.questions[0])
+  const options = Array.isArray(question.options)
+    ? question.options.flatMap(value => {
+        const option = asRecord(value)
+        return typeof option.label === 'string' ? [option.label] : []
+      })
+    : []
+  return {
+    header: typeof question.header === 'string' ? question.header : '需要确认',
+    question: typeof question.question === 'string' ? question.question : '',
+    options,
+  }
+}
+
+function readableToolName(name: string): string {
+  return (name.split(/\.|__/).filter(Boolean).at(-1) ?? name).replaceAll('_', ' ')
+}
+
+function firstLine(value: string): string {
+  const line = value.split('\n')[0] ?? value
+  return line.length > 120 ? `${line.slice(0, 117)}...` : line
+}
+
+function isContextCompactionName(name: string): boolean {
+  const normalized = name.trim().toLowerCase()
+  const suffix = normalized.split(/__|\./).at(-1)
+  return suffix === 'context_compaction' || suffix === 'contextcompaction'
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+const styles = StyleSheet.create({
+  timeline: { marginBottom: 10, gap: 8 },
+  narrativeSegment: { gap: 8 },
+  toolSegment: { marginBottom: 2 },
+  segmentHeader: {
+    minHeight: 32,
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  segmentTitle: { flexShrink: 1 },
+  segmentDetails: { gap: 8, paddingTop: 3 },
+  livePreview: {
+    marginLeft: 7,
+    paddingLeft: 12,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderLeftColor: 'rgba(128,128,128,0.38)',
+  },
+  processingStats: { flexDirection: 'row', alignItems: 'center', gap: 9 },
+  processingStat: { flexDirection: 'row', alignItems: 'center', gap: 3 },
+  completedTimeline: {
+    marginBottom: 12,
+    paddingBottom: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(128,128,128,0.38)',
+  },
+  completedHeader: {
+    minHeight: 34,
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  completedLabel: { opacity: 0.62 },
+  completedContent: { gap: 8, paddingTop: 2 },
+  activityGroup: { marginBottom: 2 },
+  activityRow: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 32,
+    gap: 7,
+  },
+  activityLabel: { flexShrink: 1 },
+  activityDetails: {
+    marginLeft: 9,
+    paddingLeft: 14,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    gap: 6,
+    paddingVertical: 4,
+  },
+  activityDetailRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  standaloneTool: { marginBottom: 2 },
+  fileActivity: { gap: 4 },
+  fileActivityRow: { minHeight: 32, flexDirection: 'row', alignItems: 'center', gap: 7 },
+  fileActivityLabel: { flex: 1 },
+  fileStats: { flexDirection: 'row', gap: 7 },
+  additions: { color: '#00a86b' },
+  deletions: { color: '#ef4444' },
+  requestCard: { borderRadius: 12, padding: 12, gap: 8 },
+  requestOption: { minHeight: 36, justifyContent: 'center', paddingHorizontal: 10 },
+  generatedImageGallery: { width: '100%', gap: 10, marginBottom: 12 },
+  generatedImage: { width: '100%', height: 280, borderRadius: 12 },
+  contextCompaction: { flexDirection: 'row', alignItems: 'center', gap: 7, paddingVertical: 4 },
+  contextDivider: { height: StyleSheet.hairlineWidth, flex: 1 },
+  contextLabel: { flexShrink: 1, fontWeight: '600' },
+  error: { marginTop: 4 },
+})

--- a/wework-mobile/src/components/assistantMarkdownPresentationContract.test.ts
+++ b/wework-mobile/src/components/assistantMarkdownPresentationContract.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+declare global {
+  interface ImportMeta {
+    glob(
+      pattern: string | string[],
+      options: { eager: true; import: 'default'; query: '?raw' }
+    ): Record<string, string>
+  }
+}
+
+const sources = import.meta.glob(['./AssistantMarkdown.tsx', './MessageList.tsx'], {
+  eager: true,
+  import: 'default',
+  query: '?raw',
+}) as Record<string, string>
+
+describe('assistant markdown presentation contract', () => {
+  it('uses the native GFM renderer for text, lists, inline code, and code blocks', () => {
+    const markdown = sources['./AssistantMarkdown.tsx']
+
+    expect(markdown).toContain('EnrichedMarkdownText')
+    expect(markdown).toContain('flavor="github"')
+    expect(markdown).toContain('enableTaskListItemToggle={false}')
+    expect(markdown).toContain('streamingAnimation={streaming}')
+    expect(markdown).toContain('codeBlock: {')
+    expect(markdown).toContain('itemSpacing: muted ? 2 : 6')
+    expect(markdown).not.toContain('react-native-markdown-display')
+  })
+
+  it('enables progressive rendering while an assistant message streams', () => {
+    const messages = sources['./MessageList.tsx']
+
+    expect(messages).toContain("<AssistantMarkdown streaming={message.status === 'streaming'}>")
+  })
+})

--- a/wework-mobile/src/components/conversationRefreshContract.test.ts
+++ b/wework-mobile/src/components/conversationRefreshContract.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+declare global {
+  interface ImportMeta {
+    glob(
+      pattern: string | string[],
+      options: { eager: true; import: 'default'; query: '?raw' }
+    ): Record<string, string>
+  }
+}
+
+const sources = import.meta.glob(['./ConversationListScreen.tsx', '../../App.tsx'], {
+  eager: true,
+  import: 'default',
+  query: '?raw',
+}) as Record<string, string>
+
+describe('conversation refresh contract', () => {
+  it('pulls only through the current runtime refresh without replacing cached rows', () => {
+    const screen = sources['./ConversationListScreen.tsx']
+    const app = sources['../../App.tsx']
+
+    expect(screen).toContain('<RefreshControl')
+    expect(screen).toContain('onRefresh={() => void props.onRefresh()}')
+    expect(screen).toContain('refreshing={props.refreshing}')
+    expect(screen).toContain('testID="conversation-list-refresh"')
+    expect(app).toContain('onRefresh={runtime.refresh}')
+    expect(app).toContain('refreshing={runtime.refreshing}')
+  })
+
+  it('separates the all-device task scope from offline-device visibility', () => {
+    const screen = sources['./ConversationListScreen.tsx']
+    const app = sources['../../App.tsx']
+
+    expect(screen).toContain('accessibilityLabel="显示所有设备任务"')
+    expect(screen).toContain('onPress={props.onSelectAllDevices}')
+    expect(screen).toContain('testID="drawer-toggle-offline-devices"')
+    expect(screen).toContain("label={showAllDevices ? '仅显示在线设备' : '显示全部设备'}")
+    expect(app).toContain('onSelectAllDevices={runtime.selectAllDevices}')
+  })
+
+  it('separates projects and standalone tasks into collapsible sections', () => {
+    const screen = sources['./ConversationListScreen.tsx']
+
+    expect(screen).toContain("title: '项目'")
+    expect(screen).toContain("title: '任务'")
+    expect(screen).toContain('onPress={() => toggleSection(item.section)}')
+    expect(screen).toContain('testID={`section-${item.section}-toggle`}')
+    expect(screen).toContain('accessibilityState={{ expanded: item.expanded }}')
+  })
+})

--- a/wework-mobile/src/domain/chatReducer.test.ts
+++ b/wework-mobile/src/domain/chatReducer.test.ts
@@ -47,6 +47,104 @@ describe('chatReducer', () => {
     })
   })
 
+  it('hides injected application context from historical and optimistic user messages', () => {
+    const runtimeContent = [
+      '<application_context>',
+      '[cloudCollaboration]',
+      'Current task: WORK-567',
+      '</application_context>',
+      '',
+      '本地启动后无法流式输出',
+    ].join('\n')
+    const historical = chatReducer([], {
+      type: 'replace',
+      messages: [{ id: 'user-history', role: 'user', content: runtimeContent }],
+    })
+    const optimistic = chatReducer(historical, {
+      type: 'optimistic-user',
+      id: 'user-live',
+      content: runtimeContent,
+      createdAt: 1788099302000,
+    })
+
+    expect(optimistic.map(message => message.content)).toEqual([
+      '本地启动后无法流式输出',
+      '本地启动后无法流式输出',
+    ])
+  })
+
+  it('prepends an older transcript page without duplicating boundary messages', () => {
+    const recent = chatReducer([], {
+      type: 'replace',
+      messages: [
+        { id: 'message-5', role: 'user', content: 'recent' },
+        { id: 'message-6', role: 'assistant', content: 'latest' },
+      ],
+    })
+    const combined = chatReducer(recent, {
+      type: 'prepend',
+      messages: [
+        { id: 'message-4', role: 'assistant', content: 'older' },
+        { id: 'message-5', role: 'user', content: 'recent' },
+      ],
+    })
+
+    expect(combined.map(message => message.id)).toEqual(['message-4', 'message-5', 'message-6'])
+  })
+
+  it('restores file change blocks and the turn summary from transcript history', () => {
+    const [message] = chatReducer([], {
+      type: 'replace',
+      messages: [
+        {
+          id: 'assistant-file-edit',
+          subtaskId: 'turn-file-edit',
+          role: 'assistant',
+          content: '已写入 abc.txt。',
+          status: 'completed',
+          blocks: [
+            {
+              id: 'apply-patch-1',
+              type: 'tool',
+              tool_name: 'apply_patch',
+              status: 'done',
+            },
+            {
+              id: 'file-changes-1',
+              type: 'file_changes',
+              status: 'done',
+              file_changes: {
+                file_count: 1,
+                additions: 1,
+                deletions: 0,
+                files: [
+                  {
+                    path: 'abc.txt',
+                    change_type: 'created',
+                    additions: 1,
+                    deletions: 0,
+                    binary: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(message).toMatchObject({
+      fileChanges: { fileCount: 1, additions: 1, deletions: 0 },
+      blocks: [
+        { type: 'tool', toolName: 'apply_patch' },
+        {
+          type: 'file_changes',
+          fileChanges: { files: [{ path: 'abc.txt', changeType: 'created' }] },
+        },
+      ],
+    })
+  })
+
   it('assembles Wework reasoning and Markdown output by subtask and item identity', () => {
     const started = stream([], {
       name: 'response.created',

--- a/wework-mobile/src/domain/chatReducer.ts
+++ b/wework-mobile/src/domain/chatReducer.ts
@@ -7,6 +7,8 @@ import type {
   RuntimeTranscriptMessage,
 } from '@/types/runtime'
 
+import { visibleRuntimeUserMessage } from './runtimeUserMessage'
+
 export interface RuntimeStreamEvent {
   name: string
   payload: Record<string, unknown>
@@ -14,6 +16,8 @@ export interface RuntimeStreamEvent {
 
 export type ChatAction =
   | { type: 'replace'; messages: RuntimeTranscriptMessage[] }
+  | { type: 'prepend'; messages: RuntimeTranscriptMessage[] }
+  | { type: 'merge-latest'; messages: RuntimeTranscriptMessage[] }
   | { type: 'optimistic-user'; id: string; content: string; createdAt: number }
   | { type: 'stream'; event: RuntimeStreamEvent }
   | { type: 'fail'; id: string; error: string }
@@ -30,6 +34,7 @@ interface BlockUpdates {
   toolOutput?: unknown
   toolOutputDelta?: string
   renderPayload?: unknown
+  fileChanges?: ChatFileChangesSummary
   status?: ChatBlockStatus
   completedAt?: number
   durationMs?: number
@@ -38,16 +43,16 @@ interface BlockUpdates {
 export function chatReducer(state: ChatMessage[], action: ChatAction): ChatMessage[] {
   switch (action.type) {
     case 'replace':
-      return uniqueMessages(
-        action.messages
-          .filter(message => ['user', 'assistant', 'system'].includes(message.role))
-          .map(toChatMessage)
-      )
+      return uniqueMessages(transcriptMessages(action.messages))
+    case 'prepend':
+      return uniqueMessages([...transcriptMessages(action.messages), ...state])
+    case 'merge-latest':
+      return uniqueMessages([...state, ...transcriptMessages(action.messages)])
     case 'optimistic-user':
       return upsertMessage(state, {
         id: action.id,
         role: 'user',
-        content: action.content,
+        content: visibleRuntimeUserMessage(action.content),
         status: 'completed',
         createdAt: action.createdAt,
       })
@@ -63,6 +68,12 @@ export function chatReducer(state: ChatMessage[], action: ChatAction): ChatMessa
   }
 }
 
+function transcriptMessages(messages: RuntimeTranscriptMessage[]): ChatMessage[] {
+  return messages
+    .filter(message => ['user', 'assistant', 'system'].includes(message.role))
+    .map(toChatMessage)
+}
+
 function toChatMessage(message: RuntimeTranscriptMessage, index: number): ChatMessage {
   const role = message.role === 'user' ? 'user' : message.role === 'system' ? 'system' : 'assistant'
   const subtaskId = idValue(message.subtaskId)
@@ -70,7 +81,9 @@ function toChatMessage(message: RuntimeTranscriptMessage, index: number): ChatMe
   const blocks = subtaskId ? normalizeBlocks(subtaskId, message.blocks, createdAt) : undefined
   const turnId = message.turnId ?? message.turn_id
   const errorType = message.errorType ?? message.error_type
-  const fileChanges = normalizeFileChanges(message.fileChanges ?? message.file_changes)
+  const fileChanges =
+    normalizeFileChanges(message.fileChanges ?? message.file_changes) ??
+    fileChangesFromBlocks(blocks)
   return {
     id:
       role === 'user'
@@ -79,7 +92,8 @@ function toChatMessage(message: RuntimeTranscriptMessage, index: number): ChatMe
     role,
     ...(subtaskId && { subtaskId }),
     ...(turnId && { turnId }),
-    content: message.content ?? '',
+    content:
+      role === 'user' ? visibleRuntimeUserMessage(message.content ?? '') : (message.content ?? ''),
     ...(blocks?.length && { blocks }),
     ...(fileChanges && { fileChanges }),
     status: terminalStatus(message.status),
@@ -184,9 +198,10 @@ function applyRuntimeEvent(state: ChatMessage[], event: RuntimeStreamEvent): Cha
     const blocks = rawBlocks
       ? normalizeBlocks(identity.subtaskId, rawBlocks, Date.now())
       : undefined
-    const fileChanges = normalizeFileChanges(
-      response.file_changes ?? response.fileChanges ?? data.file_changes ?? data.fileChanges
-    )
+    const fileChanges =
+      normalizeFileChanges(
+        response.file_changes ?? response.fileChanges ?? data.file_changes ?? data.fileChanges
+      ) ?? fileChangesFromBlocks(blocks)
     return updateAssistant(state, identity, message => ({
       ...clearError(message),
       ...(authoritativeContent !== undefined && {
@@ -302,6 +317,7 @@ function createBlock(message: ChatMessage, incoming: ChatProcessingBlock): ChatM
     content,
     textItems,
     blocks,
+    ...(incoming.type === 'file_changes' && { fileChanges: incoming.fileChanges }),
     status: isActiveStatus(incoming.status) ? 'streaming' : message.status,
     streamingThinkingContent:
       incoming.type === 'thinking' || incoming.type === 'tool'
@@ -333,6 +349,7 @@ function blockUpdates(updates: Record<string, unknown>): BlockUpdates {
   const toolOutputDelta = updates.toolOutputDelta ?? updates.tool_output_delta
   const completedAt = finiteNumber(updates.completedAt ?? updates.completed_at)
   const durationMs = finiteNumber(updates.durationMs ?? updates.duration_ms)
+  const fileChanges = normalizeFileChanges(updates.fileChanges ?? updates.file_changes)
   return {
     ...(typeof updates.content === 'string' && { content: updates.content }),
     ...(typeof contentDelta === 'string' && { contentDelta }),
@@ -344,6 +361,7 @@ function blockUpdates(updates: Record<string, unknown>): BlockUpdates {
     ...((updates.renderPayload ?? updates.render_payload) !== undefined && {
       renderPayload: updates.renderPayload ?? updates.render_payload,
     }),
+    ...(fileChanges && { fileChanges }),
     ...(typeof updates.status === 'string' && {
       status: normalizeBlockStatus(updates.status),
     }),
@@ -381,6 +399,14 @@ function updateBlock(message: ChatMessage, blockId: string, updates: BlockUpdate
         ...(updates.renderPayload !== undefined && { renderPayload: updates.renderPayload }),
       }
     }
+    if (block.type === 'file_changes') {
+      return {
+        ...block,
+        ...timing,
+        status,
+        ...(updates.fileChanges && { fileChanges: updates.fileChanges }),
+      }
+    }
     return {
       ...block,
       ...timing,
@@ -391,7 +417,7 @@ function updateBlock(message: ChatMessage, blockId: string, updates: BlockUpdate
       }),
     }
   })
-  return {
+  const updatedMessage = {
     ...clearError(message),
     blocks,
     status: updates.status && isActiveStatus(updates.status) ? 'streaming' : message.status,
@@ -402,6 +428,8 @@ function updateBlock(message: ChatMessage, blockId: string, updates: BlockUpdate
           ? undefined
           : message.streamingThinkingContent,
   }
+  const fileChanges = fileChangesFromBlocks(blocks)
+  return fileChanges ? { ...updatedMessage, fileChanges } : updatedMessage
 }
 
 function applyToolDone(
@@ -520,6 +548,17 @@ function normalizeBlock(
         kind: 'image_generation',
         ...(typeof block.result === 'string' && { imageBase64: block.result }),
       },
+      ...timing,
+    }
+  }
+  if (type === 'file_changes') {
+    const fileChanges = normalizeFileChanges(block.fileChanges ?? block.file_changes)
+    if (!fileChanges) return null
+    return {
+      id,
+      subtaskId,
+      type: 'file_changes',
+      fileChanges,
       ...timing,
     }
   }
@@ -702,6 +741,7 @@ function finalizeNarrativeBlocks(
   return (blocks ?? []).map(block => {
     if (
       block.type !== 'tool' &&
+      block.type !== 'file_changes' &&
       ['thinking', 'text', 'plan'].includes(block.type) &&
       block.status === 'streaming'
     ) {
@@ -713,6 +753,40 @@ function finalizeNarrativeBlocks(
     }
     return block
   })
+}
+
+function fileChangesFromBlocks(
+  blocks: ChatProcessingBlock[] | undefined
+): ChatFileChangesSummary | undefined {
+  const summaries = (blocks ?? []).flatMap(block =>
+    block.type === 'file_changes' ? [block.fileChanges] : []
+  )
+  if (!summaries.length) return undefined
+
+  const files = new Map<string, ChatFileChangesSummary['files'][number]>()
+  for (const summary of summaries) {
+    for (const file of summary.files) {
+      const key = `${file.oldPath ?? ''}\0${file.path}`
+      const current = files.get(key)
+      files.set(
+        key,
+        current
+          ? {
+              ...file,
+              additions: current.additions + file.additions,
+              deletions: current.deletions + file.deletions,
+              binary: current.binary || file.binary,
+            }
+          : file
+      )
+    }
+  }
+  return {
+    fileCount: files.size,
+    additions: summaries.reduce((sum, summary) => sum + summary.additions, 0),
+    deletions: summaries.reduce((sum, summary) => sum + summary.deletions, 0),
+    files: [...files.values()],
+  }
 }
 
 function finalizeBlocks(

--- a/wework-mobile/src/domain/deviceOrdering.test.ts
+++ b/wework-mobile/src/domain/deviceOrdering.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { DeviceInfo } from '@/types/runtime'
-import { onlineDevicesFirst } from './deviceOrdering'
+import { mobileOperableDevices, onlineDevicesFirst, selectedOnlineDeviceId } from './deviceOrdering'
 
 describe('onlineDevicesFirst', () => {
   it('places online and busy devices before offline devices while preserving group order', () => {
@@ -32,11 +32,39 @@ describe('onlineDevicesFirst', () => {
   })
 })
 
+describe('selectedOnlineDeviceId', () => {
+  const devices = [device('offline', 'offline'), device('first', 'online'), device('busy', 'busy')]
+
+  it('preserves the preferred online device', () => {
+    expect(selectedOnlineDeviceId(devices, 'busy')).toBe('busy')
+  })
+
+  it('selects the first online device when the preferred device is unavailable', () => {
+    expect(selectedOnlineDeviceId(devices, 'offline')).toBe('first')
+  })
+})
+
+describe('mobileOperableDevices', () => {
+  it('keeps Claude Code remote executors while removing unsupported registrations and shells', () => {
+    const devices = [
+      { ...device('app', 'online'), device_type: 'app' as const },
+      { ...device('local', 'online'), device_type: 'local' as const },
+      device('cloud', 'online'),
+      { ...device('remote', 'online'), device_type: 'remote' as const },
+      { ...device('openclaw', 'online'), bind_shell: 'openclaw' as const },
+    ]
+
+    expect(mobileOperableDevices(devices).map(item => item.device_id)).toEqual(['cloud', 'remote'])
+  })
+})
+
 function device(deviceId: string, status: DeviceInfo['status']): DeviceInfo {
   return {
     id: 1,
     device_id: deviceId,
     name: deviceId,
     status,
+    device_type: 'cloud',
+    bind_shell: 'claudecode',
   }
 }

--- a/wework-mobile/src/domain/deviceOrdering.ts
+++ b/wework-mobile/src/domain/deviceOrdering.ts
@@ -9,3 +9,23 @@ export function onlineDevicesFirst(devices: readonly DeviceInfo[]): DeviceInfo[]
   }
   return [...online, ...offline]
 }
+
+export function mobileOperableDevices(devices: readonly DeviceInfo[]): DeviceInfo[] {
+  return devices.filter(
+    device =>
+      (device.device_type === 'cloud' || device.device_type === 'remote') &&
+      device.bind_shell === 'claudecode'
+  )
+}
+
+export function selectedOnlineDeviceId(
+  devices: readonly DeviceInfo[],
+  preferredDeviceId: string | null
+): string | null {
+  const preferred = devices.find(
+    device => device.device_id === preferredDeviceId && device.status !== 'offline'
+  )
+  return (
+    preferred?.device_id ?? devices.find(device => device.status !== 'offline')?.device_id ?? null
+  )
+}

--- a/wework-mobile/src/domain/messageListScroll.test.ts
+++ b/wework-mobile/src/domain/messageListScroll.test.ts
@@ -5,6 +5,7 @@ import {
   messageListBottomOffset,
   reduceMessageListFollow,
   resolveMessageListFollow,
+  shouldLoadEarlierMessages,
 } from './messageListScroll'
 
 describe('messageListBottomOffset', () => {
@@ -102,5 +103,20 @@ describe('reduceMessageListFollow', () => {
         userInitiated: false,
       })
     ).toBe(true)
+  })
+})
+
+describe('shouldLoadEarlierMessages', () => {
+  it('loads another page when the user reaches the top', () => {
+    expect(shouldLoadEarlierMessages(metrics(32), true, false, true)).toBe(true)
+  })
+
+  it('does not auto-load during layout or while a request is active', () => {
+    expect(shouldLoadEarlierMessages(metrics(0), true, false, false)).toBe(false)
+    expect(shouldLoadEarlierMessages(metrics(0), true, true, true)).toBe(false)
+  })
+
+  it('stops loading after the server reports the beginning', () => {
+    expect(shouldLoadEarlierMessages(metrics(0), false, false, true)).toBe(false)
   })
 })

--- a/wework-mobile/src/domain/messageListScroll.ts
+++ b/wework-mobile/src/domain/messageListScroll.ts
@@ -19,6 +19,7 @@ export type MessageListFollowEvent =
     }
 
 const BOTTOM_FOLLOW_THRESHOLD = 48
+const LOAD_EARLIER_THRESHOLD = 48
 
 export function messageListBottomOffset(contentHeight: number, viewportHeight: number): number {
   return Math.max(0, contentHeight - viewportHeight)
@@ -28,6 +29,20 @@ export function isNearMessageListBottom(metrics: MessageListScrollMetrics): bool
   const distance =
     metrics.contentSize.height - metrics.layoutMeasurement.height - metrics.contentOffset.y
   return distance <= BOTTOM_FOLLOW_THRESHOLD
+}
+
+export function shouldLoadEarlierMessages(
+  metrics: MessageListScrollMetrics,
+  hasMoreBefore: boolean,
+  loadingMoreBefore: boolean,
+  userInitiated: boolean
+): boolean {
+  return (
+    userInitiated &&
+    hasMoreBefore &&
+    !loadingMoreBefore &&
+    metrics.contentOffset.y <= LOAD_EARLIER_THRESHOLD
+  )
 }
 
 export function resolveMessageListFollow({

--- a/wework-mobile/src/domain/messagePresentation.test.ts
+++ b/wework-mobile/src/domain/messagePresentation.test.ts
@@ -3,8 +3,14 @@ import { describe, expect, it } from 'vitest'
 import type { ChatProcessingBlock, ChatToolBlock } from '@/types/runtime'
 import {
   buildMessageDisplayRows,
+  buildMessageDisplaySegments,
   buildThinkingPreview,
+  generatedImagesFromBlocks,
   getToolActivityKind,
+  processingActivityStats,
+  processingDurationLabel,
+  processingSegmentTitle,
+  shouldCollapseCompletedProcessing,
 } from './messagePresentation'
 
 function tool(
@@ -56,7 +62,7 @@ describe('messagePresentation', () => {
 
     expect(buildMessageDisplayRows(blocks, '最终内容')).toMatchObject([
       { type: 'narrative', block: { id: 'text-1' } },
-      { type: 'tool-group', label: '已搜索网页 1 次' },
+      { type: 'tool-group', label: '已搜索网页' },
     ])
   })
 
@@ -67,7 +73,7 @@ describe('messagePresentation', () => {
     )
 
     expect(rows).toMatchObject([
-      { type: 'tool-group', kind: 'web', label: '已搜索网页 2 次' },
+      { type: 'tool-group', kind: 'web', label: '已搜索网页' },
       { type: 'tool-group', kind: 'file', label: '已读取 1 个文件' },
     ])
   })
@@ -79,9 +85,228 @@ describe('messagePresentation', () => {
     expect(
       getToolActivityKind(tool('read-1', 'bash', 'done', { command: 'sed -n 1,20p a.ts' }))
     ).toBe('file')
+    expect(getToolActivityKind(tool('edit-1', 'mcp__codex__edit_file'))).toBe('edit')
+    expect(getToolActivityKind(tool('read-2', 'functions.read_file'))).toBe('file')
+    expect(getToolActivityKind(tool('repl-1', 'mcp__node_repl__js'))).toBe('command')
   })
 
   it('reduces active thinking to the latest plain-text sentence', () => {
     expect(buildThinkingPreview('先分析。\n\n**现在检查** `App.tsx`！')).toBe('现在检查 App.tsx')
+  })
+
+  it('uses file change blocks instead of the redundant completed patch tool', () => {
+    const blocks: ChatProcessingBlock[] = [
+      tool('patch-1', 'apply_patch', 'done', { patch: '*** Add File: abc.txt' }),
+      {
+        id: 'files-1',
+        subtaskId: 'turn-1',
+        type: 'file_changes',
+        status: 'done',
+        createdAt: 2,
+        fileChanges: {
+          fileCount: 1,
+          additions: 1,
+          deletions: 0,
+          files: [
+            {
+              path: 'abc.txt',
+              changeType: 'created',
+              additions: 1,
+              deletions: 0,
+              binary: false,
+            },
+          ],
+        },
+      },
+    ]
+
+    expect(buildMessageDisplayRows(blocks, '完成')).toMatchObject([
+      {
+        type: 'file-changes',
+        block: { fileChanges: { files: [{ path: 'abc.txt', changeType: 'created' }] } },
+      },
+    ])
+  })
+
+  it('collapses completed processing while keeping only the final answer outside', () => {
+    const blocks = [
+      tool('search-1', 'exec_command', 'done', { cmd: 'rg abc .' }),
+      {
+        id: 'intermediate-1',
+        subtaskId: 'turn-1',
+        type: 'text' as const,
+        content: '先检查目录。',
+        status: 'done' as const,
+        createdAt: 2_000,
+      },
+    ]
+    const rows = buildMessageDisplayRows(blocks, '已经完成。')
+
+    expect(shouldCollapseCompletedProcessing(blocks, '已经完成。', rows)).toBe(true)
+    expect(processingDurationLabel(blocks, 1_000, 12_000)).toBe('已处理 11 秒')
+  })
+
+  it('matches Wework processing segments and aggregate tool stats', () => {
+    const blocks: ChatProcessingBlock[] = [
+      tool('search-1', 'exec_command', 'done', { cmd: 'rg abc src' }),
+      tool('read-1', 'read_file', 'done', { path: 'src/App.tsx' }),
+      {
+        id: 'narrative-1',
+        subtaskId: 'turn-1',
+        type: 'text',
+        content: '接着修改文件。',
+        status: 'done',
+        createdAt: 2,
+      },
+      {
+        id: 'files-1',
+        subtaskId: 'turn-1',
+        type: 'file_changes',
+        status: 'done',
+        createdAt: 3,
+        fileChanges: {
+          fileCount: 2,
+          additions: 3,
+          deletions: 1,
+          files: [
+            {
+              path: 'src/App.tsx',
+              changeType: 'modified',
+              additions: 2,
+              deletions: 1,
+              binary: false,
+            },
+            {
+              path: 'src/new.ts',
+              changeType: 'created',
+              additions: 1,
+              deletions: 0,
+              binary: false,
+            },
+          ],
+        },
+      },
+    ]
+
+    const segments = buildMessageDisplaySegments(blocks, '完成。')
+
+    expect(segments.map(segment => segment.kind)).toEqual(['tool', 'narrative', 'tool'])
+    expect(processingActivityStats(segments[0]!.rows)).toEqual({
+      command: 0,
+      file: 1,
+      search: 1,
+      edit: 0,
+      other: 0,
+    })
+    expect(processingSegmentTitle(segments[0]!.rows)).toBe('调用 2 个工具')
+    expect(processingSegmentTitle(segments[2]!.rows)).toBe('编辑 2 个文件')
+  })
+
+  it('keeps every supported special block in the same presentation pipeline', () => {
+    const request = tool('request-1', 'request_user_input')
+    request.renderPayload = {
+      kind: 'request_user_input',
+      questions: [{ header: '选择', question: '继续吗？', options: [{ label: '继续' }] }],
+    }
+    const image = tool('image-1', 'image_generation')
+    image.renderPayload = {
+      kind: 'image_generation',
+      imageBase64: 'aW1hZ2U=',
+      revisedPrompt: 'A generated preview',
+    }
+    const blocks: ChatProcessingBlock[] = [
+      {
+        id: 'thinking-1',
+        subtaskId: 'turn-1',
+        type: 'thinking',
+        content: '内部思考',
+        status: 'done',
+        createdAt: 1,
+      },
+      tool('guidance-1', 'conversation_guidance'),
+      tool('compact-1', 'contextcompaction'),
+      request,
+      image,
+      {
+        id: 'plan-1',
+        subtaskId: 'turn-1',
+        type: 'plan',
+        content: '执行计划',
+        status: 'done',
+        createdAt: 2,
+      },
+      {
+        id: 'error-1',
+        subtaskId: 'turn-1',
+        type: 'error',
+        content: '执行失败',
+        status: 'error',
+        createdAt: 3,
+      },
+    ]
+
+    const segments = buildMessageDisplaySegments(blocks, '')
+    const visibleIds = segments.flatMap(segment => segment.rows.map(row => row.id))
+
+    expect(visibleIds.some(id => id.includes('thinking-1'))).toBe(false)
+    expect(visibleIds).toContain('guidance-1')
+    expect(visibleIds).toContain('compact-1')
+    expect(visibleIds).toContain('request-1')
+    expect(visibleIds).toContain('image-1')
+    expect(visibleIds).toContain('plan-1')
+    expect(visibleIds).toContain('error-1')
+    expect(generatedImagesFromBlocks(blocks)).toEqual([
+      {
+        id: 'image-1',
+        uri: 'data:image/png;base64,aW1hZ2U=',
+        alt: 'A generated preview',
+      },
+    ])
+  })
+
+  it('hides transport-only tools but preserves an active reconnect indicator', () => {
+    const rows = buildMessageDisplayRows(
+      [
+        tool('stdin-1', 'write_stdin'),
+        tool('reconnect-done', 'runtime_reconnecting'),
+        tool('reconnect-live', 'runtime_reconnecting', 'streaming'),
+      ],
+      ''
+    )
+
+    expect(rows).toMatchObject([{ type: 'tool', id: 'reconnect-live' }])
+  })
+
+  it('merges consecutive file change snapshots like Wework', () => {
+    const makeFileChange = (id: string, additions: number): ChatProcessingBlock => ({
+      id,
+      subtaskId: 'turn-1',
+      type: 'file_changes',
+      status: 'done',
+      createdAt: additions,
+      fileChanges: {
+        fileCount: 1,
+        additions,
+        deletions: 0,
+        files: [
+          {
+            path: 'src/App.tsx',
+            changeType: 'modified',
+            additions,
+            deletions: 0,
+            binary: false,
+          },
+        ],
+      },
+    })
+
+    expect(
+      buildMessageDisplayRows([makeFileChange('files-1', 1), makeFileChange('files-2', 2)], '')
+    ).toMatchObject([
+      {
+        type: 'file-changes',
+        block: { fileChanges: { fileCount: 1, additions: 3, files: [{ additions: 3 }] } },
+      },
+    ])
   })
 })

--- a/wework-mobile/src/domain/messagePresentation.ts
+++ b/wework-mobile/src/domain/messagePresentation.ts
@@ -1,11 +1,19 @@
-import type { ChatProcessingBlock, ChatToolBlock } from '@/types/runtime'
+import type {
+  ChatFileChangeItem,
+  ChatFileChangesBlock,
+  ChatFileChangesSummary,
+  ChatNarrativeBlock,
+  ChatProcessingBlock,
+  ChatToolBlock,
+} from '@/types/runtime'
 
 export type ToolActivityKind =
   'web' | 'file' | 'search' | 'command' | 'create' | 'edit' | 'guidance' | 'tool'
 
 export type MessageDisplayRow =
-  | { type: 'narrative'; id: string; block: Exclude<ChatProcessingBlock, ChatToolBlock> }
+  | { type: 'narrative'; id: string; block: ChatNarrativeBlock }
   | { type: 'tool'; id: string; block: ChatToolBlock; kind: ToolActivityKind }
+  | { type: 'file-changes'; id: string; block: ChatFileChangesBlock }
   | {
       type: 'tool-group'
       id: string
@@ -14,6 +22,26 @@ export type MessageDisplayRow =
       label: string
       failed: boolean
     }
+
+export interface MessageDisplaySegment {
+  id: string
+  kind: 'tool' | 'narrative'
+  rows: MessageDisplayRow[]
+}
+
+export interface ProcessingActivityStats {
+  command: number
+  file: number
+  search: number
+  edit: number
+  other: number
+}
+
+export interface GeneratedImageArtifact {
+  id: string
+  uri: string
+  alt: string
+}
 
 const COMMAND_TOOLS = new Set([
   'bash',
@@ -38,57 +66,160 @@ const EDIT_TOOLS = new Set([
   'apply_patch',
   'functions.apply_patch',
 ])
+const PATCH_TOOLS = new Set(['apply_patch', 'functions.apply_patch'])
 const GUIDANCE_TOOLS = new Set(['conversation_guidance', 'user_guidance'])
-const HIDDEN_TOOLS = new Set(['write_stdin', 'functions.write_stdin', 'runtime_reconnecting'])
+const CONTEXT_COMPACTION_TOOLS = new Set(['context_compaction', 'contextcompaction'])
+const HIDDEN_TOOLS = new Set(['write_stdin', 'functions.write_stdin'])
 const SEARCH_COMMANDS = new Set(['rg', 'grep', 'find', 'fd', 'ls', 'tree', 'ag', 'ack'])
 const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'file'])
 
 export function buildMessageDisplayRows(
   blocks: ChatProcessingBlock[] | undefined,
-  finalContent: string
+  finalContent: string,
+  options: { groupCompletedTools?: boolean } = {}
 ): MessageDisplayRow[] {
+  const source = blocks ?? []
+  const groupCompletedTools = options.groupCompletedTools ?? true
   const rows: MessageDisplayRow[] = []
+  const hasFileChanges = source.some(block => block.type === 'file_changes')
   let completedTools: ChatToolBlock[] = []
-  let completedKind: ToolActivityKind | null = null
+  let completedGroupKey: string | null = null
+  let consecutiveFileChanges: ChatFileChangesBlock[] = []
 
   const flushCompletedTools = () => {
-    if (!completedTools.length || !completedKind) return
+    if (!completedTools.length) return
+    const kind = getGroupKind(completedTools)
     rows.push({
       type: 'tool-group',
       id: `tool-group-${completedTools[0]?.id}-${completedTools.at(-1)?.id}`,
       blocks: completedTools,
-      kind: completedKind,
-      label: summarizeToolActivity(completedTools, completedKind),
+      kind,
+      label: summarizeToolActivity(completedTools),
       failed: completedTools.some(block => block.status === 'error'),
     })
     completedTools = []
-    completedKind = null
+    completedGroupKey = null
   }
 
-  for (const block of blocks ?? []) {
-    if (block.type === 'thinking') continue
-    if (block.type !== 'tool') {
-      flushCompletedTools()
-      if (block.type === 'text' && block.content.trim() === finalContent.trim()) continue
-      if (block.content.trim()) rows.push({ type: 'narrative', id: block.id, block })
-      continue
-    }
-    if (isHiddenTool(block)) continue
+  const flushFileChanges = () => {
+    if (!consecutiveFileChanges.length) return
+    const block = mergeFileChangesBlocks(consecutiveFileChanges)
+    rows.push({ type: 'file-changes', id: block.id, block })
+    consecutiveFileChanges = []
+  }
 
-    const kind = getToolActivityKind(block)
-    const completed = block.status === 'done' || block.status === 'error'
-    if (!completed) {
+  for (const block of source) {
+    if (block.type === 'thinking') continue
+    if (block.type === 'tool' && isHiddenTool(block)) continue
+    if (hasFileChanges && block.type === 'tool' && isCompletedPatchTool(block)) continue
+
+    if (block.type === 'file_changes') {
       flushCompletedTools()
-      rows.push({ type: 'tool', id: block.id, block, kind })
+      consecutiveFileChanges.push(block)
       continue
     }
-    if (completedKind && completedKind !== kind) flushCompletedTools()
-    completedKind = kind
-    completedTools.push(block)
+
+    if (block.type === 'tool') {
+      flushFileChanges()
+      const completed = block.status === 'done' || block.status === 'error'
+      if (!groupCompletedTools || !completed || isStandaloneTool(block)) {
+        flushCompletedTools()
+        rows.push({ type: 'tool', id: block.id, block, kind: getToolActivityKind(block) })
+        continue
+      }
+
+      const groupKey = toolActivityGroupKey(block)
+      if (completedGroupKey && completedGroupKey !== groupKey) flushCompletedTools()
+      completedGroupKey = groupKey
+      completedTools.push(block)
+      continue
+    }
+
+    flushCompletedTools()
+    flushFileChanges()
+    if (block.type === 'text' && block.content.trim() === finalContent.trim()) continue
+    if (block.content.trim()) rows.push({ type: 'narrative', id: block.id, block })
   }
 
   flushCompletedTools()
+  flushFileChanges()
   return rows
+}
+
+export function buildMessageDisplaySegments(
+  blocks: ChatProcessingBlock[] | undefined,
+  finalContent: string
+): MessageDisplaySegment[] {
+  const source = blocks ?? []
+  const segments: Array<{ kind: MessageDisplaySegment['kind']; blocks: ChatProcessingBlock[] }> = []
+
+  for (const block of source) {
+    const kind = isCollapsibleToolBlock(block) ? 'tool' : 'narrative'
+    const previous = segments.at(-1)
+    if (previous?.kind === kind) previous.blocks.push(block)
+    else segments.push({ kind, blocks: [block] })
+  }
+
+  return segments.flatMap((segment, index) => {
+    const rows = buildMessageDisplayRows(segment.blocks, finalContent, {
+      groupCompletedTools: segment.kind === 'tool',
+    })
+    return rows.length
+      ? [{ id: `${segment.kind}-${index}-${rows[0]?.id}`, kind: segment.kind, rows }]
+      : []
+  })
+}
+
+export function processingActivityStats(rows: MessageDisplayRow[]): ProcessingActivityStats {
+  const stats: ProcessingActivityStats = { command: 0, file: 0, search: 0, edit: 0, other: 0 }
+  const addTool = (block: ChatToolBlock) => {
+    const kind = getToolActivityKind(block)
+    if (kind === 'command') stats.command += 1
+    else if (kind === 'file') stats.file += 1
+    else if (kind === 'search' || kind === 'web') stats.search += 1
+    else if (kind === 'edit' || kind === 'create') stats.edit += 1
+    else stats.other += 1
+  }
+
+  for (const row of rows) {
+    if (row.type === 'tool-group') row.blocks.forEach(addTool)
+    else if (row.type === 'tool') addTool(row.block)
+    else if (row.type === 'file-changes') {
+      stats.edit += row.block.fileChanges.fileCount || row.block.fileChanges.files.length
+    }
+  }
+  return stats
+}
+
+export function processingSegmentTitle(rows: MessageDisplayRow[]): string {
+  const stats = processingActivityStats(rows)
+  const toolCount = stats.command + stats.file + stats.search + stats.other
+  const onlyEdits = stats.edit > 0 && toolCount === 0
+  if (onlyEdits) return `编辑 ${stats.edit} 个文件`
+  if (stats.edit > 0) return `编辑 ${stats.edit} 个文件，调用 ${toolCount} 个工具`
+  return `调用 ${toolCount} 个工具`
+}
+
+export function generatedImagesFromBlocks(
+  blocks: ChatProcessingBlock[] | undefined
+): GeneratedImageArtifact[] {
+  return (blocks ?? []).flatMap(block => {
+    if (block.type !== 'tool' || normalizeToolName(block.toolName) !== 'image_generation') return []
+    const payload = asRecord(block.renderPayload)
+    const image = payload.imageBase64
+    if (typeof image !== 'string' || !image.trim()) return []
+    const revisedPrompt = payload.revisedPrompt
+    return [
+      {
+        id: block.id,
+        uri: image.startsWith('data:') ? image : `data:image/png;base64,${image}`,
+        alt:
+          typeof revisedPrompt === 'string' && revisedPrompt.trim()
+            ? revisedPrompt
+            : 'Generated image',
+      },
+    ]
+  })
 }
 
 export function getToolActivityKind(block: ChatToolBlock): ToolActivityKind {
@@ -99,35 +230,57 @@ export function getToolActivityKind(block: ChatToolBlock): ToolActivityKind {
   if (matchesToolName(name, EDIT_TOOLS)) return 'edit'
   if (matchesToolName(name, GUIDANCE_TOOLS)) return 'guidance'
   if (['search', 'grep', 'glob'].some(hint => name.includes(hint))) return 'search'
+  if (isNodeReplTool(name)) return 'command'
   if (matchesToolName(name, COMMAND_TOOLS)) return commandActivityKind(commandFrom(block))
   return 'tool'
 }
 
-export function summarizeToolActivity(
-  blocks: ChatToolBlock[],
-  kind = getGroupKind(blocks)
-): string {
-  const count = blocks.length
-  const failed = blocks.some(block => block.status === 'error')
-  if (failed) return kind === 'command' ? `运行失败 ${count} 条命令` : `执行失败 ${count} 个工具`
-  switch (kind) {
-    case 'web':
-      return `已搜索网页 ${count} 次`
-    case 'file':
-      return `已读取 ${count} 个文件`
-    case 'search':
-      return `已搜索代码 ${count} 次`
-    case 'command':
-      return `已运行 ${count} 条命令`
-    case 'create':
-      return `已新增 ${count} 个文件`
-    case 'edit':
-      return `已编辑 ${count} 个文件`
-    case 'guidance':
-      return '已引导对话'
-    case 'tool':
-      return `已调用 ${count} 个工具`
+export function summarizeToolActivity(blocks: ChatToolBlock[]): string {
+  if (
+    blocks.length > 0 &&
+    blocks.every(block => normalizeToolName(block.toolName) === 'web_search')
+  ) {
+    return '已搜索网页'
   }
+
+  const labels: string[] = []
+  const counts = activityCounts(blocks)
+  if (counts.file) labels.push(`已读取 ${counts.file} 个文件`)
+  if (counts.search) labels.push('已搜索代码')
+  if (counts.create) labels.push(`已新增 ${counts.create} 个文件`)
+  if (counts.edit) labels.push(`已编辑 ${counts.edit} 个文件`)
+  if (counts.guidance) labels.push('已引导对话')
+  if (counts.command) labels.push(`已运行 ${counts.command} 条命令`)
+  if (counts.tool) labels.push(`已调用 ${counts.tool} 个工具`)
+  if (counts.failedCommand) labels.push(`运行失败 ${counts.failedCommand} 条命令`)
+  if (counts.failedTool) labels.push(`执行失败 ${counts.failedTool} 个工具`)
+  return labels.join(' ') || `已调用 ${blocks.length} 个工具`
+}
+
+export function processingDurationLabel(
+  blocks: ChatProcessingBlock[] | undefined,
+  messageCreatedAt: number,
+  messageCompletedAt?: number
+): string {
+  const visible = blocks?.filter(block => block.type !== 'thinking') ?? []
+  const first = visible[0]?.createdAt ?? messageCreatedAt
+  const last = visible.at(-1)
+  const end = messageCompletedAt ?? last?.completedAt ?? last?.createdAt ?? first
+  const durationMs = Math.max(0, end - first)
+  return durationMs < 1000 ? '已处理' : `已处理 ${formatDuration(durationMs)}`
+}
+
+export function shouldCollapseCompletedProcessing(
+  blocks: ChatProcessingBlock[] | undefined,
+  finalContent: string,
+  rows: MessageDisplayRow[]
+): boolean {
+  return (
+    Boolean(finalContent.trim()) &&
+    rows.length > 0 &&
+    !blocks?.some(block => block.type === 'plan' && block.content.trim()) &&
+    !blocks?.some(block => block.status !== 'done' && block.status !== 'error')
+  )
 }
 
 export function buildThinkingPreview(content: string, maximumLength = 96): string {
@@ -148,15 +301,79 @@ export function buildThinkingPreview(content: string, maximumLength = 96): strin
     : `${preview.slice(0, Math.max(0, maximumLength - 3))}...`
 }
 
+export function fileChangeLabel(file: ChatFileChangeItem, running: boolean): string {
+  const filename = basename(file.path)
+  if (running) {
+    if (file.changeType === 'created') return `正在创建 ${filename}`
+    if (file.changeType === 'deleted') return `正在删除 ${filename}`
+    if (file.changeType === 'renamed') return `正在重命名 ${filename}`
+    return `正在编辑 ${filename}`
+  }
+  if (file.changeType === 'created') return `已创建 ${filename}`
+  if (file.changeType === 'deleted') return `已删除 ${filename}`
+  if (file.changeType === 'renamed') return `已重命名 ${filename}`
+  return `已编辑 ${filename}`
+}
+
+function activityCounts(blocks: ChatToolBlock[]) {
+  const counts = {
+    file: 0,
+    search: 0,
+    command: 0,
+    create: 0,
+    edit: 0,
+    guidance: 0,
+    tool: 0,
+    failedCommand: 0,
+    failedTool: 0,
+  }
+  for (const block of blocks) {
+    const kind = getToolActivityKind(block)
+    if (block.status === 'error') {
+      if (kind === 'command') counts.failedCommand += 1
+      else counts.failedTool += 1
+      continue
+    }
+    if (kind === 'web' || kind === 'search') counts.search += 1
+    else counts[kind] += 1
+  }
+  return counts
+}
+
 function getGroupKind(blocks: ChatToolBlock[]): ToolActivityKind {
   const kinds = blocks.map(getToolActivityKind)
-  const first = kinds[0]
-  return first && kinds.every(kind => kind === first) ? first : 'tool'
+  const primary = kinds.filter(kind => kind !== 'tool')
+  const first = primary[0]
+  return first && primary.every(kind => kind === first) ? first : 'tool'
+}
+
+function toolActivityGroupKey(block: ChatToolBlock): string {
+  return normalizeToolName(block.toolName) === 'web_search'
+    ? 'web-search'
+    : getToolActivityKind(block)
+}
+
+function isCompletedPatchTool(block: ChatToolBlock): boolean {
+  return block.status === 'done' && matchesToolName(normalizeToolName(block.toolName), PATCH_TOOLS)
+}
+
+function isStandaloneTool(block: ChatToolBlock): boolean {
+  const name = normalizeToolName(block.toolName)
+  if (matchesToolName(name, CONTEXT_COMPACTION_TOOLS)) return true
+  const payload = asRecord(block.renderPayload)
+  return payload.kind === 'request_user_input' || payload.kind === 'image_generation'
+}
+
+function isCollapsibleToolBlock(block: ChatProcessingBlock): boolean {
+  if (block.type === 'file_changes') return true
+  if (block.type !== 'tool') return false
+  const name = normalizeToolName(block.toolName)
+  return !matchesToolName(name, GUIDANCE_TOOLS) && !matchesToolName(name, CONTEXT_COMPACTION_TOOLS)
 }
 
 function isHiddenTool(block: ChatToolBlock): boolean {
   const name = normalizeToolName(block.toolName)
-  return HIDDEN_TOOLS.has(name)
+  return HIDDEN_TOOLS.has(name) || (name === 'runtime_reconnecting' && block.status === 'done')
 }
 
 function commandActivityKind(command?: string): ToolActivityKind {
@@ -175,11 +392,71 @@ function commandActivityKind(command?: string): ToolActivityKind {
 }
 
 function commandFrom(block: ChatToolBlock): string | undefined {
-  for (const key of ['command', 'cmd', 'commandLine']) {
+  for (const key of ['command', 'cmd', 'commandLine', 'code']) {
     const value = block.toolInput?.[key]
     if (typeof value === 'string') return value
   }
   return undefined
+}
+
+function mergeFileChangesBlocks(blocks: ChatFileChangesBlock[]): ChatFileChangesBlock {
+  if (blocks.length === 1) return blocks[0] as ChatFileChangesBlock
+  const first = blocks[0] as ChatFileChangesBlock
+  const latest = blocks.at(-1) as ChatFileChangesBlock
+  const summary = mergeFileChangesSummaries(blocks.map(block => block.fileChanges))
+  return {
+    ...latest,
+    id: `file-changes-${first.id}`,
+    createdAt: Math.min(...blocks.map(block => block.createdAt)),
+    fileChanges: summary,
+  }
+}
+
+function mergeFileChangesSummaries(summaries: ChatFileChangesSummary[]): ChatFileChangesSummary {
+  const files = new Map<string, ChatFileChangeItem>()
+  for (const summary of summaries) {
+    for (const file of summary.files) {
+      const key = `${file.oldPath ?? ''}\0${file.path}`
+      const existing = files.get(key)
+      files.set(
+        key,
+        existing
+          ? {
+              ...file,
+              additions: existing.additions + file.additions,
+              deletions: existing.deletions + file.deletions,
+              binary: existing.binary || file.binary,
+            }
+          : file
+      )
+    }
+  }
+  return {
+    fileCount: files.size,
+    additions: summaries.reduce((sum, summary) => sum + summary.additions, 0),
+    deletions: summaries.reduce((sum, summary) => sum + summary.deletions, 0),
+    files: [...files.values()],
+  }
+}
+
+function formatDuration(durationMs: number): string {
+  const seconds = Math.floor(durationMs / 1000)
+  if (seconds < 60) return `${seconds} 秒`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60)
+    return remainingSeconds ? `${minutes} 分 ${remainingSeconds} 秒` : `${minutes} 分钟`
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes ? `${hours} 小时 ${remainingMinutes} 分钟` : `${hours} 小时`
+}
+
+function basename(path: string): string {
+  return path.replace(/\\/g, '/').split('/').filter(Boolean).at(-1) ?? path
+}
+
+function isNodeReplTool(name: string): boolean {
+  return name === 'node_repl.js' || name === 'node_repl__js' || name.endsWith('__node_repl__js')
 }
 
 function matchesToolName(name: string, names: Set<string>): boolean {
@@ -190,4 +467,10 @@ function matchesToolName(name: string, names: Set<string>): boolean {
 
 function normalizeToolName(name: string): string {
   return name.trim().toLowerCase()
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
 }

--- a/wework-mobile/src/domain/runtimeUserMessage.test.ts
+++ b/wework-mobile/src/domain/runtimeUserMessage.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { splitRuntimeUserMessage, visibleRuntimeUserMessage } from './runtimeUserMessage'
+
+describe('runtime user message', () => {
+  it('extracts visible input from attachment and application context wrappers', () => {
+    const content = [
+      '# Files mentioned by the user:',
+      '',
+      '## image.png: /tmp/image.png',
+      '',
+      '## My request for Codex:',
+      '<application_context>',
+      '[wework.terminal.current]',
+      'terminal state',
+      '</application_context>',
+      '',
+      'Fix the sidebar',
+    ].join('\n')
+
+    expect(splitRuntimeUserMessage(content)).toEqual({
+      prefix: '# Files mentioned by the user:\n\n## image.png: /tmp/image.png\n\n',
+      request: 'Fix the sidebar',
+    })
+    expect(visibleRuntimeUserMessage(content)).toBe('Fix the sidebar')
+  })
+
+  it('removes application context without an attachment wrapper', () => {
+    expect(
+      visibleRuntimeUserMessage(
+        '<application_context>\n[terminal]\nstate\n</application_context>\n\nContinue fixing'
+      )
+    ).toBe('Continue fixing')
+  })
+
+  it('removes a complete wrapper containing nested application contexts', () => {
+    const referencedConversation = JSON.stringify([
+      {
+        role: 'user',
+        content:
+          '<application_context>\\n[source]\\nsource state\\n</application_context>\\n\\nOriginal question',
+      },
+    ])
+    const content = [
+      '<application_context>',
+      '[referencedConversations]',
+      referencedConversation,
+      '</application_context>',
+      '',
+      'Continue with the referenced conversation',
+    ].join('\n')
+
+    expect(visibleRuntimeUserMessage(content)).toBe('Continue with the referenced conversation')
+  })
+
+  it('preserves malformed context instead of dropping user content', () => {
+    expect(visibleRuntimeUserMessage('<application_context>\nuser text')).toBe(
+      '<application_context>\nuser text'
+    )
+  })
+})

--- a/wework-mobile/src/domain/runtimeUserMessage.ts
+++ b/wework-mobile/src/domain/runtimeUserMessage.ts
@@ -1,0 +1,58 @@
+const CODEX_REQUEST_MARKER_PATTERN = /^## My request for Codex:\s*$/im
+const APPLICATION_CONTEXT_OPEN = '<application_context>'
+const APPLICATION_CONTEXT_CLOSE = '</application_context>'
+
+export interface RuntimeUserMessageParts {
+  prefix: string
+  request: string
+}
+
+export function splitRuntimeUserMessage(content: string): RuntimeUserMessageParts | null {
+  const requestMarker = content.match(CODEX_REQUEST_MARKER_PATTERN)
+  if (requestMarker?.index === undefined) return null
+
+  return {
+    prefix: content.slice(0, requestMarker.index),
+    request: stripLeadingApplicationContext(
+      content.slice(requestMarker.index + requestMarker[0].length)
+    ),
+  }
+}
+
+export function visibleRuntimeUserMessage(content: string): string {
+  const parts = splitRuntimeUserMessage(content)
+  return parts?.request ?? stripLeadingApplicationContext(content)
+}
+
+function stripLeadingApplicationContext(content: string): string {
+  const trimmed = content.trimStart()
+  if (!trimmed.startsWith(APPLICATION_CONTEXT_OPEN)) return trimmed.trim()
+
+  const closeIndex = matchingApplicationContextCloseIndex(trimmed)
+  if (closeIndex < 0) return trimmed.trim()
+
+  return trimmed.slice(closeIndex + APPLICATION_CONTEXT_CLOSE.length).trim()
+}
+
+function matchingApplicationContextCloseIndex(content: string): number {
+  let depth = 1
+  let offset = APPLICATION_CONTEXT_OPEN.length
+
+  while (offset < content.length) {
+    const nextOpen = content.indexOf(APPLICATION_CONTEXT_OPEN, offset)
+    const nextClose = content.indexOf(APPLICATION_CONTEXT_CLOSE, offset)
+    if (nextClose < 0) return -1
+
+    if (nextOpen >= 0 && nextOpen < nextClose) {
+      depth += 1
+      offset = nextOpen + APPLICATION_CONTEXT_OPEN.length
+      continue
+    }
+
+    depth -= 1
+    if (depth === 0) return nextClose
+    offset = nextClose + APPLICATION_CONTEXT_CLOSE.length
+  }
+
+  return -1
+}

--- a/wework-mobile/src/domain/runtimeWorkAdapter.test.ts
+++ b/wework-mobile/src/domain/runtimeWorkAdapter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { adaptRuntimeWorkListResponse } from './runtimeWorkAdapter'
+
+describe('adaptRuntimeWorkListResponse', () => {
+  it('matches the Mac cloud-device grouping and preserves runtime metadata', () => {
+    const result = adaptRuntimeWorkListResponse(
+      {
+        workspaces: [
+          {
+            workspacePath: '/work/Wegent',
+            projectKey: 'project:wegent',
+            label: 'Wegent',
+            workspaceKind: 'workspace',
+            tasks: [
+              {
+                task_id: 41,
+                thread_id: 'thread-1',
+                title: 'Fix mobile loading',
+                runtime: 'codex',
+                workspace_kind: 'worktree',
+                worktree_id: '4159',
+                updated_at: '2026-09-04T01:00:00Z',
+              },
+            ],
+          },
+          {
+            workspacePath: '/chat/one',
+            workspaceKind: 'chat',
+            tasks: [],
+          },
+        ],
+      },
+      'device-1',
+      'Mac Studio'
+    )
+
+    expect(result.totalTasks).toBe(1)
+    expect(result.projects[0]).toMatchObject({
+      project: { key: 'project:wegent', name: 'Wegent', stateDeviceId: 'device-1' },
+      deviceWorkspaces: [
+        {
+          deviceId: 'device-1',
+          deviceName: 'Mac Studio',
+          tasks: [
+            {
+              taskId: '41',
+              threadId: 'thread-1',
+              workspaceKind: 'worktree',
+              worktreeId: '4159',
+            },
+          ],
+        },
+      ],
+    })
+    expect(result.chats).toHaveLength(1)
+  })
+
+  it('does not let an empty remote projection replace its local owner workspace', () => {
+    const result = adaptRuntimeWorkListResponse(
+      {
+        workspaces: [
+          { workspacePath: '/local/Wegent', label: 'Wegent', workspaceSource: 'local', tasks: [] },
+          {
+            workspacePath: '/remote/Wegent',
+            label: 'Wegent',
+            workspaceSource: 'remote',
+            remoteHostId: 'remote-device',
+            tasks: [],
+          },
+        ],
+      },
+      'device-1'
+    )
+
+    expect(result.projects).toHaveLength(1)
+    expect(result.projects[0]?.deviceWorkspaces[0]?.deviceId).toBe('device-1')
+  })
+})

--- a/wework-mobile/src/domain/runtimeWorkAdapter.ts
+++ b/wework-mobile/src/domain/runtimeWorkAdapter.ts
@@ -1,0 +1,196 @@
+import type {
+  RuntimeDeviceWorkspace,
+  RuntimeTaskSummary,
+  RuntimeWorkListResponse,
+} from '@/types/runtime'
+
+export function adaptRuntimeWorkListResponse(
+  response: unknown,
+  deviceId: string,
+  deviceName = 'Cloud Executor'
+): RuntimeWorkListResponse {
+  const record = recordValue(response)
+  if (Array.isArray(record.projects) && Array.isArray(record.chats)) {
+    return normalizeProjectedWork(
+      record as unknown as RuntimeWorkListResponse,
+      deviceId,
+      deviceName
+    )
+  }
+
+  const workspaces = Array.isArray(record.workspaces)
+    ? record.workspaces
+    : Object.entries(recordValue(record.workspaces)).map(([workspacePath, workspace]) => ({
+        ...recordValue(workspace),
+        workspacePath,
+      }))
+  const projects: RuntimeWorkListResponse['projects'] = []
+  const projectsByKey = new Map<string, RuntimeWorkListResponse['projects'][number]>()
+  const chats: RuntimeWorkListResponse['chats'] = []
+  const localWorkspaceLabels = new Set<string>()
+  let totalTasks = 0
+
+  for (const rawWorkspace of workspaces) {
+    const workspace = recordValue(rawWorkspace)
+    const workspacePath = workspacePathValue(workspace)
+    if (!workspacePath) continue
+    const workspaceSource = stringValue(workspace.workspaceSource ?? workspace.workspace_source)
+    if (!workspaceSource || workspaceSource === 'local') {
+      localWorkspaceLabels.add(workspaceLabel(workspacePath, workspace.label))
+    }
+  }
+
+  for (const rawWorkspace of workspaces) {
+    const workspace = recordValue(rawWorkspace)
+    const workspacePath = workspacePathValue(workspace)
+    if (!workspacePath) continue
+    const tasks = normalizeTasks(workspace.tasks, workspacePath)
+    const workspaceKind =
+      stringValue(workspace.workspaceKind ?? workspace.workspace_kind) ??
+      (tasks.some(task => task.workspaceKind === 'chat') ? 'chat' : 'workspace')
+    const label = workspaceLabel(workspacePath, workspace.label)
+    const workspaceSource = stringValue(workspace.workspaceSource ?? workspace.workspace_source)
+    const remoteHostId = stringValue(workspace.remoteHostId ?? workspace.remote_host_id)
+    const workspaceDeviceId = workspaceSource === 'remote' && remoteHostId ? remoteHostId : deviceId
+    if (tasks.length === 0 && workspaceSource === 'remote' && localWorkspaceLabels.has(label)) {
+      continue
+    }
+
+    const deviceWorkspace: RuntimeDeviceWorkspace = {
+      id: stableLocalId(`${workspaceDeviceId}\0${workspacePath}`),
+      projectId: null,
+      deviceId: workspaceDeviceId,
+      deviceName: remoteHostId ?? deviceName,
+      deviceStatus: workspaceDeviceId === deviceId ? 'online' : 'offline',
+      available: workspaceDeviceId === deviceId,
+      workspacePath,
+      workspaceKind,
+      worktreeId: stringValue(workspace.worktreeId ?? workspace.worktree_id),
+      label,
+      workspaceSource,
+      remoteHostId,
+      mapped: true,
+      tasks,
+    }
+    totalTasks += tasks.length
+
+    if (workspaceKind === 'chat') {
+      chats.push(deviceWorkspace)
+      continue
+    }
+
+    const projectKey =
+      stringValue(workspace.projectKey ?? workspace.project_key) ?? `local:${workspacePath}`
+    const existing = projectsByKey.get(projectKey)
+    if (existing) {
+      existing.deviceWorkspaces.push(deviceWorkspace)
+      existing.totalTasks = (existing.totalTasks ?? 0) + tasks.length
+      continue
+    }
+    const project = {
+      project: {
+        id: stableLocalId(`${deviceId}\0${projectKey}`),
+        key: projectKey,
+        name: label,
+        stateDeviceId: deviceId,
+      },
+      deviceWorkspaces: [deviceWorkspace],
+      totalTasks: tasks.length,
+    }
+    projectsByKey.set(projectKey, project)
+    projects.push(project)
+  }
+
+  return { projects, chats, totalTasks }
+}
+
+function normalizeProjectedWork(
+  work: RuntimeWorkListResponse,
+  deviceId: string,
+  deviceName: string
+): RuntimeWorkListResponse {
+  const normalizeWorkspace = (workspace: RuntimeDeviceWorkspace): RuntimeDeviceWorkspace => ({
+    ...workspace,
+    deviceId,
+    deviceName: workspace.deviceName || deviceName,
+    deviceStatus: workspace.deviceStatus || 'online',
+    available: workspace.available !== false,
+    tasks: normalizeTasks(workspace.tasks, workspace.workspacePath),
+  })
+  return {
+    ...work,
+    projects: work.projects.map(project => ({
+      ...project,
+      project: { ...project.project, stateDeviceId: project.project.stateDeviceId ?? deviceId },
+      deviceWorkspaces: project.deviceWorkspaces.map(normalizeWorkspace),
+    })),
+    chats: work.chats.map(normalizeWorkspace),
+  }
+}
+
+function normalizeTasks(value: unknown, fallbackWorkspacePath: string): RuntimeTaskSummary[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap(item => {
+    const task = recordValue(item)
+    const taskId = idValue(task.taskId ?? task.task_id)
+    if (!taskId) return []
+    const workspacePath = workspacePathValue(task) ?? fallbackWorkspacePath
+    const workspaceKind = stringValue(task.workspaceKind ?? task.workspace_kind)
+    const worktreeId = stringValue(task.worktreeId ?? task.worktree_id)
+    const threadId = stringValue(task.threadId ?? task.thread_id)
+    return [
+      {
+        ...task,
+        taskId,
+        title: stringValue(task.title) ?? taskId,
+        runtime: stringValue(task.runtime) ?? 'codex',
+        workspacePath,
+        ...(threadId ? { threadId } : {}),
+        ...(workspaceKind ? { workspaceKind } : {}),
+        ...(worktreeId ? { worktreeId } : {}),
+        updatedAt: timestampValue(task.updatedAt ?? task.updated_at),
+        createdAt: timestampValue(task.createdAt ?? task.created_at),
+      } as RuntimeTaskSummary,
+    ]
+  })
+}
+
+function workspacePathValue(value: Record<string, unknown>): string | null {
+  return stringValue(
+    value.workspacePath ??
+      value.workspace_path ??
+      value.projectWorkspacePath ??
+      value.project_workspace_path ??
+      value.cwd ??
+      value.path
+  )
+}
+
+function workspaceLabel(workspacePath: string, value: unknown): string {
+  return stringValue(value) ?? workspacePath.split('/').filter(Boolean).at(-1) ?? workspacePath
+}
+
+function stableLocalId(value: string): number {
+  let hash = 0
+  for (const character of value) hash = (hash * 31 + character.charCodeAt(0)) >>> 0
+  return (hash % 1_000_000_000) + 1
+}
+
+function timestampValue(value: unknown): string | number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : stringValue(value)
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function idValue(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return stringValue(value)
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}

--- a/wework-mobile/src/domain/work.test.ts
+++ b/wework-mobile/src/domain/work.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import type { RuntimeWorkListResponse } from '@/types/runtime'
 import { runtimeTaskKey } from './runtimeTaskLifecycle'
-import { flattenConversations, runtimeWorkContainsTask } from './work'
+import {
+  flattenConversations,
+  mergeRuntimeWorkForDevices,
+  runtimeWorkContainsTask,
+  runtimeWorkForDevices,
+} from './work'
 
 describe('flattenConversations', () => {
   it('combines project and standalone chats in update order', () => {
@@ -115,3 +120,60 @@ describe('flattenConversations', () => {
     expect(runtimeWorkContainsTask(work, { deviceId: 'cloud-2', taskId: 'task-1' })).toBe(false)
   })
 })
+
+describe('mergeRuntimeWorkForDevices', () => {
+  it('builds the PC-style all-devices view and merges shared projects', () => {
+    const result = mergeRuntimeWorkForDevices(
+      {
+        'device-1': projectWork('device-1', 'task-1'),
+        'device-2': projectWork('device-2', 'task-2'),
+      },
+      ['device-1', 'device-2']
+    )
+
+    expect(result.projects).toHaveLength(1)
+    expect(result.projects[0]?.deviceWorkspaces.map(workspace => workspace.deviceId)).toEqual([
+      'device-1',
+      'device-2',
+    ])
+    expect(result.totalTasks).toBe(2)
+  })
+})
+
+describe('runtimeWorkForDevices', () => {
+  it('removes cached work owned by unsupported devices', () => {
+    const result = runtimeWorkForDevices(
+      {
+        claudecode: projectWork('claudecode', 'task-1'),
+        openclaw: projectWork('openclaw', 'task-2'),
+      },
+      ['claudecode']
+    )
+
+    expect(Object.keys(result)).toEqual(['claudecode'])
+  })
+})
+
+function projectWork(deviceId: string, taskId: string): RuntimeWorkListResponse {
+  return {
+    projects: [
+      {
+        project: { key: 'shared-project', name: 'Wegent' },
+        deviceWorkspaces: [
+          {
+            deviceId,
+            deviceName: deviceId,
+            deviceStatus: 'online',
+            available: true,
+            workspacePath: `/work/${deviceId}`,
+            tasks: [
+              { taskId, title: taskId, runtime: 'codex', workspacePath: `/work/${deviceId}` },
+            ],
+          },
+        ],
+      },
+    ],
+    chats: [],
+    totalTasks: 1,
+  }
+}

--- a/wework-mobile/src/domain/work.ts
+++ b/wework-mobile/src/domain/work.ts
@@ -30,6 +30,84 @@ export function allWorkspaces(work: RuntimeWorkListResponse): RuntimeDeviceWorks
   return [...projectWorkspaces, ...work.chats]
 }
 
+export function mergeRuntimeWorkForDevices(
+  workByDevice: Readonly<Record<string, RuntimeWorkListResponse>>,
+  deviceIds: readonly string[]
+): RuntimeWorkListResponse {
+  const projectsByKey = new Map<string, RuntimeWorkListResponse['projects'][number]>()
+  const chatsByKey = new Map<string, RuntimeDeviceWorkspace>()
+
+  for (const deviceId of deviceIds) {
+    const work = workByDevice[deviceId]
+    if (!work) continue
+    for (const projectWork of work.projects) {
+      const existing = projectsByKey.get(projectWork.project.key)
+      if (!existing) {
+        projectsByKey.set(projectWork.project.key, {
+          ...projectWork,
+          project: { ...projectWork.project },
+          deviceWorkspaces: mergeWorkspaces([], projectWork.deviceWorkspaces),
+        })
+        continue
+      }
+      existing.deviceWorkspaces = mergeWorkspaces(
+        existing.deviceWorkspaces,
+        projectWork.deviceWorkspaces
+      )
+    }
+    for (const workspace of work.chats) {
+      const key = workspaceKey(workspace)
+      const existing = chatsByKey.get(key)
+      if (!existing || (!existing.available && workspace.available)) chatsByKey.set(key, workspace)
+    }
+  }
+
+  const projects = [...projectsByKey.values()].map(project => ({
+    ...project,
+    totalTasks: project.deviceWorkspaces.reduce(
+      (total, workspace) => total + workspace.tasks.length,
+      0
+    ),
+  }))
+  const chats = [...chatsByKey.values()]
+  return {
+    projects,
+    chats,
+    totalTasks:
+      projects.reduce((total, project) => total + (project.totalTasks ?? 0), 0) +
+      chats.reduce((total, workspace) => total + workspace.tasks.length, 0),
+  }
+}
+
+export function runtimeWorkForDevices(
+  workByDevice: Readonly<Record<string, RuntimeWorkListResponse>>,
+  deviceIds: readonly string[]
+): Record<string, RuntimeWorkListResponse> {
+  const selectedWork: Record<string, RuntimeWorkListResponse> = {}
+  for (const deviceId of deviceIds) {
+    const work = workByDevice[deviceId]
+    if (work) selectedWork[deviceId] = work
+  }
+  return selectedWork
+}
+
+function mergeWorkspaces(
+  current: readonly RuntimeDeviceWorkspace[],
+  incoming: readonly RuntimeDeviceWorkspace[]
+): RuntimeDeviceWorkspace[] {
+  const merged = new Map(current.map(workspace => [workspaceKey(workspace), workspace]))
+  for (const workspace of incoming) {
+    const key = workspaceKey(workspace)
+    const existing = merged.get(key)
+    if (!existing || (!existing.available && workspace.available)) merged.set(key, workspace)
+  }
+  return [...merged.values()]
+}
+
+function workspaceKey(workspace: RuntimeDeviceWorkspace): string {
+  return `${workspace.deviceId}\0${workspace.workspacePath}`
+}
+
 export function runtimeWorkContainsTask(
   work: RuntimeWorkListResponse,
   address: Pick<RuntimeTaskAddress, 'deviceId' | 'taskId'>

--- a/wework-mobile/src/hooks/mobileRuntimeDeviceContract.test.ts
+++ b/wework-mobile/src/hooks/mobileRuntimeDeviceContract.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+declare global {
+  interface ImportMeta {
+    glob(
+      pattern: string | string[],
+      options: { eager: true; import: 'default'; query: '?raw' }
+    ): Record<string, string>
+  }
+}
+
+const sources = import.meta.glob('./useMobileRuntime.ts', {
+  eager: true,
+  import: 'default',
+  query: '?raw',
+}) as Record<string, string>
+
+describe('mobile runtime device contract', () => {
+  it('filters unsupported shells before publishing devices or loading work', () => {
+    const runtime = sources['./useMobileRuntime.ts']
+
+    expect(runtime).toContain('mobileOperableDevices(response.items)')
+    expect(runtime).toContain('mobileOperableDevices(cached.devices)')
+    expect(runtime).toContain('runtimeWorkForDevices(workByDeviceRef.current, operableDeviceIds)')
+    expect(runtime).not.toContain('mobileRemoteDevices')
+  })
+})

--- a/wework-mobile/src/hooks/useMobileRuntime.ts
+++ b/wework-mobile/src/hooks/useMobileRuntime.ts
@@ -4,6 +4,7 @@ import { AppState } from 'react-native'
 
 import { chatReducer } from '@/domain/chatReducer'
 import { composerApps } from '@/domain/composerApps'
+import { mobileOperableDevices, selectedOnlineDeviceId } from '@/domain/deviceOrdering'
 import {
   continuationSelection,
   defaultModel,
@@ -19,9 +20,16 @@ import {
   type RuntimeSendTransition,
 } from '@/domain/runtimeTaskLifecycle'
 import { createConversationWorkspace } from '@/domain/runtimeConversationWorkspace'
-import { allWorkspaces, flattenConversations, runtimeWorkContainsTask } from '@/domain/work'
+import {
+  allWorkspaces,
+  flattenConversations,
+  mergeRuntimeWorkForDevices,
+  runtimeWorkContainsTask,
+  runtimeWorkForDevices,
+} from '@/domain/work'
 import type { RuntimeSessionConfig } from '@/services/backendConfig'
 import { RuntimeApi } from '@/services/runtimeApi'
+import { MobileRuntimeCache, type RuntimeCacheSnapshot } from '@/services/runtimeCache'
 import {
   DEFAULT_RUNTIME_PERMISSION_MODE,
   loadRuntimePermissionMode,
@@ -59,20 +67,26 @@ export interface MobileRuntimeState {
   currentTitle: string
   selectedWorkspace: RuntimeDeviceWorkspace | null
   selectedDeviceId: string | null
+  allDevicesSelected: boolean
   models: UnifiedModel[]
   selectedModel: UnifiedModel | null
   selectedModelOptions: ModelOptions
   permissionMode: RuntimePermissionMode
   gitRef: string | null
   loading: boolean
+  hasMoreMessagesBefore: boolean
+  loadingMoreMessagesBefore: boolean
+  refreshing: boolean
   sending: boolean
   running: boolean
   stopping: boolean
   error: string | null
   refresh: () => Promise<void>
+  loadMoreMessagesBefore: () => Promise<void>
   openConversation: (item: ConversationItem) => Promise<void>
   startNewConversation: (workspace?: RuntimeDeviceWorkspace) => void
   selectDevice: (deviceId: string) => void
+  selectAllDevices: () => void
   selectWorkspace: (workspace: RuntimeDeviceWorkspace | null) => void
   selectModel: (model: UnifiedModel, options?: ModelOptions) => void
   selectPermissionMode: (mode: RuntimePermissionMode) => void
@@ -90,9 +104,10 @@ export interface NewConversationOptions {
   pursueGoal?: boolean
 }
 
-export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeState {
+export function useMobileRuntime(config: RuntimeSessionConfig, userId: number): MobileRuntimeState {
   const api = useMemo(() => new RuntimeApi(config), [config])
   const stream = useMemo(() => new RuntimeStream(config), [config])
+  const cache = useMemo(() => new MobileRuntimeCache(config.apiBaseUrl, userId), [config, userId])
   const lifecycle = useMemo(() => new RuntimeTaskLifecycleProjection(), [api])
   const [work, setWork] = useState(EMPTY_WORK)
   const workRef = useRef<RuntimeWorkListResponse>(EMPTY_WORK)
@@ -105,6 +120,7 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
   const [currentTitle, setCurrentTitle] = useState('新会话')
   const [selectedWorkspace, setSelectedWorkspace] = useState<RuntimeDeviceWorkspace | null>(null)
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
+  const [allDevicesSelected, setAllDevicesSelected] = useState(false)
   const [models, setModels] = useState<UnifiedModel[]>([])
   const [selectedModel, setSelectedModel] = useState<UnifiedModel | null>(null)
   const [selectedModelOptions, setSelectedModelOptions] = useState<ModelOptions>({})
@@ -113,13 +129,25 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
   )
   const [gitRef, setGitRef] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [hasMoreMessagesBefore, setHasMoreMessagesBefore] = useState(false)
+  const [loadingMoreMessagesBefore, setLoadingMoreMessagesBefore] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const [sending, setSending] = useState(false)
   const [stoppingTaskKey, setStoppingTaskKey] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const unsubscribeRef = useRef<(() => void) | null>(null)
   const currentAddressRef = useRef<RuntimeTaskAddress | null>(null)
-  const workRequestIdRef = useRef(0)
+  const workRequestRevisionRef = useRef(new Map<string, number>())
+  const devicesRef = useRef<DeviceInfo[]>([])
+  const modelsRef = useRef<UnifiedModel[]>([])
+  const selectedDeviceIdRef = useRef<string | null>(null)
+  const allDevicesSelectedRef = useRef(false)
+  const workByDeviceRef = useRef<Record<string, RuntimeWorkListResponse>>({})
+  const refreshingRef = useRef(false)
   const stopRequestsRef = useRef(new Set<string>())
+  const transcriptBeforeCursorRef = useRef<string | null>(null)
+  const loadingMoreMessagesBeforeRef = useRef(false)
+  const transcriptPaginationRevisionRef = useRef(0)
 
   const currentTaskRunning = currentAddress
     ? runtimeTaskRunning(currentAddress, work, taskRunningByKey)
@@ -157,22 +185,134 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
     setStoppingTaskKey(current => (current === key ? null : current))
   }, [])
 
-  const reloadWork = useCallback(async () => {
-    const requestId = ++workRequestIdRef.current
-    const nextWork = await api.listWork()
-    if (requestId !== workRequestIdRef.current) return nextWork
+  const persistCache = useCallback(() => {
+    const snapshot: RuntimeCacheSnapshot = {
+      allDevicesSelected: allDevicesSelectedRef.current,
+      devices: devicesRef.current,
+      models: modelsRef.current,
+      selectedDeviceId: selectedDeviceIdRef.current,
+      workByDevice: workByDeviceRef.current,
+    }
+    return cache.write(snapshot)
+  }, [cache])
+
+  const publishSelectedDevice = useCallback(
+    (deviceId: string | null, cachedWork?: RuntimeWorkListResponse) => {
+      allDevicesSelectedRef.current = false
+      setAllDevicesSelected(false)
+      selectedDeviceIdRef.current = deviceId
+      setSelectedDeviceId(deviceId)
+      const nextWork = cachedWork ?? (deviceId ? workByDeviceRef.current[deviceId] : undefined)
+      workRef.current = nextWork ?? EMPTY_WORK
+      setWork(workRef.current)
+      setSelectedWorkspace(null)
+      void persistCache().catch(cause => console.warn('Failed to cache selected device', cause))
+      return nextWork
+    },
+    [persistCache]
+  )
+
+  const publishAllDevices = useCallback(() => {
+    allDevicesSelectedRef.current = true
+    setAllDevicesSelected(true)
+    selectedDeviceIdRef.current = null
+    setSelectedDeviceId(null)
+    const nextWork = mergeRuntimeWorkForDevices(
+      workByDeviceRef.current,
+      devicesRef.current.map(device => device.device_id)
+    )
     workRef.current = nextWork
     setWork(nextWork)
-    if (lifecycle.syncWork(nextWork)) publishTaskLifecycle()
+    setSelectedWorkspace(null)
+    void persistCache().catch(cause => console.warn('Failed to cache all-device scope', cause))
     return nextWork
-  }, [api, lifecycle, publishTaskLifecycle])
+  }, [persistCache])
+
+  const nextWorkRevision = useCallback((deviceId: string) => {
+    const next = (workRequestRevisionRef.current.get(deviceId) ?? 0) + 1
+    workRequestRevisionRef.current.set(deviceId, next)
+    return next
+  }, [])
+
+  const commitDeviceWork = useCallback(
+    async (deviceId: string, nextWork: RuntimeWorkListResponse) => {
+      workByDeviceRef.current = { ...workByDeviceRef.current, [deviceId]: nextWork }
+      if (allDevicesSelectedRef.current) {
+        const merged = mergeRuntimeWorkForDevices(
+          workByDeviceRef.current,
+          devicesRef.current.map(device => device.device_id)
+        )
+        workRef.current = merged
+        setWork(merged)
+        if (lifecycle.syncWork(merged)) publishTaskLifecycle()
+      } else if (selectedDeviceIdRef.current === deviceId) {
+        workRef.current = nextWork
+        setWork(nextWork)
+        if (lifecycle.syncWork(nextWork)) publishTaskLifecycle()
+      }
+      await persistCache()
+    },
+    [lifecycle, persistCache, publishTaskLifecycle]
+  )
+
+  const reloadWork = useCallback(
+    async (requestedDeviceId?: string | null) => {
+      const deviceId = requestedDeviceId ?? selectedDeviceIdRef.current
+      if (!deviceId) return EMPTY_WORK
+      const revision = nextWorkRevision(deviceId)
+      const deviceName = devicesRef.current.find(device => device.device_id === deviceId)?.name
+      const nextWork = await stream.listWork(deviceId, deviceName)
+      if (workRequestRevisionRef.current.get(deviceId) !== revision) return nextWork
+      await commitDeviceWork(deviceId, nextWork)
+      return nextWork
+    },
+    [commitDeviceWork, nextWorkRevision, stream]
+  )
+
+  const reloadAllWork = useCallback(async () => {
+    const onlineDevices = devicesRef.current.filter(device => device.status !== 'offline')
+    const requests = onlineDevices.map(device => ({
+      device,
+      revision: nextWorkRevision(device.device_id),
+      request: stream.listWork(device.device_id, device.name),
+    }))
+    const results = await Promise.allSettled(requests.map(item => item.request))
+    const failed = results.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+    if (failed) throw failed.reason
+
+    const nextWorkByDevice = { ...workByDeviceRef.current }
+    results.forEach((result, index) => {
+      const request = requests[index]
+      if (
+        result.status === 'fulfilled' &&
+        request &&
+        workRequestRevisionRef.current.get(request.device.device_id) === request.revision
+      ) {
+        nextWorkByDevice[request.device.device_id] = result.value
+      }
+    })
+    workByDeviceRef.current = nextWorkByDevice
+    if (allDevicesSelectedRef.current) {
+      const merged = mergeRuntimeWorkForDevices(
+        nextWorkByDevice,
+        devicesRef.current.map(device => device.device_id)
+      )
+      workRef.current = merged
+      setWork(merged)
+      if (lifecycle.syncWork(merged)) publishTaskLifecycle()
+    }
+    await persistCache()
+  }, [lifecycle, nextWorkRevision, persistCache, publishTaskLifecycle, stream])
 
   const workInvalidator = useMemo(
     () =>
       new RuntimeWorkInvalidator(async () => {
-        await reloadWork()
+        if (allDevicesSelectedRef.current) await reloadAllWork()
+        else await reloadWork(selectedDeviceIdRef.current)
       }),
-    [reloadWork]
+    [reloadAllWork, reloadWork]
   )
 
   const invalidateWork = useCallback(() => {
@@ -180,7 +320,7 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
   }, [workInvalidator])
 
   const reloadTranscript = useCallback(
-    async (address: RuntimeTaskAddress) => {
+    async (address: RuntimeTaskAddress, replace = false) => {
       const observation = lifecycle.transcriptRequested(address)
       const transcript = await stream.getTranscript(address)
       if (
@@ -190,12 +330,55 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
         publishTaskLifecycle()
       }
       if (transcript.running === false) clearStoppingTask(address)
-      if (currentAddressRef.current?.taskId !== address.taskId) return
-      dispatchMessages({ type: 'replace', messages: transcript.messages })
+      if (!sameRuntimeAddress(currentAddressRef.current, address)) return
+      dispatchMessages({
+        type: replace ? 'replace' : 'merge-latest',
+        messages: transcript.messages,
+      })
+      if (replace) {
+        transcriptBeforeCursorRef.current = transcript.beforeCursor ?? null
+        setHasMoreMessagesBefore(Boolean(transcript.beforeCursor))
+      }
       if (transcript.title) setCurrentTitle(transcript.title)
     },
     [clearStoppingTask, lifecycle, publishTaskLifecycle, stream]
   )
+
+  const loadMoreMessagesBefore = useCallback(async () => {
+    const address = currentAddressRef.current
+    const beforeCursor = transcriptBeforeCursorRef.current
+    if (!address || !beforeCursor || loadingMoreMessagesBeforeRef.current) return
+
+    const revision = transcriptPaginationRevisionRef.current
+    loadingMoreMessagesBeforeRef.current = true
+    setLoadingMoreMessagesBefore(true)
+    try {
+      const transcript = await stream.getTranscript(address, { beforeCursor })
+      if (
+        transcriptPaginationRevisionRef.current !== revision ||
+        !sameRuntimeAddress(currentAddressRef.current, address)
+      )
+        return
+      dispatchMessages({ type: 'prepend', messages: transcript.messages })
+      transcriptBeforeCursorRef.current = transcript.beforeCursor ?? null
+      setHasMoreMessagesBefore(Boolean(transcript.beforeCursor))
+    } catch (cause) {
+      if (
+        transcriptPaginationRevisionRef.current === revision &&
+        sameRuntimeAddress(currentAddressRef.current, address)
+      ) {
+        setError(messageFrom(cause))
+      }
+    } finally {
+      if (
+        transcriptPaginationRevisionRef.current === revision &&
+        sameRuntimeAddress(currentAddressRef.current, address)
+      ) {
+        loadingMoreMessagesBeforeRef.current = false
+        setLoadingMoreMessagesBefore(false)
+      }
+    }
+  }, [stream])
 
   const subscribe = useCallback(
     (address: RuntimeTaskAddress) => {
@@ -214,40 +397,54 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
     [reloadTranscript, stream]
   )
 
+  const applyModels = useCallback((nextModels: UnifiedModel[]) => {
+    modelsRef.current = nextModels
+    setModels(nextModels)
+    setSelectedModel(current => {
+      const next =
+        nextModels.find(model => model.name === current?.name && model.type === current.type) ??
+        defaultModel(nextModels)
+      if (next && (!current || next.name !== current.name || next.type !== current.type)) {
+        setSelectedModelOptions(defaultModelOptions(next))
+      }
+      return next
+    })
+  }, [])
+
+  const refreshDevices = useCallback(async (): Promise<string | null> => {
+    const response = await api.listDevices()
+    const operableDevices = mobileOperableDevices(response.items)
+    const operableDeviceIds = operableDevices.map(device => device.device_id)
+    devicesRef.current = operableDevices
+    workByDeviceRef.current = runtimeWorkForDevices(workByDeviceRef.current, operableDeviceIds)
+    setDevices(operableDevices)
+    if (allDevicesSelectedRef.current) {
+      publishAllDevices()
+      await persistCache()
+      return null
+    }
+    const deviceId = selectedOnlineDeviceId(operableDevices, selectedDeviceIdRef.current)
+    if (deviceId !== selectedDeviceIdRef.current) publishSelectedDevice(deviceId)
+    await persistCache()
+    return deviceId
+  }, [api, persistCache, publishAllDevices, publishSelectedDevice])
+
   const refresh = useCallback(async () => {
-    setLoading(true)
+    const deviceId = selectedDeviceIdRef.current
+    if ((!allDevicesSelectedRef.current && !deviceId) || refreshingRef.current) return
+    refreshingRef.current = true
+    setRefreshing(true)
     setError(null)
     try {
-      const [, deviceResponse, modelResponse] = await Promise.all([
-        reloadWork(),
-        api.listDevices(),
-        api.listModels(),
-      ])
-      setDevices(deviceResponse.items)
-      setModels(modelResponse.data)
-      setSelectedModel(current => {
-        const next =
-          modelResponse.data.find(
-            model => model.name === current?.name && model.type === current.type
-          ) ?? defaultModel(modelResponse.data)
-        if (next && (!current || next.name !== current.name || next.type !== current.type)) {
-          setSelectedModelOptions(defaultModelOptions(next))
-        }
-        return next
-      })
-      const online = deviceResponse.items.find(device => device.status !== 'offline')
-      setSelectedDeviceId(current => {
-        const currentIsOnline = deviceResponse.items.some(
-          device => device.device_id === current && device.status !== 'offline'
-        )
-        return currentIsOnline ? current : (online?.device_id ?? null)
-      })
+      if (allDevicesSelectedRef.current) await reloadAllWork()
+      else await reloadWork(deviceId)
     } catch (cause) {
       setError(messageFrom(cause))
     } finally {
-      setLoading(false)
+      refreshingRef.current = false
+      setRefreshing(false)
     }
-  }, [api, reloadWork])
+  }, [reloadAllWork, reloadWork])
 
   useEffect(() => {
     setTaskRunningByKey(lifecycle.snapshot())
@@ -304,21 +501,146 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
   }, [api, selectedWorkspace])
 
   useEffect(() => {
-    void refresh()
+    let cancelled = false
+    void (async () => {
+      const cached = await cache.read()
+      if (cancelled) return
+      const cachedDevices = mobileOperableDevices(cached.devices)
+      devicesRef.current = cachedDevices
+      modelsRef.current = cached.models
+      workByDeviceRef.current = runtimeWorkForDevices(
+        cached.workByDevice,
+        cachedDevices.map(device => device.device_id)
+      )
+      setDevices(cachedDevices)
+      applyModels(cached.models)
+      const cachedDeviceId = selectedOnlineDeviceId(cachedDevices, cached.selectedDeviceId)
+      const cachedWork = cached.allDevicesSelected
+        ? publishAllDevices()
+        : publishSelectedDevice(
+            cachedDeviceId,
+            cachedDeviceId ? cached.workByDevice[cachedDeviceId] : undefined
+          )
+      const hasCachedWork = cached.allDevicesSelected
+        ? cachedDevices.some(device => Boolean(cached.workByDevice[device.device_id]))
+        : Boolean(cachedDeviceId && cached.workByDevice[cachedDeviceId])
+      if (cachedWork && lifecycle.syncWork(cachedWork)) publishTaskLifecycle()
+      setLoading(!hasCachedWork)
+
+      let deviceId = cachedDeviceId
+      try {
+        deviceId = await refreshDevices()
+      } catch (cause) {
+        if (!cancelled) setError(messageFrom(cause))
+      }
+      if (cancelled) return
+
+      const selectedCachedWork = allDevicesSelectedRef.current
+        ? mergeRuntimeWorkForDevices(
+            workByDeviceRef.current,
+            devicesRef.current.map(device => device.device_id)
+          )
+        : deviceId
+          ? workByDeviceRef.current[deviceId]
+          : undefined
+      if (selectedCachedWork && (allDevicesSelectedRef.current || deviceId)) {
+        workRef.current = selectedCachedWork
+        setWork(selectedCachedWork)
+        setLoading(false)
+      }
+      if (allDevicesSelectedRef.current) {
+        void reloadAllWork()
+          .catch(cause => {
+            if (!cancelled) setError(messageFrom(cause))
+          })
+          .finally(() => {
+            if (!cancelled && allDevicesSelectedRef.current) setLoading(false)
+          })
+      } else if (deviceId) {
+        void reloadWork(deviceId)
+          .catch(cause => {
+            if (!cancelled) setError(messageFrom(cause))
+          })
+          .finally(() => {
+            if (!cancelled && selectedDeviceIdRef.current === deviceId) setLoading(false)
+          })
+      } else {
+        setLoading(false)
+      }
+
+      void api
+        .listModels()
+        .then(response => {
+          if (cancelled) return
+          applyModels(response.data)
+          void persistCache().catch(cause => console.warn('Failed to cache models', cause))
+        })
+        .catch(cause => {
+          if (!cancelled && cached.models.length === 0) setError(messageFrom(cause))
+        })
+    })()
     return () => {
+      cancelled = true
       unsubscribeRef.current?.()
       stream.dispose()
     }
-  }, [refresh, stream])
+  }, [
+    api,
+    applyModels,
+    cache,
+    lifecycle,
+    persistCache,
+    publishSelectedDevice,
+    publishAllDevices,
+    publishTaskLifecycle,
+    refreshDevices,
+    reloadAllWork,
+    reloadWork,
+    stream,
+  ])
+
+  const selectDevice = useCallback(
+    (deviceId: string) => {
+      if (!allDevicesSelectedRef.current && deviceId === selectedDeviceIdRef.current) return
+      const cachedWork = publishSelectedDevice(deviceId)
+      setLoading(!cachedWork)
+      void reloadWork(deviceId)
+        .catch(cause => setError(messageFrom(cause)))
+        .finally(() => {
+          if (selectedDeviceIdRef.current === deviceId) setLoading(false)
+        })
+    },
+    [publishSelectedDevice, reloadWork]
+  )
+
+  const selectAllDevices = useCallback(() => {
+    if (allDevicesSelectedRef.current) return
+    const hasCachedWork = devicesRef.current.some(device =>
+      Boolean(workByDeviceRef.current[device.device_id])
+    )
+    publishAllDevices()
+    setLoading(!hasCachedWork)
+    void reloadAllWork()
+      .catch(cause => setError(messageFrom(cause)))
+      .finally(() => {
+        if (allDevicesSelectedRef.current) setLoading(false)
+      })
+  }, [publishAllDevices, reloadAllWork])
 
   const openConversation = useCallback(
     async (item: ConversationItem) => {
       setLoading(true)
       setError(null)
+      transcriptPaginationRevisionRef.current += 1
+      transcriptBeforeCursorRef.current = null
+      loadingMoreMessagesBeforeRef.current = false
+      setHasMoreMessagesBefore(false)
+      setLoadingMoreMessagesBefore(false)
+      dispatchMessages({ type: 'replace', messages: [] })
       currentAddressRef.current = item.address
       setCurrentAddress(item.address)
       setCurrentTitle(item.title)
-      setSelectedDeviceId(item.address.deviceId)
+      if (!allDevicesSelectedRef.current) publishSelectedDevice(item.address.deviceId, work)
       const workspace = allWorkspaces(work).find(
         candidate =>
           candidate.deviceId === item.address.deviceId &&
@@ -327,26 +649,38 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
       setSelectedWorkspace(workspace ?? null)
       subscribe(item.address)
       try {
-        await reloadTranscript(item.address)
+        await reloadTranscript(item.address, true)
       } catch (cause) {
-        setError(messageFrom(cause))
+        if (sameRuntimeAddress(currentAddressRef.current, item.address)) {
+          setError(messageFrom(cause))
+        }
       } finally {
-        setLoading(false)
+        if (sameRuntimeAddress(currentAddressRef.current, item.address)) setLoading(false)
       }
     },
-    [reloadTranscript, subscribe, work]
+    [publishSelectedDevice, reloadTranscript, subscribe, work]
   )
 
-  const startNewConversation = useCallback((workspace?: RuntimeDeviceWorkspace) => {
-    unsubscribeRef.current?.()
-    unsubscribeRef.current = null
-    currentAddressRef.current = null
-    setCurrentAddress(null)
-    setCurrentTitle(workspace?.label || '新会话')
-    setSelectedWorkspace(workspace ?? null)
-    if (workspace) setSelectedDeviceId(workspace.deviceId)
-    dispatchMessages({ type: 'replace', messages: [] })
-  }, [])
+  const startNewConversation = useCallback(
+    (workspace?: RuntimeDeviceWorkspace) => {
+      unsubscribeRef.current?.()
+      unsubscribeRef.current = null
+      currentAddressRef.current = null
+      setCurrentAddress(null)
+      setCurrentTitle(workspace?.label || '新会话')
+      transcriptPaginationRevisionRef.current += 1
+      transcriptBeforeCursorRef.current = null
+      loadingMoreMessagesBeforeRef.current = false
+      setHasMoreMessagesBefore(false)
+      setLoadingMoreMessagesBefore(false)
+      if (workspace && !allDevicesSelectedRef.current) {
+        publishSelectedDevice(workspace.deviceId, workRef.current)
+      }
+      setSelectedWorkspace(workspace ?? null)
+      dispatchMessages({ type: 'replace', messages: [] })
+    },
+    [publishSelectedDevice]
+  )
 
   const send = useCallback(
     async (rawMessage: string, options?: NewConversationOptions): Promise<boolean> => {
@@ -390,7 +724,10 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
           return true
         }
 
-        const requestedDeviceId = selectedWorkspace?.deviceId ?? selectedDeviceId
+        const requestedDeviceId =
+          selectedWorkspace?.deviceId ??
+          selectedDeviceId ??
+          selectedOnlineDeviceId(devicesRef.current, null)
         if (!requestedDeviceId) throw new Error('没有可用的云端 executor')
         const deviceId = requestedDeviceId
         const taskId = createRuntimeTaskId()
@@ -452,7 +789,7 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
           publishTaskLifecycle()
           subscribe(resolvedAddress)
         }
-        void reloadWork().catch(cause => setError(messageFrom(cause)))
+        void reloadWork(resolvedAddress.deviceId).catch(cause => setError(messageFrom(cause)))
         return true
       } catch (cause) {
         if (sendTransition && lifecycle.sendRejected(sendTransition)) publishTaskLifecycle()
@@ -506,7 +843,7 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
     try {
       const response = await api.cancelTask(address)
       if (!response.accepted) throw new Error(response.error || '停止当前回复失败')
-      void reloadWork().catch(cause => setError(messageFrom(cause)))
+      void reloadWork(address.deviceId).catch(cause => setError(messageFrom(cause)))
       return true
     } catch (cause) {
       clearStoppingTask(address)
@@ -530,7 +867,10 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
 
   const loadComposerApps = useCallback(async () => {
     const deviceId =
-      currentAddressRef.current?.deviceId ?? selectedWorkspace?.deviceId ?? selectedDeviceId
+      currentAddressRef.current?.deviceId ??
+      selectedWorkspace?.deviceId ??
+      selectedDeviceId ??
+      selectedOnlineDeviceId(devicesRef.current, null)
     if (!deviceId) throw new Error('请先选择在线 Executor')
     const installedPlugins = await api.listInstalledPlugins(deviceId)
     return composerApps(installedPlugins)
@@ -553,7 +893,8 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
             name: input.name.trim(),
           })
         }
-        const refreshedWork = await reloadWork()
+        publishSelectedDevice(input.deviceId)
+        const refreshedWork = await reloadWork(input.deviceId)
         const workspace = allWorkspaces(refreshedWork).find(
           candidate =>
             candidate.deviceId === input.deviceId &&
@@ -568,7 +909,7 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
         setLoading(false)
       }
     },
-    [api, reloadWork, startNewConversation]
+    [api, publishSelectedDevice, reloadWork, startNewConversation]
   )
 
   return {
@@ -580,20 +921,26 @@ export function useMobileRuntime(config: RuntimeSessionConfig): MobileRuntimeSta
     currentTitle,
     selectedWorkspace,
     selectedDeviceId,
+    allDevicesSelected,
     models,
     selectedModel,
     selectedModelOptions,
     permissionMode,
     gitRef,
     loading,
+    hasMoreMessagesBefore,
+    loadingMoreMessagesBefore,
+    refreshing,
     sending,
     running: currentTaskRunning,
     stopping: currentTaskStopping,
     error,
     refresh,
+    loadMoreMessagesBefore,
     openConversation,
     startNewConversation,
-    selectDevice: setSelectedDeviceId,
+    selectDevice,
+    selectAllDevices,
     selectWorkspace: setSelectedWorkspace,
     selectModel: (model, options) => {
       setSelectedModel(model)
@@ -621,6 +968,13 @@ function runtimeTaskRunning(
       workspace.deviceId === address.deviceId &&
       workspace.tasks.some(task => task.taskId === address.taskId && task.running === true)
   )
+}
+
+function sameRuntimeAddress(
+  current: RuntimeTaskAddress | null,
+  candidate: RuntimeTaskAddress
+): boolean {
+  return current?.deviceId === candidate.deviceId && current.taskId === candidate.taskId
 }
 
 function createRuntimeTaskId(): string {

--- a/wework-mobile/src/services/runtimeApi.test.ts
+++ b/wework-mobile/src/services/runtimeApi.test.ts
@@ -19,27 +19,6 @@ const config = {
 describe('RuntimeApi', () => {
   afterEach(() => vi.unstubAllGlobals())
 
-  it('loads runtime work with bearer authentication', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ projects: [], chats: [], totalTasks: 0 }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    await new RuntimeApi(config).listWork()
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://wegent.example/api/v1/runtime-work',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer secret-token',
-        }),
-      })
-    )
-  })
-
   it('loads the Wework model catalog including execution configuration', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ data: [] }), {
@@ -309,7 +288,7 @@ describe('RuntimeApi', () => {
       )
     )
 
-    await expect(new RuntimeApi(config).listWork()).rejects.toEqual(
+    await expect(new RuntimeApi(config).listDevices()).rejects.toEqual(
       new RuntimeApiError('executor offline', 502, {
         detail: 'executor offline',
       })

--- a/wework-mobile/src/services/runtimeApi.ts
+++ b/wework-mobile/src/services/runtimeApi.ts
@@ -10,7 +10,6 @@ import type {
   RuntimeTaskCancelResponse,
   RuntimeTaskAddress,
   RuntimeWorktreePreflightResponse,
-  RuntimeWorkListResponse,
   RuntimeWorkspaceOpenResponse,
   ModelSelectionConfig,
   UnifiedModelListResponse,
@@ -59,10 +58,6 @@ export class RuntimeApi {
 
   listDevices(): Promise<DeviceListResponse> {
     return this.request('/devices')
-  }
-
-  listWork(): Promise<RuntimeWorkListResponse> {
-    return this.request('/runtime-work')
   }
 
   listModels(): Promise<UnifiedModelListResponse> {

--- a/wework-mobile/src/services/runtimeCache.test.ts
+++ b/wework-mobile/src/services/runtimeCache.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const files = new Map<string, string>()
+
+vi.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///documents/',
+  getInfoAsync: vi.fn(async (path: string) => ({ exists: files.has(path) })),
+  makeDirectoryAsync: vi.fn(async () => undefined),
+  readAsStringAsync: vi.fn(async (path: string) => files.get(path) ?? ''),
+  writeAsStringAsync: vi.fn(async (path: string, value: string) => {
+    files.set(path, value)
+  }),
+}))
+
+import { MobileRuntimeCache } from './runtimeCache'
+
+describe('MobileRuntimeCache', () => {
+  beforeEach(() => files.clear())
+
+  it('persists the selected device and each device work independently', async () => {
+    const cache = new MobileRuntimeCache('https://wegent.example/api', 7)
+    await cache.write({
+      allDevicesSelected: true,
+      devices: [
+        {
+          id: 1,
+          device_id: 'device-1',
+          name: 'Mac',
+          status: 'online',
+          device_type: 'remote',
+          bind_shell: 'openclaw',
+        },
+      ],
+      models: [{ name: 'gpt', type: 'public' }],
+      selectedDeviceId: null,
+      workByDevice: {
+        'device-1': { projects: [], chats: [], totalTasks: 0 },
+        'device-2': { projects: [], chats: [], totalTasks: 2 },
+      },
+    })
+
+    await expect(cache.read()).resolves.toMatchObject({
+      allDevicesSelected: true,
+      selectedDeviceId: null,
+      devices: [{ device_id: 'device-1', device_type: 'remote', bind_shell: 'openclaw' }],
+      workByDevice: {
+        'device-1': { totalTasks: 0 },
+        'device-2': { totalTasks: 2 },
+      },
+    })
+  })
+
+  it('keeps caches isolated by backend and user', async () => {
+    await new MobileRuntimeCache('https://wegent.example/api', 7).write({
+      allDevicesSelected: false,
+      devices: [
+        {
+          id: 1,
+          device_id: 'private',
+          name: 'Private',
+          status: 'online',
+          device_type: 'cloud',
+          bind_shell: 'claudecode',
+        },
+      ],
+      models: [],
+      selectedDeviceId: 'private',
+      workByDevice: {},
+    })
+
+    await expect(new MobileRuntimeCache('https://wegent.example/api', 8).read()).resolves.toEqual({
+      allDevicesSelected: false,
+      devices: [],
+      models: [],
+      selectedDeviceId: null,
+      workByDevice: {},
+    })
+  })
+})

--- a/wework-mobile/src/services/runtimeCache.ts
+++ b/wework-mobile/src/services/runtimeCache.ts
@@ -1,0 +1,159 @@
+import * as FileSystem from 'expo-file-system/legacy'
+
+import type { DeviceInfo, RuntimeWorkListResponse, UnifiedModel } from '@/types/runtime'
+
+const CACHE_VERSION = 2
+const CACHE_DIRECTORY = 'wegent-mobile/runtime'
+
+export interface RuntimeCacheSnapshot {
+  allDevicesSelected: boolean
+  devices: DeviceInfo[]
+  models: UnifiedModel[]
+  selectedDeviceId: string | null
+  workByDevice: Record<string, RuntimeWorkListResponse>
+}
+
+interface RuntimeCacheEnvelope extends RuntimeCacheSnapshot {
+  version: typeof CACHE_VERSION
+  apiBaseUrl: string
+  userId: number
+  updatedAt: number
+}
+
+const EMPTY_SNAPSHOT: RuntimeCacheSnapshot = {
+  allDevicesSelected: false,
+  devices: [],
+  models: [],
+  selectedDeviceId: null,
+  workByDevice: {},
+}
+
+export class MobileRuntimeCache {
+  private writeQueue: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly apiBaseUrl: string,
+    private readonly userId: number
+  ) {}
+
+  async read(): Promise<RuntimeCacheSnapshot> {
+    const path = this.path()
+    if (!path || !(await FileSystem.getInfoAsync(path)).exists) return EMPTY_SNAPSHOT
+    try {
+      const envelope = parseEnvelope(JSON.parse(await FileSystem.readAsStringAsync(path)))
+      if (!envelope || envelope.apiBaseUrl !== this.apiBaseUrl || envelope.userId !== this.userId) {
+        return EMPTY_SNAPSHOT
+      }
+      return snapshotFrom(envelope)
+    } catch {
+      return EMPTY_SNAPSHOT
+    }
+  }
+
+  write(snapshot: RuntimeCacheSnapshot): Promise<void> {
+    const envelope: RuntimeCacheEnvelope = {
+      version: CACHE_VERSION,
+      apiBaseUrl: this.apiBaseUrl,
+      userId: this.userId,
+      updatedAt: Date.now(),
+      ...snapshot,
+    }
+    this.writeQueue = this.writeQueue
+      .catch(() => undefined)
+      .then(async () => {
+        const path = this.path()
+        const directory = cacheDirectory()
+        if (!path || !directory) return
+        await FileSystem.makeDirectoryAsync(directory, { intermediates: true })
+        await FileSystem.writeAsStringAsync(path, JSON.stringify(envelope))
+      })
+    return this.writeQueue
+  }
+
+  private path(): string | null {
+    const directory = cacheDirectory()
+    if (!directory) return null
+    return `${directory}/${stableId(`${this.apiBaseUrl}\0${this.userId}`)}.json`
+  }
+}
+
+function cacheDirectory(): string | null {
+  return FileSystem.documentDirectory ? `${FileSystem.documentDirectory}${CACHE_DIRECTORY}` : null
+}
+
+function parseEnvelope(value: unknown): RuntimeCacheEnvelope | null {
+  if (!isRecord(value)) return null
+  if (
+    value.version !== CACHE_VERSION ||
+    typeof value.apiBaseUrl !== 'string' ||
+    typeof value.userId !== 'number' ||
+    typeof value.updatedAt !== 'number' ||
+    typeof value.allDevicesSelected !== 'boolean' ||
+    !Array.isArray(value.devices) ||
+    !Array.isArray(value.models) ||
+    (value.selectedDeviceId !== null && typeof value.selectedDeviceId !== 'string') ||
+    !isRecord(value.workByDevice)
+  ) {
+    return null
+  }
+  const workByDevice = Object.fromEntries(
+    Object.entries(value.workByDevice).filter((entry): entry is [string, RuntimeWorkListResponse] =>
+      isRuntimeWork(entry[1])
+    )
+  )
+  return {
+    version: CACHE_VERSION,
+    apiBaseUrl: value.apiBaseUrl,
+    userId: value.userId,
+    updatedAt: value.updatedAt,
+    allDevicesSelected: value.allDevicesSelected,
+    devices: value.devices.filter(isDeviceInfo),
+    models: value.models as UnifiedModel[],
+    selectedDeviceId: value.selectedDeviceId as string | null,
+    workByDevice,
+  }
+}
+
+function isDeviceInfo(value: unknown): value is DeviceInfo {
+  if (!isRecord(value)) return false
+  return (
+    typeof value.id === 'number' &&
+    typeof value.device_id === 'string' &&
+    typeof value.name === 'string' &&
+    (value.status === 'online' || value.status === 'offline' || value.status === 'busy') &&
+    (value.device_type === 'local' ||
+      value.device_type === 'app' ||
+      value.device_type === 'cloud' ||
+      value.device_type === 'remote') &&
+    (value.bind_shell === 'claudecode' || value.bind_shell === 'openclaw')
+  )
+}
+
+function isRuntimeWork(value: unknown): value is RuntimeWorkListResponse {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.projects) &&
+    Array.isArray(value.chats) &&
+    typeof value.totalTasks === 'number'
+  )
+}
+
+function snapshotFrom(envelope: RuntimeCacheEnvelope): RuntimeCacheSnapshot {
+  return {
+    allDevicesSelected: envelope.allDevicesSelected,
+    devices: envelope.devices,
+    models: envelope.models,
+    selectedDeviceId: envelope.selectedDeviceId,
+    workByDevice: envelope.workByDevice,
+  }
+}
+
+function stableId(value: string): string {
+  let hash = 0
+  for (const character of value) hash = (hash * 31 + character.charCodeAt(0)) >>> 0
+  return hash.toString(36)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/wework-mobile/src/services/runtimeStream.test.ts
+++ b/wework-mobile/src/services/runtimeStream.test.ts
@@ -50,7 +50,7 @@ describe('RuntimeStream', () => {
         params: {
           deviceId: 'device-1',
           taskId: 'task-1',
-          limit: 50,
+          limit: 5,
         },
       })
       acknowledge({
@@ -68,6 +68,81 @@ describe('RuntimeStream', () => {
     await expect(
       stream.getTranscript({ deviceId: 'device-1', taskId: 'task-1' })
     ).resolves.toMatchObject({ taskId: 'task-1', messages: [{ content: 'pwd' }] })
+  })
+
+  it('loads the preceding transcript page with the server cursor', async () => {
+    emit.mockImplementation((name, payload, acknowledge) => {
+      expect(name).toBe('runtime:request')
+      expect(payload).toMatchObject({
+        method: 'runtime.tasks.transcript',
+        params: {
+          deviceId: 'device-1',
+          taskId: 'task-1',
+          limit: 5,
+          beforeCursor: 'offset:15',
+        },
+      })
+      acknowledge({
+        ok: true,
+        result: {
+          taskId: 'task-1',
+          workspacePath: '/work',
+          runtime: 'codex',
+          messages: [{ id: 'user-older', role: 'user', content: 'older' }],
+          hasMoreBefore: true,
+          beforeCursor: 'offset:10',
+        },
+      })
+    })
+    const stream = new RuntimeStream(config)
+
+    await expect(
+      stream.getTranscript(
+        { deviceId: 'device-1', taskId: 'task-1' },
+        { beforeCursor: 'offset:15' }
+      )
+    ).resolves.toMatchObject({ beforeCursor: 'offset:10' })
+  })
+
+  it('loads only the selected device work through the Mac runtime protocol', async () => {
+    emit.mockImplementation((name, payload, acknowledge) => {
+      expect(name).toBe('runtime:request')
+      expect(payload).toMatchObject({
+        method: 'runtime.tasks.list',
+        device_id: 'device-1',
+        timeout_seconds: 75,
+        params: {},
+      })
+      acknowledge({
+        ok: true,
+        result: {
+          workspaces: [
+            {
+              workspacePath: '/work/Wegent',
+              label: 'Wegent',
+              tasks: [{ taskId: 'task-1', title: 'Fix loading', runtime: 'codex' }],
+            },
+          ],
+        },
+      })
+    })
+    const stream = new RuntimeStream(config)
+
+    await expect(stream.listWork('device-1', 'Mac Studio')).resolves.toMatchObject({
+      projects: [
+        {
+          project: { name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'device-1',
+              deviceName: 'Mac Studio',
+              tasks: [{ taskId: 'task-1', workspacePath: '/work/Wegent' }],
+            },
+          ],
+        },
+      ],
+      totalTasks: 1,
+    })
   })
 
   it('decompresses large transcript acknowledgements', async () => {
@@ -93,6 +168,49 @@ describe('RuntimeStream', () => {
     )
   })
 
+  it('retries an oversized five-turn page as one turn with the same cursor', async () => {
+    emit
+      .mockImplementationOnce((_name, payload, acknowledge) => {
+        expect(payload).toMatchObject({
+          params: { taskId: 'task-1', limit: 5, beforeCursor: 'offset:15' },
+        })
+        acknowledge({
+          ok: false,
+          error: {
+            code: 'runtime_rpc_failed',
+            message: 'Response exceeded the transport payload limit',
+          },
+        })
+      })
+      .mockImplementationOnce((_name, payload, acknowledge) => {
+        expect(payload).toMatchObject({
+          params: { taskId: 'task-1', limit: 1, beforeCursor: 'offset:15' },
+        })
+        acknowledge({
+          ok: true,
+          result: {
+            taskId: 'task-1',
+            workspacePath: '/work',
+            runtime: 'codex',
+            messages: [{ id: 'assistant-1', role: 'assistant', content: 'latest' }],
+            beforeCursor: 'offset:14',
+          },
+        })
+      })
+    const stream = new RuntimeStream(config)
+
+    await expect(
+      stream.getTranscript(
+        { deviceId: 'device-1', taskId: 'task-1' },
+        { beforeCursor: 'offset:15' }
+      )
+    ).resolves.toMatchObject({
+      messages: [{ content: 'latest' }],
+      beforeCursor: 'offset:14',
+    })
+    expect(emit).toHaveBeenCalledTimes(2)
+  })
+
   it('surfaces runtime acknowledgement errors', async () => {
     emit.mockImplementation((_name, _payload, acknowledge) => {
       acknowledge({
@@ -105,6 +223,7 @@ describe('RuntimeStream', () => {
     await expect(stream.getTranscript({ deviceId: 'device-1', taskId: 'task-1' })).rejects.toThrow(
       'device_offline: Executor offline'
     )
+    expect(emit).toHaveBeenCalledOnce()
   })
 
   it('uses the Wework runtime relay contract and strictly scopes events', () => {

--- a/wework-mobile/src/services/runtimeStream.ts
+++ b/wework-mobile/src/services/runtimeStream.ts
@@ -3,14 +3,21 @@ import { gunzipSync, strFromU8 } from 'fflate'
 import { io, type Socket } from 'socket.io-client'
 
 import type { RuntimeStreamEvent } from '@/domain/chatReducer'
-import type { RuntimeTaskAddress, RuntimeTranscriptResponse } from '@/types/runtime'
+import { adaptRuntimeWorkListResponse } from '@/domain/runtimeWorkAdapter'
+import type {
+  RuntimeTaskAddress,
+  RuntimeTranscriptResponse,
+  RuntimeWorkListResponse,
+} from '@/types/runtime'
 import type { RuntimeSessionConfig } from './backendConfig'
 
 const RUNTIME_NAMESPACE = '/wework-runtime'
 const RUNTIME_EVENT = 'runtime:event'
 const REQUEST_EVENT = 'runtime:request'
 const TRANSCRIPT_TIMEOUT_MS = 15_000
-const TRANSCRIPT_PAGE_SIZE = 50
+const LIST_TIMEOUT_MS = 75_000
+export const TRANSCRIPT_PAGE_SIZE = 5
+const TRANSCRIPT_PAYLOAD_LIMIT_PAGE_SIZE = 1
 const COMPRESSED_ENCODING = 'gzip+base64+json'
 
 type Listener = (event: RuntimeStreamEvent) => void
@@ -84,13 +91,26 @@ export class RuntimeStream {
     }
   }
 
-  getTranscript(address: RuntimeTaskAddress): Promise<RuntimeTranscriptResponse> {
-    return this.request(
-      'runtime.tasks.transcript',
-      { ...address, limit: TRANSCRIPT_PAGE_SIZE },
-      address.deviceId,
-      TRANSCRIPT_TIMEOUT_MS
+  async getTranscript(
+    address: RuntimeTaskAddress,
+    options: { beforeCursor?: string } = {}
+  ): Promise<RuntimeTranscriptResponse> {
+    try {
+      return await this.requestTranscript(address, options, TRANSCRIPT_PAGE_SIZE)
+    } catch (error) {
+      if (!isTranscriptPayloadLimitError(error)) throw error
+      return this.requestTranscript(address, options, TRANSCRIPT_PAYLOAD_LIMIT_PAGE_SIZE)
+    }
+  }
+
+  async listWork(deviceId: string, deviceName?: string): Promise<RuntimeWorkListResponse> {
+    const response = await this.request<unknown>(
+      'runtime.tasks.list',
+      {},
+      deviceId,
+      LIST_TIMEOUT_MS
     )
+    return adaptRuntimeWorkListResponse(response, deviceId, deviceName)
   }
 
   dispose(): void {
@@ -159,6 +179,23 @@ export class RuntimeStream {
       )
     })
   }
+
+  private requestTranscript(
+    address: RuntimeTaskAddress,
+    options: { beforeCursor?: string },
+    limit: number
+  ): Promise<RuntimeTranscriptResponse> {
+    return this.request(
+      'runtime.tasks.transcript',
+      {
+        ...address,
+        limit,
+        ...(options.beforeCursor && { beforeCursor: options.beforeCursor }),
+      },
+      address.deviceId,
+      TRANSCRIPT_TIMEOUT_MS
+    )
+  }
 }
 
 function decodeRuntimeResult<T>(result: T | undefined): T {
@@ -181,6 +218,15 @@ function runtimeRequestError(ack: RuntimeRequestAck<unknown>): string {
   const code = ack.error?.code?.trim()
   const message = ack.error?.message?.trim() || 'Runtime 请求失败'
   return code ? `${code}: ${message}` : message
+}
+
+function isTranscriptPayloadLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('response exceeded the transport payload limit') ||
+    message.includes('runtime_rpc_response_too_large')
+  )
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/wework-mobile/src/types/runtime.ts
+++ b/wework-mobile/src/types/runtime.ts
@@ -40,7 +40,8 @@ export interface DeviceInfo {
   device_id: string
   name: string
   status: DeviceStatus
-  device_type?: string | null
+  device_type: 'local' | 'app' | 'cloud' | 'remote'
+  bind_shell: 'claudecode' | 'openclaw'
   capabilities?: string[] | null
 }
 
@@ -58,14 +59,20 @@ export interface RuntimeTaskAddress {
 
 export interface RuntimeTaskSummary {
   taskId: string
+  threadId?: string | null
   title: string
   runtime: string
   workspacePath: string
   workspaceKind?: string | null
+  worktreeId?: string | null
+  gitInfo?: Record<string, unknown> | null
   updatedAt?: string | number | null
   createdAt?: string | number | null
   running?: boolean
   status?: string | null
+  pinned?: boolean
+  pinnedOrder?: number | null
+  sidebarOrder?: number | null
 }
 
 export interface RuntimeDeviceWorkspace {
@@ -77,7 +84,11 @@ export interface RuntimeDeviceWorkspace {
   available: boolean
   workspacePath: string
   workspaceKind?: string | null
+  worktreeId?: string | null
   label?: string | null
+  workspaceSource?: string | null
+  remoteHostId?: string | null
+  mapped?: boolean
   tasks: RuntimeTaskSummary[]
 }
 
@@ -85,11 +96,13 @@ export interface RuntimeProjectRef {
   id?: number
   key: string
   name: string
+  stateDeviceId?: string | null
 }
 
 export interface RuntimeProjectWork {
   project: RuntimeProjectRef
   deviceWorkspaces: RuntimeDeviceWorkspace[]
+  totalTasks?: number
 }
 
 export interface RuntimeWorkListResponse {
@@ -314,7 +327,12 @@ export interface ChatNarrativeBlock extends ChatProcessingBlockBase {
   content: string
 }
 
-export type ChatProcessingBlock = ChatToolBlock | ChatNarrativeBlock
+export interface ChatFileChangesBlock extends ChatProcessingBlockBase {
+  type: 'file_changes'
+  fileChanges: ChatFileChangesSummary
+}
+
+export type ChatProcessingBlock = ChatToolBlock | ChatNarrativeBlock | ChatFileChangesBlock
 
 export interface ChatFileChangeItem {
   path: string
@@ -364,6 +382,8 @@ export interface RuntimeChatBlock {
   toolOutput?: unknown
   render_payload?: unknown
   renderPayload?: unknown
+  file_changes?: RuntimeFileChangesSummary
+  fileChanges?: RuntimeFileChangesSummary
   status?: string
   timestamp?: string | number | null
   created_at?: string | number | null


### PR DESCRIPTION
## Summary

- align mobile remote device, project, task, and message presentation with Wework desktop
- cache authentication, devices, tasks, and conversations while refreshing them asynchronously
- filter unsupported OpenClaw devices and load device/task data incrementally
- add collapsible project/task sections, processing tools, file-change summaries, and native Markdown rendering
- page conversation history and retry oversized transcript requests with a single turn
- hide injected application context from user-visible messages
- bump the iOS build to 0.1.0 (2)

## Verification

- `pnpm --dir wework-mobile typecheck`
- `pnpm --dir wework-mobile test` — 31 files, 159 tests
- `pnpm --dir wework-mobile build` — Android and iOS exports
- Xcode 27 beta 6 archive and App Store Connect upload succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions and runtime data are restored between app launches.
  * Browse work across all supported devices, refresh device data, and control offline-device visibility.
  * Load earlier conversation messages as you scroll upward.
  * View clearer processing timelines, file changes, generated images, and streaming markdown.
  * Projects and tasks are organized into collapsible sections with improved empty states.

* **Improvements**
  * Runtime work and device selection are more reliable across local and remote environments.
  * Updated app branding and iOS release/build versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->