### PR TITLE
fix(wework): restore hidden window on relaunch

### DIFF
--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -1191,7 +1191,37 @@ async function main() {
       ])
       return child
     }
+    const launchSecondDesktopAppInstance = async () => {
+      const child = spawn(appBinary, electronLaunchArguments, {
+        cwd: weworkDir,
+        env: appEnvironment,
+        stdio: 'ignore',
+      })
+      await new Promise((resolvePromise, reject) => {
+        const timeout = setTimeout(() => {
+          child.kill('SIGKILL')
+          reject(new Error('The second Wework instance did not exit after transferring focus'))
+        }, DEFAULT_STEP_TIMEOUT_MS)
+        child.once('error', error => {
+          clearTimeout(timeout)
+          reject(error)
+        })
+        child.once('exit', (code, signal) => {
+          clearTimeout(timeout)
+          if (code === 0) {
+            resolvePromise()
+            return
+          }
+          reject(
+            new Error(
+              `The second Wework instance exited with ${code ?? `signal ${signal ?? 'unknown'}`}`
+            )
+          )
+        })
+      })
+    }
     app = await startDesktopAppProcess()
+    desktopScenario?.setLaunchSecondInstance?.(launchSecondDesktopAppInstance)
     const restartDesktopApp = async (options = null) => {
       const beforeStart = typeof options === 'function' ? options : options?.afterStop
       const desktopDeviceIdPath = join(resultDir, 'electron-user-data', 'desktop-device-id')

--- a/wework/e2e/desktop/scenarios/embedded-browser-annotation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-annotation.scenario.mjs
@@ -675,19 +675,6 @@ async function pageValue(bridge, expression) {
   return result.value
 }
 
-async function pageValueWithRuntimeDiagnostics(control, bridge, expression, previousRevision) {
-  try {
-    return await pageValue(bridge, expression)
-  } catch (error) {
-    const actualRevision = await browserAnnotationRuntimeRevision(control).catch(() => null)
-    throw new Error(
-      `${
-        error instanceof Error ? error.message : String(error)
-      }; annotationRuntimeRevision=${previousRevision}->${String(actualRevision)}`
-    )
-  }
-}
-
 async function waitForPageValue(bridge, expression, expected, timeoutMs, message) {
   const startedAt = Date.now()
   let actual = null
@@ -1216,15 +1203,12 @@ async function verifyDesign(
     uiTimeoutMs,
     'Holding Original View did not complete its page render'
   )
-  assert.equal(
-    await pageValueWithRuntimeDiagnostics(
-      control,
-      bridge,
-      `getComputedStyle(document.querySelector('#design-target')).color`,
-      runtimeRevision
-    ),
+  await waitForPageValue(
+    bridge,
+    `getComputedStyle(document.querySelector('#design-target')).color`,
     'rgb(17, 24, 39)',
-    'Original View did not restore the target color'
+    uiTimeoutMs,
+    `Original View did not restore the target color after runtime revision ${runtimeRevision}`
   )
   await captureScreenshot(control, 'browser-annotation-06-original-view.png')
   await control.command('pointerUp', BROWSER_ANNOTATION_ORIGINAL_VIEW_SELECTOR)
@@ -1244,15 +1228,12 @@ async function verifyDesign(
     uiTimeoutMs,
     'Releasing Original View did not complete its page render'
   )
-  assert.equal(
-    await pageValueWithRuntimeDiagnostics(
-      control,
-      bridge,
-      `getComputedStyle(document.querySelector('#design-target')).color`,
-      runtimeRevision
-    ),
+  await waitForPageValue(
+    bridge,
+    `getComputedStyle(document.querySelector('#design-target')).color`,
     'rgb(239, 68, 68)',
-    'Releasing Original View did not replay the design change'
+    uiTimeoutMs,
+    `Releasing Original View did not replay the design change after runtime revision ${runtimeRevision}`
   )
 
   await control.command('click', BROWSER_ANNOTATION_CLOSE_SELECTOR)

--- a/wework/e2e/desktop/scenarios/tray-lifecycle.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/tray-lifecycle.scenario.mjs
@@ -4,16 +4,10 @@ async function readWindowState(control) {
   return JSON.parse(await control.command('getNativeWindowState', 'body'))
 }
 
-async function waitForReadyAfter(control, readyCount, timeoutMs) {
+async function waitForReadyAfter(control, readyCount, timeoutMs, message) {
   let timeout
   const reconnectTimeout = new Promise((_, reject) => {
-    timeout = setTimeout(
-      () =>
-        reject(
-          new Error('Restoring the main window from Tray did not reconnect the desktop controller')
-        ),
-      timeoutMs
-    )
+    timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
   })
   try {
     await Promise.race([control.awaitReadyAfter(readyCount), reconnectTimeout])
@@ -45,8 +39,19 @@ async function waitForRoute(control, expected, timeoutMs) {
 }
 
 export async function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) {
+  let launchSecondInstance = null
+
   return {
+    appEnvironment: {
+      WEWORK_E2E_BACKGROUND_WINDOW: '0',
+    },
+
+    setLaunchSecondInstance(launch) {
+      launchSecondInstance = launch
+    },
+
     async verify(control) {
+      assert.ok(launchSecondInstance, 'The second-instance launcher was not configured')
       const tray = JSON.parse(await control.command('getTraySnapshot', 'body'))
       assert.equal(tray.created, true, 'The Electron Tray was not created')
       assert.match(
@@ -74,7 +79,7 @@ export async function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) 
       )
       await waitForRoute(control, '/settings', uiTimeoutMs)
 
-      const readyCountBeforeClose = control.readyCount
+      const readyCountBeforeSecondInstance = control.readyCount
       await control.command('requestMainWindowClose', 'body')
       await control.command('waitFor', '[data-testid="runtime-task-close-confirm-overlay"]', {
         timeoutMs: uiTimeoutMs,
@@ -90,10 +95,45 @@ export async function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) 
         assert.equal(hidden.dockVisible, false, 'Closing to Tray did not hide the macOS Dock icon')
       }
 
+      await launchSecondInstance()
+      await waitForReadyAfter(
+        control,
+        readyCountBeforeSecondInstance,
+        uiTimeoutMs,
+        'Launching Wework again did not reconnect the desktop controller'
+      )
+      const secondInstanceRestored = await waitForWindowState(
+        control,
+        state => state.visible && !state.minimized,
+        'Launching Wework again did not restore the hidden main window',
+        uiTimeoutMs
+      )
+      if (secondInstanceRestored.platform === 'darwin') {
+        assert.equal(
+          secondInstanceRestored.dockVisible,
+          true,
+          'Launching Wework again did not restore the macOS Dock icon'
+        )
+      }
+      await captureScreenshot(control, 'tray-lifecycle-second-instance-restored.png', 'body')
+
+      const readyCountBeforeTrayRestore = control.readyCount
+      await control.command('requestMainWindowClose', 'body')
+      await waitForWindowState(
+        control,
+        state => !state.visible,
+        'A subsequent close-to-tray request did not hide the Electron window',
+        uiTimeoutMs
+      )
       await control.command('activateTray', 'body', {
         value: JSON.stringify({ type: 'click' }),
       })
-      await waitForReadyAfter(control, readyCountBeforeClose, uiTimeoutMs)
+      await waitForReadyAfter(
+        control,
+        readyCountBeforeTrayRestore,
+        uiTimeoutMs,
+        'Restoring the main window from Tray did not reconnect the desktop controller'
+      )
       const restored = await waitForWindowState(
         control,
         state => state.visible && !state.minimized,
@@ -107,7 +147,7 @@ export async function createDesktopScenario({ captureScreenshot, uiTimeoutMs }) 
     },
 
     diagnostics() {
-      return { trayLifecycle: true }
+      return { secondInstanceRestore: true, trayLifecycle: true }
     },
   }
 }

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -304,10 +304,9 @@ app.on('second-instance', (_event, _argv, _workingDirectory, additionalData) => 
   if (workspaceOpenRequest) queueWorkspaceOpenRequest(workspaceOpenRequest)
   if (keepE2EWindowInBackground) return
   if (focusStartupSplashIfActive()) return
-  if (!mainWindow) return
-  if (mainWindow.isMinimized()) mainWindow.restore()
-  mainWindow.show()
-  mainWindow.focus()
+  void reactivateMainWindow().catch(error => {
+    console.error('[window] failed to reactivate main window from second instance', error)
+  })
 })
 
 function normalizedWorkspaceOpenRequest(value: unknown): LocalWorkspaceOpenRequest | null {
@@ -1017,11 +1016,10 @@ async function reactivateMainWindow(): Promise<void> {
     e2eForegroundActivationAllowed = true
     app.setActivationPolicy('regular')
   }
+  if (process.platform === 'darwin') app.show()
+  presentWindow(target)
   await setDockVisible(true)
   await loadPrimaryDshView()
-  if (target.isMinimized()) target.restore()
-  target.show()
-  target.focus()
 }
 
 function dispatchTrayAction(action: TrayAction): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop app behavior when a second instance is launched while the primary app is minimized to the system tray.
  - The existing app window now reliably reappears and receives focus.
  - On macOS, the Dock icon is restored correctly during app reactivation.
  - Improved window and app-content focus during startup and reactivation.
  - Improved reliability when checking annotation colors after switching views.
  - Added coverage for repeated close-to-tray and tray-restoration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->