### PR TITLE
fix(wework): theme remote device select menu

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -718,6 +718,9 @@ semantics for all three.
   persistent visible label.
 - Placeholder text is an example or prompt, not the only label.
 - Helper and error text sit next to the field they describe.
+- Native `select` popups must explicitly theme their `option`, `optgroup`, and
+  disabled text from Wework semantic tokens. Do not rely on the host platform
+  to inherit the WebView's light or dark colors for the expanded popup.
 - Validate format after blur or a reasonable pause; validate completeness on
   submit.
 - Preserve valid values and focus the first invalid field or an error summary.

--- a/wework/e2e/desktop/scenarios/tray-lifecycle.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/tray-lifecycle.scenario.mjs
@@ -4,6 +4,24 @@ async function readWindowState(control) {
   return JSON.parse(await control.command('getNativeWindowState', 'body'))
 }
 
+async function waitForReadyAfter(control, readyCount, timeoutMs) {
+  let timeout
+  const reconnectTimeout = new Promise((_, reject) => {
+    timeout = setTimeout(
+      () =>
+        reject(
+          new Error('Restoring the main window from Tray did not reconnect the desktop controller')
+        ),
+      timeoutMs
+    )
+  })
+  try {
+    await Promise.race([control.awaitReadyAfter(readyCount), reconnectTimeout])
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 async function waitForWindowState(control, predicate, message, timeoutMs) {
   const deadline = Date.now() + timeoutMs
   let latest = null
@@ -75,7 +93,7 @@ export async function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) 
       await control.command('activateTray', 'body', {
         value: JSON.stringify({ type: 'click' }),
       })
-      await control.awaitReadyAfter(readyCountBeforeClose)
+      await waitForReadyAfter(control, readyCountBeforeClose, uiTimeoutMs)
       const restored = await waitForWindowState(
         control,
         state => state.visible && !state.minimized,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4706,6 +4706,7 @@ describe('DesktopWorkbenchLayout', () => {
     await userEvent.click(screen.getByTestId('project-create-remote-option'))
 
     const select = screen.getByTestId('standalone-remote-device-select')
+    expect(select).toHaveClass('wework-native-select')
     expect(select).toHaveTextContent('云设备')
     expect(select).toHaveTextContent('远程 Docker 设备')
     expect(select).toHaveTextContent('Cloud Device')

--- a/wework/src/components/projects/StandaloneProjectDialogs.tsx
+++ b/wework/src/components/projects/StandaloneProjectDialogs.tsx
@@ -849,7 +849,7 @@ export function StandaloneFolderProjectDialog({
                   setGitParentPickerOpen(false)
                   setGitError(null)
                 }}
-                className="min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none"
+                className="wework-native-select min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none"
               >
                 {!activeDevice && (
                   <option value="" disabled>

--- a/wework/src/components/sites/SitesWorkspace.test.tsx
+++ b/wework/src/components/sites/SitesWorkspace.test.tsx
@@ -775,7 +775,7 @@ describe('SitesWorkspace', () => {
     render(<SitesWorkspace api={api} onCreate={vi.fn()} />)
 
     expect(await screen.findByTestId('environment-variables-dialog')).toBeInTheDocument()
-    expect(api.getEnvironmentVariables).toHaveBeenCalledWith('site-1')
+    await waitFor(() => expect(api.getEnvironmentVariables).toHaveBeenCalledWith('site-1'))
   })
 
   test('keeps the edit dialog open when metadata saving fails', async () => {

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -19,6 +19,24 @@ body[data-wework-panel-resizing] [data-testid='workspace-browser-frame'] {
   pointer-events: none !important;
 }
 
+.wework-native-select {
+  color-scheme: inherit;
+}
+
+.wework-native-select optgroup {
+  background-color: rgb(var(--color-popover));
+  color: rgb(var(--color-text-secondary));
+}
+
+.wework-native-select option {
+  background-color: rgb(var(--color-popover));
+  color: rgb(var(--color-text-primary));
+}
+
+.wework-native-select option:disabled {
+  color: rgb(var(--color-text-muted));
+}
+
 :root {
   color-scheme: light;
   --color-bg-base: 255 255 255;

--- a/wework/src/test/theme-token-guard.test.ts
+++ b/wework/src/test/theme-token-guard.test.ts
@@ -100,6 +100,19 @@ describe('theme token guard', () => {
     expect(source).toContain("darkMode: 'class'")
   })
 
+  test('native select menus derive their popup colors from theme tokens', () => {
+    const globalsPath = resolve(process.cwd(), 'src/styles/globals.css')
+    const source = readFileSync(globalsPath, 'utf8')
+
+    expect(source).toContain('.wework-native-select optgroup {')
+    expect(source).toContain('.wework-native-select option {')
+    expect(source).toContain('.wework-native-select option:disabled {')
+    expect(source).toContain('background-color: rgb(var(--color-popover));')
+    expect(source).toContain('color: rgb(var(--color-text-primary));')
+    expect(source).toContain('color: rgb(var(--color-text-secondary));')
+    expect(source).toContain('color: rgb(var(--color-text-muted));')
+  })
+
   test('titlebar and window frame use the same opaque surface colors', () => {
     const globalsPath = resolve(process.cwd(), 'src/styles/globals.css')
     const source = readFileSync(globalsPath, 'utf8')


### PR DESCRIPTION
## Summary

- theme the native remote-device select popup with Wework semantic colors in light and dark modes
- preserve the native select behavior and existing desktop E2E selectors
- document the native select theming rule in the Wework design specification
- fix the Sites environment deep-link unit test race by waiting for the child effect request

## Verification

- focused remote project and theme token tests: 269 passed
- focused Sites deep-link test: 1 passed
- Prettier and ESLint passed
- isolated Electron build and launch passed
- pre-push: ESLint, TypeScript, and 5184 unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Native select menus now use application theme colors for option groups, options, and disabled options.
  - Remote device selectors now match standard application select styling.

- **Documentation**
  - Updated design guidance to define theme requirements for native select popups.

- **Quality Improvements**
  - Added coverage for themed select menus and remote device selector styling.
  - Improved desktop tray restoration checks with clearer timeout handling when reconnection does not complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->