### PR TITLE
fix(wework): preserve unsaved automation drafts

### DIFF
--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -1817,6 +1817,41 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     assert.equal(unifiedGraphNodes[1].kind, 'dynamic')
     assert.equal(unifiedGraphNodes[1].subgraph.nodes.length, 1)
 
+    const executionPrompt = '[data-testid^="execution-node-prompt-"]'
+    const unsavedPrompt = '尚未保存的自动化输入必须保留。'
+    await control.command('click', '[data-testid^="execution-node-step-"]', {
+      visible: true,
+    })
+    await control.command('fill', executionPrompt, { value: unsavedPrompt })
+    await control.command('waitFor', 'body', {
+      text: '有未保存更改',
+      timeoutMs: uiTimeoutMs,
+    })
+    await control.command('click', '[data-testid="workspace-tab-select-fixed-task"]')
+    await control.command('waitFor', '[data-testid="desktop-empty-composer-frame"]', {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    await control.command('click', boardWorkspaceTabSelector)
+    await control.command('waitFor', executionPrompt, {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    assert.equal(
+      await control.command('getValue', executionPrompt),
+      unsavedPrompt,
+      'Automation editor lost unsaved input after its parent workspace rerendered'
+    )
+    await captureScreenshot(control, 'project-automation-unsaved-draft-preserved.png')
+    await control.command('fill', executionPrompt, {
+      value: '根据 Issue 修改代码并运行相关测试。',
+    })
+    await control.command('waitFor', '[data-testid="automation-editor-global-actions"]', {
+      text: '已保存',
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+
     await disableRule(projectId, unifiedRule)
     const projectWithWorkflow = await cloudRequest(`/api/v1/cloud-projects/${projectId}`)
     await cloudRequest(`/api/v1/cloud-projects/${projectId}`, {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1628,6 +1628,97 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('desktop-workbench-content')).not.toBeInTheDocument()
   })
 
+  test('keeps a retained board bound to its own workspace tab route', async () => {
+    deliveryApiMock.available = true
+    const project = {
+      id: 'project-1',
+      public_id: 'public-project-1',
+      project_key: 'PROJECT-1',
+      name: 'Retained Project',
+      description: '',
+      project_store: 'backend',
+      task_provider: 'local',
+      provider_config: {},
+      created_by_user_id: 1,
+      status: 'active',
+      tags: [],
+      version: 1,
+      created_at: '2026-08-09T00:00:00Z',
+      updated_at: '2026-08-09T00:00:00Z',
+    }
+    deliveryApiMock.listCloudProjects.mockResolvedValue({ items: [project] })
+    const boardTab = {
+      id: 'board-project-1',
+      kind: 'board' as const,
+      title: project.name,
+      contentRoute: '/todo?projectStore=backend&projectId=project-1',
+      fixed: false,
+    }
+    const taskTab = {
+      id: 'fixed-task',
+      kind: 'task' as const,
+      title: '任务',
+      contentRoute: '/',
+      fixed: true,
+    }
+    const actions = {
+      openTab: vi.fn(),
+      selectTab: vi.fn(),
+      closeTab: vi.fn(),
+      closeOtherTabs: vi.fn(),
+      restoreClosedTab: vi.fn(),
+      moveTab: vi.fn(),
+      updateActiveTab: vi.fn(),
+    }
+    const workspaceTabs = (activeTab: typeof boardTab | typeof taskTab) => ({
+      tabs: [taskTab, boardTab],
+      activeTabId: activeTab.id,
+      activeTab,
+      ...actions,
+    })
+    const props = {
+      ...baseProps,
+      workspaceTabId: boardTab.id,
+      surfaceKind: 'board' as const,
+      state: {
+        ...baseProps.state,
+        user: {
+          id: 1,
+          user_name: 'local',
+          email: 'local@example.com',
+        },
+      },
+    }
+    const view = render(
+      <WorkspaceTabsContext.Provider value={workspaceTabs(boardTab)}>
+        <DesktopWorkbenchLayout {...props} />
+      </WorkspaceTabsContext.Provider>
+    )
+
+    expect(await screen.findByTestId('cloud-project-header')).toHaveTextContent(project.name)
+    await userEvent.click(screen.getByTestId('cloud-project-automation-view'))
+    expect(screen.getByTestId('cloud-project-automation-view')).toHaveClass('bg-background')
+
+    view.rerender(
+      <WorkspaceTabsContext.Provider value={workspaceTabs(taskTab)}>
+        <DesktopWorkbenchLayout {...props} routeActive={false} />
+      </WorkspaceTabsContext.Provider>
+    )
+
+    expect(screen.getByTestId('cloud-project-header')).toHaveTextContent(project.name)
+    expect(screen.getByTestId('cloud-project-automation-view')).toHaveClass('bg-background')
+    expect(actions.updateActiveTab).not.toHaveBeenCalled()
+
+    view.rerender(
+      <WorkspaceTabsContext.Provider value={workspaceTabs(boardTab)}>
+        <DesktopWorkbenchLayout {...props} />
+      </WorkspaceTabsContext.Provider>
+    )
+
+    expect(screen.getByTestId('cloud-project-header')).toHaveTextContent(project.name)
+    expect(screen.getByTestId('cloud-project-automation-view')).toHaveClass('bg-background')
+  })
+
   test('returns to the workspace after opening settings from its account menu', async () => {
     deliveryApiMock.available = true
     window.history.pushState({}, '', '/todo')

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -189,6 +189,11 @@ export function DesktopWorkbenchLayout({
   )
   const availableProjectSpaceApis = useMemo(() => projectSpaceApis(services), [services])
   const workspaceTabs = useOptionalWorkspaceTabs()
+  const ownedWorkspaceTab = workspaceTabs
+    ? workspaceTabId
+      ? (workspaceTabs.tabs.find(tab => tab.id === workspaceTabId) ?? null)
+      : workspaceTabs.activeTab
+    : null
   const activePane = useMemo<WorkbenchPaneIdentity>(
     () => ({
       currentRuntimeTask: state.currentRuntimeTask,
@@ -533,7 +538,7 @@ export function DesktopWorkbenchLayout({
   const [settingsOpen, setSettingsOpen] = useState(() => isSettingsRoute(initialPath))
   const settingsReturnPathRef = useRef(initialPath === '/todo' ? '/todo' : '/')
   const activeTabRouteRef = useRef(
-    workspaceTabs?.activeTab?.contentRoute ??
+    ownedWorkspaceTab?.contentRoute ??
       `${stripAppBasePath(window.location.pathname)}${window.location.search}`
   )
   const [autoOpenAddCloudDeviceDialog, setAutoOpenAddCloudDeviceDialog] = useState(false)
@@ -568,9 +573,9 @@ export function DesktopWorkbenchLayout({
   const effectiveSidebarCollapsed = sidebarCollapsed || sidebarAutoCollapsed
 
   useEffect(() => {
-    if (!workspaceTabs?.activeTab) return
-    activeTabRouteRef.current = workspaceTabs.activeTab.contentRoute
-  }, [workspaceTabs?.activeTab])
+    if (!ownedWorkspaceTab) return
+    activeTabRouteRef.current = ownedWorkspaceTab.contentRoute
+  }, [ownedWorkspaceTab])
 
   useEffect(() => {
     let previousPath = stripAppBasePath(window.location.pathname)
@@ -1095,24 +1100,30 @@ export function DesktopWorkbenchLayout({
                 onOpenSettings={options => openSettings(options)}
                 onLogout={onLogout}
                 activeProjectRef={
-                  workspaceTabs?.activeTab.kind === 'board'
-                    ? projectSpaceRefFromRoute(workspaceTabs.activeTab.contentRoute)
+                  ownedWorkspaceTab?.kind === 'board'
+                    ? projectSpaceRefFromRoute(ownedWorkspaceTab.contentRoute)
                     : undefined
                 }
                 defaultProjectRequested={
-                  workspaceTabs?.activeTab.kind === 'board' &&
-                  projectSpaceRouteRequestsDefaultProject(workspaceTabs.activeTab.contentRoute)
+                  ownedWorkspaceTab?.kind === 'board' &&
+                  projectSpaceRouteRequestsDefaultProject(ownedWorkspaceTab.contentRoute)
                 }
                 focusedItemId={
-                  workspaceTabs?.activeTab.kind === 'board'
-                    ? projectSpaceRouteParam(workspaceTabs.activeTab.contentRoute, 'itemId')
+                  ownedWorkspaceTab?.kind === 'board'
+                    ? projectSpaceRouteParam(ownedWorkspaceTab.contentRoute, 'itemId')
                     : undefined
                 }
                 onFocusedItemHandled={() => {
-                  if (!workspaceTabs || workspaceTabs.activeTab.kind !== 'board') return
-                  const projectRef = projectSpaceRefFromRoute(workspaceTabs.activeTab.contentRoute)
+                  if (
+                    !workspaceTabs ||
+                    ownedWorkspaceTab?.kind !== 'board' ||
+                    workspaceTabs.activeTabId !== ownedWorkspaceTab.id
+                  ) {
+                    return
+                  }
+                  const projectRef = projectSpaceRefFromRoute(ownedWorkspaceTab.contentRoute)
                   const defaultProjectRequested = projectSpaceRouteRequestsDefaultProject(
-                    workspaceTabs.activeTab.contentRoute
+                    ownedWorkspaceTab.contentRoute
                   )
                   workspaceTabs.updateActiveTab({
                     contentRoute: projectRef
@@ -1123,7 +1134,13 @@ export function DesktopWorkbenchLayout({
                   })
                 }}
                 onActiveProjectChange={project => {
-                  if (!workspaceTabs || workspaceTabs.activeTab.kind !== 'board') return
+                  if (
+                    !workspaceTabs ||
+                    ownedWorkspaceTab?.kind !== 'board' ||
+                    workspaceTabs.activeTabId !== ownedWorkspaceTab.id
+                  ) {
+                    return
+                  }
                   if (!project) {
                     workspaceTabs.updateActiveTab({
                       title: t('workbench.workspace_tab_board', '项目空间'),

--- a/wework/src/features/todo/AutomationRulesView.jsx
+++ b/wework/src/features/todo/AutomationRulesView.jsx
@@ -628,12 +628,17 @@ export function AutomationRulesView({
 
   useEffect(() => {
     setRules(backendRules)
-    setDraft(current => {
-      if (!current.persisted) return current
-      const refreshed = backendRules.find(rule => rule.id === current.id)
-      return refreshed ? cloneRule(refreshed) : current
-    })
   }, [backendRules])
+
+  useEffect(() => {
+    if (!draft.persisted || JSON.stringify(draft) !== savedSnapshot) return
+    const refreshed = backendRules.find(rule => rule.id === draft.id)
+    if (!refreshed) return
+    const refreshedSnapshot = JSON.stringify(refreshed)
+    if (refreshedSnapshot === savedSnapshot) return
+    setDraft(cloneRule(refreshed))
+    setSavedSnapshot(refreshedSnapshot)
+  }, [backendRules, draft, savedSnapshot])
 
   useEffect(() => {
     setRuns(backendRuns)

--- a/wework/src/features/todo/ProjectAutomationView.test.tsx
+++ b/wework/src/features/todo/ProjectAutomationView.test.tsx
@@ -3,6 +3,8 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { CloudProject } from '@/api/deliveries'
 import type { ProjectAutomationRule, ProjectAutomationRun } from '@/api/projectAutomations'
 import type { WorkbenchServices } from '@/features/workbench/workbenchServices'
+import { AutomationRulesView } from './AutomationRulesView.jsx'
+import { automationRuleFromBackend } from './automationRuleBackend'
 import { ProjectAutomationView } from './ProjectAutomationView'
 
 const localExecutorMocks = vi.hoisted(() => ({
@@ -255,7 +257,9 @@ function renderView({
       },
     ]),
   }
-  const view = render(
+  const projectAutomationView = (
+    updatedCallback: ((project: CloudProject) => void) | undefined = onProjectUpdated
+  ) => (
     <ProjectAutomationView
       api={{} as NonNullable<WorkbenchServices['deliveryApi']>}
       project={viewProject}
@@ -265,15 +269,35 @@ function renderView({
       pluginApi={pluginApi}
       currentUserId={7}
       canManageAgents
-      onProjectUpdated={onProjectUpdated}
+      onProjectUpdated={updatedCallback}
     />
   )
-  return { projectAutomationApi, deviceApi, modelApi, pluginApi, view }
+  const view = render(projectAutomationView())
+  return {
+    projectAutomationApi,
+    deviceApi,
+    modelApi,
+    pluginApi,
+    view,
+    rerender: (updatedCallback?: (project: CloudProject) => void) =>
+      view.rerender(projectAutomationView(updatedCallback)),
+  }
 }
 
 async function openRuleEditor(ruleId = 'rule-1') {
   fireEvent.click(await screen.findByTestId(`automation-card-${ruleId}`))
   return screen.findByTestId('automation-rule-editor')
+}
+
+function refreshedFirstStepPrompt(
+  current: ReturnType<typeof automationRuleFromBackend>,
+  prompt: string
+) {
+  return {
+    ...current,
+    version: current.version + 1,
+    steps: current.steps.map((step, index) => (index === 0 ? { ...step, prompt } : step)),
+  }
 }
 
 describe('ProjectAutomationView', () => {
@@ -405,6 +429,55 @@ describe('ProjectAutomationView', () => {
     expect(deviceApi.listDevices).not.toHaveBeenCalled()
     expect(modelApi.listModels).not.toHaveBeenCalled()
     expect(pluginApi.listPlugins).not.toHaveBeenCalled()
+  })
+
+  test('does not reload automation rules when a parent callback changes', async () => {
+    let now = Date.now()
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    try {
+      const { projectAutomationApi, rerender } = renderView({ onProjectUpdated: vi.fn() })
+      expect(await screen.findByTestId('automation-card-rule-1')).toBeInTheDocument()
+      expect(projectAutomationApi.list).toHaveBeenCalledOnce()
+
+      now += 31_000
+      rerender(vi.fn())
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(projectAutomationApi.list).toHaveBeenCalledOnce()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  test('preserves a dirty editor draft when refreshed rules arrive', async () => {
+    const initialRule = automationRuleFromBackend(rule)
+    const refreshedRule = refreshedFirstStepPrompt(initialRule, '服务端刷新内容')
+    const view = render(<AutomationRulesView rules={[initialRule]} runs={[]} />)
+    fireEvent.click(screen.getByTestId('automation-card-rule-1'))
+    fireEvent.click(screen.getByTestId('execution-node-step-1'))
+    fireEvent.change(screen.getByTestId('execution-node-prompt-step-1'), {
+      target: { value: '尚未保存的本地输入' },
+    })
+
+    view.rerender(<AutomationRulesView rules={[refreshedRule]} runs={[]} />)
+
+    expect(screen.getByTestId('execution-node-prompt-step-1')).toHaveValue('尚未保存的本地输入')
+    expect(screen.getByText('有未保存更改')).toBeInTheDocument()
+  })
+
+  test('applies a refreshed rule when the editor draft is clean', async () => {
+    const initialRule = automationRuleFromBackend(rule)
+    const refreshedRule = refreshedFirstStepPrompt(initialRule, '服务端刷新内容')
+    const view = render(<AutomationRulesView rules={[initialRule]} runs={[]} />)
+    fireEvent.click(screen.getByTestId('automation-card-rule-1'))
+    fireEvent.click(screen.getByTestId('execution-node-step-1'))
+
+    view.rerender(<AutomationRulesView rules={[refreshedRule]} runs={[]} />)
+
+    expect(screen.getByTestId('execution-node-prompt-step-1')).toHaveValue('服务端刷新内容')
+    expect(screen.queryByText('有未保存更改')).not.toBeInTheDocument()
   })
 
   test('opens and applies an embedded template from the template store', async () => {

--- a/wework/src/features/todo/ProjectAutomationView.tsx
+++ b/wework/src/features/todo/ProjectAutomationView.tsx
@@ -281,6 +281,7 @@ export function ProjectAutomationView(props: ProjectAutomationViewProps) {
   const projectId = String(project.id)
   const cacheKey = `${projectId}:${String(currentUserId ?? '')}`
   const projectRef = useRef(project)
+  const onProjectUpdatedRef = useRef(onProjectUpdated)
   const initialCache = readProjectAutomationRuleCache(cacheKey, projectAutomationApi)
   const [rules, setRules] = useState<AutomationUiRule[]>(() => initialCache?.rules ?? [])
   const [runs, setRuns] = useState<AutomationUiRun[]>([])
@@ -295,6 +296,10 @@ export function ProjectAutomationView(props: ProjectAutomationViewProps) {
   useEffect(() => {
     projectRef.current = project
   }, [project])
+
+  useEffect(() => {
+    onProjectUpdatedRef.current = onProjectUpdated
+  }, [onProjectUpdated])
 
   const load = useCallback(
     async ({ force = false }: { force?: boolean } = {}) => {
@@ -343,7 +348,7 @@ export function ProjectAutomationView(props: ProjectAutomationViewProps) {
               version: result.projectVersion,
             }
             projectRef.current = updatedProject
-            onProjectUpdated?.(updatedProject)
+            onProjectUpdatedRef.current?.(updatedProject)
             return buildAutomationRuleSnapshot(updatedProject, [result.automation, ...backendRules])
           })
           request = { source: projectAutomationApi, promise }
@@ -372,7 +377,7 @@ export function ProjectAutomationView(props: ProjectAutomationViewProps) {
         setLoading(false)
       }
     },
-    [cacheKey, canManageAgents, currentUserId, onProjectUpdated, projectAutomationApi, projectId, t]
+    [cacheKey, canManageAgents, currentUserId, projectAutomationApi, projectId, t]
   )
 
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unsaved automation-editor changes are now preserved when switching between workspace tabs.
  * Backend refreshes no longer overwrite in-progress editor changes.
  * Clean automation drafts continue to update when refreshed rule data differs.
  * Project update callbacks now remain current during legacy workflow migration.
  * Workspace tabs now keep their associated board content and context when switching between tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->