### PR TITLE
fix(device): probe --insecure-storage support before gh/glab auth login

### DIFF
--- a/backend/app/schemas/git_credentials.py
+++ b/backend/app/schemas/git_credentials.py
@@ -44,6 +44,7 @@ class GitCliSyncResult(BaseModel):
     domain: str
     status: Literal["configured", "not_installed", "failed"]
     reason_code: Optional[str] = None
+    detail: Optional[str] = None
 
 
 class DeviceGitAccountSyncResponse(BaseModel):

--- a/backend/app/services/device/git_credentials.py
+++ b/backend/app/services/device/git_credentials.py
@@ -261,6 +261,8 @@ def _safe_device_result(
     device_id: str,
     result: dict[str, Any],
     duplicate_domains: list[str],
+    *,
+    user_id: int,
 ) -> dict[str, Any]:
     stdout = result.get("stdout")
     if not result.get("success") or not isinstance(stdout, dict):
@@ -274,6 +276,20 @@ def _safe_device_result(
         )
 
     cli = stdout.get("cli") if isinstance(stdout.get("cli"), list) else []
+    for item in cli:
+        if not isinstance(item, dict) or item.get("status") == "configured":
+            continue
+        logger.warning(
+            "Git credential CLI setup incomplete: user_id=%s device_id=%s "
+            "provider=%s domain=%s status=%s reason_code=%s detail=%s",
+            user_id,
+            device_id,
+            item.get("provider"),
+            item.get("domain"),
+            item.get("status"),
+            item.get("reason_code"),
+            item.get("detail"),
+        )
     identity_warnings = (
         stdout.get("identity_warning_domains")
         if isinstance(stdout.get("identity_warning_domains"), list)
@@ -361,4 +377,4 @@ async def sync_git_accounts_to_device(
             raise DeviceGitCredentialSyncError(
                 "The selected device could not receive Git credentials"
             ) from exc
-    return _safe_device_result(device_id, result, duplicate_domains)
+    return _safe_device_result(device_id, result, duplicate_domains, user_id=user.id)

--- a/backend/app/services/device/git_credentials_command.py
+++ b/backend/app/services/device/git_credentials_command.py
@@ -163,6 +163,24 @@ def secure_tree(path):
     ensure_mode(path, 0o700)
 
 
+def cli_supports_insecure_storage(executable):
+    # --insecure-storage only exists on gh/glab releases with keyring-backed
+    # token storage; older CLIs already store tokens in the config file.
+    try:
+        result = subprocess.run(
+            [executable, "auth", "login", "--help"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return "--insecure-storage" in (result.stdout or "")
+
+
 def configure_cli(account, revision):
     provider = account["provider"]
     tool = "gh" if provider == "github" else "glab" if provider == "gitlab" else None
@@ -182,30 +200,22 @@ def configure_cli(account, revision):
     environment = os.environ.copy()
     if tool == "gh":
         environment["GH_CONFIG_DIR"] = str(config_dir)
-        command = [
-            executable,
-            "auth",
-            "login",
-            "--hostname",
-            account["domain"],
-            "--git-protocol",
-            "https",
-            "--with-token",
-            "--insecure-storage",
-        ]
+        token_flag = "--with-token"
     else:
         environment["GLAB_CONFIG_DIR"] = str(config_dir)
-        command = [
-            executable,
-            "auth",
-            "login",
-            "--hostname",
-            account["domain"],
-            "--git-protocol",
-            "https",
-            "--stdin",
-            "--insecure-storage",
-        ]
+        token_flag = "--stdin"
+    command = [
+        executable,
+        "auth",
+        "login",
+        "--hostname",
+        account["domain"],
+        "--git-protocol",
+        "https",
+        token_flag,
+    ]
+    if cli_supports_insecure_storage(executable):
+        command.append("--insecure-storage")
 
     try:
         result = subprocess.run(

--- a/backend/app/services/device/git_credentials_command.py
+++ b/backend/app/services/device/git_credentials_command.py
@@ -13,6 +13,7 @@ import fcntl
 import hashlib
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -163,9 +164,11 @@ def secure_tree(path):
     ensure_mode(path, 0o700)
 
 
-def cli_supports_insecure_storage(executable):
-    # --insecure-storage only exists on gh/glab releases with keyring-backed
-    # token storage; older CLIs already store tokens in the config file.
+def cli_login_flags(executable):
+    # Executor images ship wildly different gh/glab generations: some predate
+    # --git-protocol, others predate keyring-backed storage and reject
+    # --insecure-storage. Unknown flags make `auth login` exit non-zero, so
+    # probe the installed CLI and only pass the flags it advertises.
     try:
         result = subprocess.run(
             [executable, "auth", "login", "--help"],
@@ -173,12 +176,28 @@ def cli_supports_insecure_storage(executable):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            errors="replace",
             timeout=10,
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return False
-    return "--insecure-storage" in (result.stdout or "")
+        return frozenset()
+    return frozenset(re.findall(r"--[a-z][a-z0-9-]+", result.stdout or ""))
+
+
+def cli_failure_detail(result, token, *, spawn_error=None):
+    # Surface a sanitized, token-free tail of the CLI output so sync failures
+    # are diagnosable from backend logs and the API response.
+    if spawn_error is not None:
+        return "spawn_error: %s" % spawn_error
+    output = (result.stdout or "") if result else ""
+    if token:
+        output = output.replace(token, "***")
+    output = " ".join(output.split())
+    if len(output) > 300:
+        output = "..." + output[-300:]
+    prefix = "exit=%s" % (result.returncode if result else "?")
+    return "%s %s".strip() % (prefix, output) if output else prefix
 
 
 def configure_cli(account, revision):
@@ -210,26 +229,30 @@ def configure_cli(account, revision):
         "login",
         "--hostname",
         account["domain"],
-        "--git-protocol",
-        "https",
-        token_flag,
     ]
-    if cli_supports_insecure_storage(executable):
+    flags = cli_login_flags(executable)
+    if "--git-protocol" in flags:
+        command += ["--git-protocol", "https"]
+    command.append(token_flag)
+    if "--insecure-storage" in flags:
         command.append("--insecure-storage")
 
     try:
         result = subprocess.run(
             command,
             input=account["token"] + "\n",
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
+            errors="replace",
             timeout=30,
             check=False,
             env=environment,
         )
-    except (OSError, subprocess.TimeoutExpired):
+        spawn_error = None
+    except (OSError, subprocess.TimeoutExpired) as exc:
         result = None
+        spawn_error = type(exc).__name__
     secure_tree(config_dir)
     if result is None or result.returncode != 0:
         return {
@@ -237,7 +260,32 @@ def configure_cli(account, revision):
             "domain": account["domain"],
             "status": "failed",
             "reason_code": "cli_auth_failed",
+            "detail": cli_failure_detail(
+                result, account["token"], spawn_error=spawn_error
+            ),
         }
+    if "--git-protocol" not in flags:
+        # Legacy CLIs (e.g. glab 1.2x) cannot select the git protocol at login
+        # and default to ssh; force https afterwards so CLI-driven git
+        # operations also use the synced HTTPS credentials. Failure is
+        # harmless because the managed gitconfig already rewrites ssh to https.
+        subprocess.run(
+            [
+                executable,
+                "config",
+                "set",
+                "git_protocol",
+                "https",
+                "--host",
+                account["domain"],
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+            env=environment,
+        )
+        secure_tree(config_dir)
     return {
         "provider": tool,
         "domain": account["domain"],

--- a/backend/tests/services/device/test_git_credentials.py
+++ b/backend/tests/services/device/test_git_credentials.py
@@ -446,22 +446,23 @@ def test_device_command_reports_cli_outcome_without_affecting_git_auth(
     assert applied.returncode == 0, applied.stderr
     assert token not in applied.stdout
     result = json.loads(applied.stdout)
-    assert result["cli"] == [
-        {
-            "provider": "gh" if provider == "github" else "glab",
-            "domain": f"{provider}.example.com",
-            "status": expected_status,
-            "reason_code": (
-                None
-                if expected_status == "configured"
-                else (
-                    "cli_auth_failed"
-                    if expected_status == "failed"
-                    else "cli_not_installed"
-                )
-            ),
-        }
-    ]
+    expected_cli_result = {
+        "provider": "gh" if provider == "github" else "glab",
+        "domain": f"{provider}.example.com",
+        "status": expected_status,
+        "reason_code": (
+            None
+            if expected_status == "configured"
+            else (
+                "cli_auth_failed"
+                if expected_status == "failed"
+                else "cli_not_installed"
+            )
+        ),
+    }
+    if expected_status == "failed":
+        expected_cli_result["detail"] = f"exit={tool_exit_code}"
+    assert result["cli"] == [expected_cli_result]
 
     environment = os.environ.copy()
     environment["HOME"] = str(home)
@@ -513,23 +514,71 @@ def _recording_tool_path(
     return str(bin_path), args_log
 
 
+def test_device_command_redacts_token_from_cli_failure_detail(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    for command in ("git", "python3", "sh"):
+        executable = shutil.which(command)
+        assert executable is not None
+        (bin_path / command).symlink_to(executable)
+    token = "leaky-glab-secret"
+    glab = bin_path / "glab"
+    glab.write_text(
+        "#!/bin/sh\nread -r credential\n"
+        f'echo "login failed for token {token}" >&2\n'
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    glab.chmod(0o700)
+    account = {
+        "domain": "gitlab.example.com",
+        "host": "gitlab.example.com",
+        "provider": "gitlab",
+        "token": token,
+        "username": "alice",
+        "identity_name": "Alice",
+        "identity_email": "alice@example.com",
+    }
+
+    applied = _run_sync_command(home, [account], command_path=str(bin_path))
+
+    assert applied.returncode == 0, applied.stderr
+    cli_result = json.loads(applied.stdout)["cli"][0]
+    assert cli_result["status"] == "failed"
+    assert "login failed for token ***" in cli_result["detail"]
+    assert token not in applied.stdout
+
+
 @pytest.mark.parametrize("supports_insecure_storage", [True, False])
-def test_device_command_only_passes_insecure_storage_when_supported(
+@pytest.mark.parametrize("supports_git_protocol", [True, False])
+def test_device_command_only_passes_supported_login_flags(
     tmp_path,
     supports_insecure_storage,
+    supports_git_protocol,
 ):
-    # Legacy CLIs (e.g. glab 1.79 shipped in executor images) exit 1 on the
-    # unknown --insecure-storage flag, so the sync must probe for support.
+    # Executor images ship different glab generations: some reject
+    # --insecure-storage, others (e.g. glab 1.2x) reject --git-protocol.
+    # Unknown flags make `auth login` exit non-zero, so the sync must probe
+    # for support and only pass the flags the installed CLI advertises.
     home = tmp_path / "home"
     home.mkdir()
     help_text = "Usage: glab auth login --hostname <host> --stdin"
     if supports_insecure_storage:
         help_text += " --insecure-storage"
+    if supports_git_protocol:
+        help_text += " --git-protocol"
+    reject_flag = None
+    if not supports_git_protocol:
+        reject_flag = "--git-protocol"
+    elif not supports_insecure_storage:
+        reject_flag = "--insecure-storage"
     command_path, args_log = _recording_tool_path(
         tmp_path,
         tool="glab",
         help_text=help_text,
-        reject_flag=None if supports_insecure_storage else "--insecure-storage",
+        reject_flag=reject_flag,
     )
     account = {
         "domain": "gitlab.example.com",
@@ -546,12 +595,14 @@ def test_device_command_only_passes_insecure_storage_when_supported(
     assert applied.returncode == 0, applied.stderr
     result = json.loads(applied.stdout)
     assert result["cli"][0]["status"] == "configured"
-    login_invocations = [
-        line
-        for line in args_log.read_text(encoding="utf-8").splitlines()
-        if "--hostname" in line
-    ]
+    invocations = args_log.read_text(encoding="utf-8").splitlines()
+    login_invocations = [line for line in invocations if "--hostname" in line]
     assert len(login_invocations) == 1
     assert (
         "--insecure-storage" in login_invocations[0]
     ) is supports_insecure_storage
+    assert ("--git-protocol" in login_invocations[0]) is supports_git_protocol
+    config_set_invocations = [
+        line for line in invocations if line.startswith("config set git_protocol")
+    ]
+    assert len(config_set_invocations) == (0 if supports_git_protocol else 1)

--- a/backend/tests/services/device/test_git_credentials.py
+++ b/backend/tests/services/device/test_git_credentials.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -479,3 +480,78 @@ def test_device_command_reports_cli_outcome_without_affecting_git_auth(
     assert f"password={token}" in credential.stdout
     env_file = home / ".wecode" / "git-auth" / "env.sh"
     assert env_file.exists() is (expected_status == "configured")
+
+
+def _recording_tool_path(
+    tmp_path: Path,
+    *,
+    tool: str,
+    help_text: str,
+    reject_flag: str | None = None,
+) -> tuple[str, Path]:
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    for command in ("git", "python3", "sh"):
+        executable = shutil.which(command)
+        assert executable is not None
+        (bin_path / command).symlink_to(executable)
+    args_log = tmp_path / "tool-args.log"
+    script = (
+        "#!/bin/sh\n"
+        'if [ "$1" = "auth" ] && [ "$2" = "login" ] && [ "$3" = "--help" ]; then\n'
+        f"  printf '%s\\n' {shlex.quote(help_text)}\n"
+        "  exit 0\n"
+        "fi\n"
+        f"printf '%s\\n' \"$*\" >> {shlex.quote(str(args_log))}\n"
+    )
+    if reject_flag:
+        script += f'case " $* " in *" {reject_flag} "*) exit 1;; esac\n'
+    script += "read -r credential\nexit 0\n"
+    executable = bin_path / tool
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return str(bin_path), args_log
+
+
+@pytest.mark.parametrize("supports_insecure_storage", [True, False])
+def test_device_command_only_passes_insecure_storage_when_supported(
+    tmp_path,
+    supports_insecure_storage,
+):
+    # Legacy CLIs (e.g. glab 1.79 shipped in executor images) exit 1 on the
+    # unknown --insecure-storage flag, so the sync must probe for support.
+    home = tmp_path / "home"
+    home.mkdir()
+    help_text = "Usage: glab auth login --hostname <host> --stdin"
+    if supports_insecure_storage:
+        help_text += " --insecure-storage"
+    command_path, args_log = _recording_tool_path(
+        tmp_path,
+        tool="glab",
+        help_text=help_text,
+        reject_flag=None if supports_insecure_storage else "--insecure-storage",
+    )
+    account = {
+        "domain": "gitlab.example.com",
+        "host": "gitlab.example.com",
+        "provider": "gitlab",
+        "token": "cli-probe-secret",
+        "username": "alice",
+        "identity_name": "Alice",
+        "identity_email": "alice@example.com",
+    }
+
+    applied = _run_sync_command(home, [account], command_path=command_path)
+
+    assert applied.returncode == 0, applied.stderr
+    result = json.loads(applied.stdout)
+    assert result["cli"][0]["status"] == "configured"
+    login_invocations = [
+        line
+        for line in args_log.read_text(encoding="utf-8").splitlines()
+        if "--hostname" in line
+    ]
+    assert len(login_invocations) == 1
+    assert (
+        "--insecure-storage" in login_invocations[0]
+    ) is supports_insecure_storage

--- a/wework/electron/pnpm-lock.yaml
+++ b/wework/electron/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@trycua/cua-driver@0.22.1': 1f161a52203b2bcd3207ec2f08bc914596e4abc7660028b035d0670b52368acd
+  '@trycua/cua-driver@0.22.1':
+    hash: 1f161a52203b2bcd3207ec2f08bc914596e4abc7660028b035d0670b52368acd
+    path: patches/@trycua__cua-driver@0.22.1.patch
 
 importers:
 
@@ -320,6 +322,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
@@ -333,6 +336,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1231,6 +1235,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}

--- a/wework/src/components/settings/DeviceGitSyncSection.tsx
+++ b/wework/src/components/settings/DeviceGitSyncSection.tsx
@@ -328,6 +328,7 @@ export function DeviceGitSyncSection({
                       {item.status === 'not_installed'
                         ? t('workbench.git_device_sync_cli_missing', 'CLI 未安装，Git 认证已生效')
                         : t('workbench.git_device_sync_cli_failed', 'CLI 登录失败，Git 认证已生效')}
+                      {item.status === 'failed' && item.detail ? `（${item.detail}）` : null}
                     </p>
                   ))}
                 {syncResult.identity_warning_domains.length ? (

--- a/wework/src/components/settings/GitHostingSettingsPage.test.tsx
+++ b/wework/src/components/settings/GitHostingSettingsPage.test.tsx
@@ -138,6 +138,7 @@ describe('GitHostingSettingsPage', () => {
           domain: 'git.example.com',
           status: 'not_installed',
           reason_code: 'cli_not_installed',
+          detail: null,
         },
       ],
       warning_codes: [],
@@ -242,6 +243,36 @@ describe('GitHostingSettingsPage', () => {
     )
   })
 
+  test('shows CLI failure detail from the device sync result', async () => {
+    syncGitAccounts.mockResolvedValue({
+      device_id: 'remote-1',
+      status: 'synced_with_warnings',
+      synced_domains: ['git.example.com'],
+      removed_domains: [],
+      duplicate_domains: [],
+      identity_warning_domains: [],
+      cli: [
+        {
+          provider: 'glab',
+          domain: 'git.example.com',
+          status: 'failed',
+          reason_code: 'cli_auth_failed',
+          detail: 'exit=1 error validating token: unauthorized',
+        },
+      ],
+      warning_codes: [],
+    })
+    render(<DeviceGitSyncSection />)
+
+    await screen.findAllByText('gitlab · git.example.com')
+    await userEvent.selectOptions(screen.getByTestId('git-device-sync-select'), 'remote-1')
+    await userEvent.click(screen.getByTestId('git-device-sync-submit'))
+
+    expect(await screen.findByTestId('git-device-sync-result')).toHaveTextContent(
+      'CLI 登录失败，Git 认证已生效（exit=1 error validating token: unauthorized）'
+    )
+  })
+
   test('requires confirmation before clearing managed credentials', async () => {
     getGitAccountSyncSummary.mockResolvedValue({
       accounts: [],
@@ -284,6 +315,7 @@ describe('GitHostingSettingsPage', () => {
           domain: 'git.example.com',
           status: 'configured',
           reason_code: null,
+          detail: null,
         },
       ],
       warning_codes: ['stale_cleanup_failed'],

--- a/wework/src/types/gitCredentials.ts
+++ b/wework/src/types/gitCredentials.ts
@@ -21,6 +21,7 @@ export interface GitCliSyncResult {
   domain: string
   status: 'configured' | 'not_installed' | 'failed'
   reason_code: string | null
+  detail: string | null
 }
 
 export interface DeviceGitAccountSyncResult {


### PR DESCRIPTION
## Summary

- 设备 Git 配置同步在云设备上执行 `glab auth login ... --insecure-storage` 时失败（UI 提示「CLI 登录失败，Git 认证已生效」）。
- 根因：executor 基础镜像（`docker/base/Dockerfile`）固定安装 **glab 1.79.0**，该版本早于 keyring 存储，不认识 `--insecure-storage`，直接 `Unknown flag` 退出 1。已用官方 1.79.0 二进制本地复现；去掉该参数后同版本登录成功，token 明文写入 `$GLAB_CONFIG_DIR/config.yml`（这本来就是 `--insecure-storage` 想保留的行为）。
- 修复：`configure_cli` 先执行 `auth login --help` 探测，仅当 CLI 支持时才附加 `--insecure-storage`。对存量旧设备和新设备都生效，gh 同理兼容。
- 附带参数化回归测试：模拟「不支持且传参即失败」的旧 glab 与支持该 flag 的新 glab，断言两种情况下都能 configured 且参数传递正确。

## Test plan

- [x] `cd backend && uv run pytest tests/services/device/test_git_credentials.py` — 17 passed
- [x] 用真实 glab 1.79.0 二进制跑完整同步脚本，`status: configured`，token 正确写入托管 config
- [x] 用真实 glab 1.114.0 复跑，同样 configured（新 CLI 路径不回归）
- [ ] 合并后在 wework 重新点击「同步 Git 配置」，确认 glab 域不再报 CLI 登录失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git credential setup across supported CLI tools.
  * Uses only authentication options supported by the installed CLI.
  * Applies HTTPS configuration for older CLI versions that lack direct protocol support.
  * Prevents login failures caused by unsupported insecure-storage options.
  * Provides additional details when CLI authentication fails while protecting access tokens.
  * Git authentication remains effective even if provider CLI setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->