### PR TITLE
fix(wework): align sidebar and composer typography

### DIFF
--- a/wework/dsh/ui-cloud-work/src/CloudConnectionSidebarButton.tsx
+++ b/wework/dsh/ui-cloud-work/src/CloudConnectionSidebarButton.tsx
@@ -246,7 +246,7 @@ export function CloudConnectionSidebarButton({
           }}
           title={statusTitle}
           className={cn(
-            'flex h-[30px] min-w-0 flex-1 items-center gap-2 rounded-[10px] py-0 pl-0 pr-2 text-left text-base font-normal leading-5 text-[rgb(var(--color-sidebar-text-primary))]',
+            'flex h-[30px] min-w-0 flex-1 items-center gap-2 rounded-[10px] py-0 pl-0 pr-2 text-left text-base leading-5 text-[rgb(var(--color-sidebar-text-primary))]',
             (needsAttention || cloudWorkUnavailable) && 'text-red-500'
           )}
         >

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -1666,7 +1666,8 @@ describe('DesktopSidebar', () => {
     const projectsTitle = projectsToggle.querySelector('span')
 
     for (const button of [newTaskButton, pluginsButton, cloudButton]) {
-      expect(button).toHaveClass('font-normal', 'text-[rgb(var(--color-sidebar-text-primary))]')
+      expect(button).not.toHaveClass('font-normal')
+      expect(button).toHaveClass('text-[rgb(var(--color-sidebar-text-primary))]')
     }
     expect(collapseSidebarButton).toHaveClass(
       'text-[rgb(var(--color-sidebar-text-primary))]',

--- a/wework/src/components/layout/DesktopSidebarPrimitives.tsx
+++ b/wework/src/components/layout/DesktopSidebarPrimitives.tsx
@@ -55,7 +55,7 @@ export function DesktopSidebarNavItem({
       onClick={onClick}
       onPointerEnter={onPointerEnter}
       className={cn(
-        'flex h-[30px] w-full items-center gap-2 rounded-[10px] px-2 text-left text-base font-normal leading-5',
+        'flex h-[30px] w-full items-center gap-2 rounded-[10px] px-2 text-left text-base leading-5',
         selected
           ? 'bg-[rgb(var(--color-sidebar-active))] text-text-primary'
           : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]'

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -790,12 +790,12 @@ button:disabled {
   .composer-mention-node,
   .composer-link-node {
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
     max-width: 100%;
     font-size: inherit;
     font-weight: inherit;
     line-height: inherit;
-    vertical-align: baseline;
+    vertical-align: -0.08em;
     white-space: nowrap;
     user-select: text;
     -webkit-user-select: text;
@@ -837,7 +837,6 @@ button:disabled {
     display: inline-block;
     flex: none;
     order: -1;
-    align-self: center;
     width: 1em;
     height: 1em;
     margin-right: 0.25em;


### PR DESCRIPTION
## Summary

- let top-level desktop sidebar navigation inherit the shared Wework UI font weight
- vertically center plugin mention contents and align the inline node with surrounding composer text
- update the sidebar typography regression assertion

## Verification

- `pnpm --filter wework test src/components/layout/DesktopSidebar.test.tsx`
- `pnpm --filter wework test src/components/chat/composer/composerMentions.test.ts src/components/chat/composer/ComposerProseMirrorEditor.test.tsx`
- pre-commit Wework formatting, ESLint, and typography checks
- pre-push Wework ESLint, TypeScript, full renderer unit tests, and DSH unit tests
- isolated Electron visual verification in light/default-size and dark/16px themes
- isolated Electron empty-composer verification: caret and placeholder share the same first-line box

Task: WORK-367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar button text styling to inherit the default font weight.
  * Improved vertical alignment for composer mentions and links, including mention icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->