### PR TITLE
fix(wework): stop inferring connector auth from prompts

### DIFF
--- a/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/split-workbench.scenario.mjs
@@ -4,7 +4,7 @@ import { waitForWorkbenchDebugState } from '../modules/workspace-flows.mjs'
 
 const ACTIVE_SURFACE = '[data-workspace-tab-content][aria-hidden="false"]'
 const COMPOSER = '[data-testid="desktop-empty-composer-frame"] [data-testid="chat-message-input"]'
-const FIRST_PROMPT = 'SPLIT LEFT TASK'
+const FIRST_PROMPT = 'SPLIT LEFT TASK: investigate online Connector authentication'
 const SECOND_PROMPT = 'SPLIT RIGHT TASK'
 const THIRD_PROMPT = 'SPLIT OUTSIDE TASK'
 const PANE_SELECTOR = '[data-testid^="workbench-pane-"][data-focused]'

--- a/wework/src/features/plugins/localConnectorAuthGate.test.ts
+++ b/wework/src/features/plugins/localConnectorAuthGate.test.ts
@@ -81,7 +81,7 @@ describe('localConnectorAuthGate', () => {
     expect(items[0]?.pluginKey).toBe('weibo-api-wiki')
   })
 
-  test('only preflights explicit plugin or connector auth messages', () => {
+  test('only preflights explicit plugin mentions', () => {
     expect(messageNeedsConnectorPreflight('继续分析这个问题')).toBe(false)
     expect(
       messageNeedsConnectorPreflight(
@@ -96,7 +96,12 @@ describe('localConnectorAuthGate', () => {
           connectorSlug: 'weibo-wiki',
         })
       )
-    ).toBe(true)
+    ).toBe(false)
+    expect(
+      messageNeedsConnectorPreflight(
+        'Investigate why the online Connector authentication fails before creating a task.'
+      )
+    ).toBe(false)
   })
 
   test('detects connector_auth_required payloads', () => {

--- a/wework/src/features/plugins/localConnectorAuthGate.ts
+++ b/wework/src/features/plugins/localConnectorAuthGate.ts
@@ -84,23 +84,7 @@ export function findLocalConnectorsForMessage(
   plugins: InstalledPlugin[]
 ): LocalConnectorRequirement[] {
   const uris = message.match(PLUGIN_URI_PATTERN) ?? []
-  if (uris.length === 0) {
-    // Also gate plugins with on_use when message doesn't mention them but skills may still load.
-    // Prefer explicit mentions; fall back to enabled on_install/on_use local connectors only
-    // when the message clearly references their display name.
-    return listLocalConnectors(plugins, { authPolicies: ['on_install', 'on_use'] }).filter(
-      requirement => {
-        const name = requirement.displayName.trim()
-        const key = requirement.pluginKey.trim()
-        if (!name && !key) return false
-        const lower = message.toLowerCase()
-        return (
-          (name.length > 0 && lower.includes(name.toLowerCase())) ||
-          (key.length > 0 && lower.includes(key.toLowerCase()))
-        )
-      }
-    )
-  }
+  if (uris.length === 0) return []
 
   const mentioned = new Set<string>()
   for (const uri of uris) {
@@ -124,7 +108,7 @@ export function findLocalConnectorsForMessage(
 
 export function messageNeedsConnectorPreflight(text: string | null | undefined): boolean {
   if (!text) return false
-  return text.match(PLUGIN_URI_PATTERN) !== null || resolveLocalConnectorAuthHint(text) !== null
+  return text.match(PLUGIN_URI_PATTERN) !== null
 }
 
 /** Plugin names referenced by explicit `plugin://` mentions in composer text. */

--- a/wework/src/features/plugins/useLocalConnectorAuthGate.ts
+++ b/wework/src/features/plugins/useLocalConnectorAuthGate.ts
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createLocalCodexPluginApi } from '@/api/local/codexPlugins'
 import { useTranslation } from '@/hooks/useTranslation'
-import {
-  localConnectorAuthHealth,
-  type LocalConnectorAuthTarget,
-} from '@/api/local/localConnectorAuth'
+import type { LocalConnectorAuthTarget } from '@/api/local/localConnectorAuth'
 import {
   enrichInstalledPluginsForLocalAuth,
   extractConnectorAuthConnectorSlug,
@@ -43,13 +40,6 @@ function requirementTitle(
     : t('workbench.plugins_local_qr_login_title', { name: requirement.displayName })
 }
 
-function hintTitle(
-  displayName: string,
-  t: (key: string, options?: Record<string, unknown>) => string
-): string {
-  return t('workbench.plugins_local_qr_login_title', { name: displayName })
-}
-
 async function loadInstalledPlugins(options?: {
   pluginNames?: string[]
 }): Promise<InstalledPlugin[]> {
@@ -69,16 +59,6 @@ async function loadInstalledPlugins(options?: {
           : () => false,
     }
   )
-}
-
-async function targetNeedsLogin(target: LocalConnectorAuthTarget): Promise<boolean> {
-  try {
-    const health = await localConnectorAuthHealth(target)
-    return health.status !== 'ok'
-  } catch {
-    // If health cannot run, still show the card so the user can recover.
-    return true
-  }
 }
 
 function hasOnlyOpenAiOfficialPluginMentions(input: string): boolean {
@@ -136,9 +116,8 @@ export function useLocalConnectorAuthGate(options: {
       if (!messageNeedsConnectorPreflight(input)) return 'send'
       try {
         const mentioned = listMentionedPluginNames(input)
-        const hint = resolveLocalConnectorAuthHint(input)
-        if (!hint && hasOnlyOpenAiOfficialPluginMentions(input)) return 'send'
-        const pluginNames = [...mentioned, ...(hint?.pluginKey ? [hint.pluginKey] : [])]
+        if (hasOnlyOpenAiOfficialPluginMentions(input)) return 'send'
+        const pluginNames = mentioned
         const cached = pluginsRef.current
         const cachedCoversMentions =
           Boolean(cached) &&
@@ -176,19 +155,7 @@ export function useLocalConnectorAuthGate(options: {
         }
         const requirements = findLocalConnectorsForMessage(input, plugins)
         if (requirements.length === 0) {
-          if (!hint) return 'send'
-          const target: LocalConnectorAuthTarget = {
-            pluginKey: hint.pluginKey,
-            connectorSlug: hint.connectorSlug,
-          }
-          if (!(await targetNeedsLogin(target))) return 'send'
-          setPending({
-            target,
-            title: hintTitle(hint.displayName, t),
-            mode: 'preflight',
-            pendingInput: input,
-          })
-          return 'blocked'
+          return 'send'
         }
         const needing = await findFirstLocalNeedingLogin(requirements)
         if (!needing) return 'send'


### PR DESCRIPTION
## Summary
- restrict local connector auth preflight to explicit `plugin://` mentions
- stop inferring plugin identities from ordinary task prompt text
- add unit and desktop E2E regression coverage for `online Connector authentication`

## Verification
- `pnpm --filter wework test src/features/plugins/localConnectorAuthGate.test.ts src/api/local/localConnectorAuth.test.ts`
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- `pnpm --filter wework e2e:desktop --segment split-workbench`
- pre-push Wework ESLint, TypeScript, and unit tests

Closes WORK-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connector authentication checks now trigger only when a message explicitly includes a plugin URI.
  * Generic authentication-related wording no longer incorrectly triggers connector preflight checks.
  * Messages without explicit plugin references are sent normally instead of showing an authentication prompt.
* **Tests**
  * Updated coverage to reflect the refined connector authentication behavior.
* **End-to-End Tests**
  * Updated a desktop scenario to explicitly test investigating online Connector authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->