### PR TITLE
feat(wework): toggle offline device items in sidebar

### DIFF
--- a/wework/src/components/common/ActionMenu.test.tsx
+++ b/wework/src/components/common/ActionMenu.test.tsx
@@ -214,4 +214,28 @@ describe('ActionMenu', () => {
     expect(zoomIn).toHaveBeenCalledOnce()
     expect(screen.getByTestId('more-actions-menu')).toBeInTheDocument()
   })
+
+  test('exposes checked items with checkbox menu semantics', () => {
+    render(
+      <ActionMenu
+        ariaLabel="More actions"
+        testId="more-actions"
+        items={[
+          {
+            label: 'Show offline devices',
+            testId: 'show-offline-devices',
+            checked: true,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('more-actions'))
+
+    const item = screen.getByTestId('show-offline-devices')
+    expect(item).toHaveAttribute('role', 'menuitemcheckbox')
+    expect(item).toHaveAttribute('aria-checked', 'true')
+    expect(item.querySelector('svg')).toBeInTheDocument()
+  })
 })

--- a/wework/src/components/common/ActionMenu.tsx
+++ b/wework/src/components/common/ActionMenu.tsx
@@ -7,7 +7,7 @@ import type {
 } from 'react'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { ChevronDown, ChevronRight, MoreHorizontal } from 'lucide-react'
+import { Check, ChevronDown, ChevronRight, MoreHorizontal } from 'lucide-react'
 import { KeyboardShortcut } from './KeyboardShortcut'
 
 const MENU_GAP = 8
@@ -40,6 +40,7 @@ export interface ActionMenuItem {
   testId: string
   danger?: boolean
   disabled?: boolean
+  checked?: boolean
   shortcut?: string
   children?: ActionMenuItem[]
   /** Renders a static separator row instead of an interactive item. */
@@ -468,7 +469,8 @@ export function ActionMenu({
                   ref={element => {
                     itemRefs.current[item.testId] = element
                   }}
-                  role="menuitem"
+                  role={item.checked === undefined ? 'menuitem' : 'menuitemcheckbox'}
+                  aria-checked={item.checked}
                   disabled={item.disabled}
                   aria-haspopup={item.children?.length ? 'menu' : undefined}
                   aria-expanded={item.children?.length ? openSubmenuId === item.testId : undefined}
@@ -521,6 +523,9 @@ export function ActionMenu({
                       className="ml-auto h-5 bg-muted px-1.5 text-xs text-text-secondary"
                     />
                   ) : null}
+                  {item.checked ? (
+                    <Check className="ml-auto h-4 w-4 shrink-0 text-text-secondary" />
+                  ) : null}
                   {item.children?.length ? <ChevronRight className="ml-auto h-4 w-4" /> : null}
                 </button>
               )
@@ -554,7 +559,8 @@ export function ActionMenu({
                     ref={element => {
                       submenuItemRefs.current[item.testId] = element
                     }}
-                    role="menuitem"
+                    role={item.checked === undefined ? 'menuitem' : 'menuitemcheckbox'}
+                    aria-checked={item.checked}
                     disabled={item.disabled}
                     onPointerDown={event => {
                       if (item.disabled) return
@@ -589,6 +595,9 @@ export function ActionMenu({
                         value={formatActionMenuShortcut(item.shortcut)}
                         className="ml-auto h-5 bg-muted px-1.5 text-xs text-text-secondary"
                       />
+                    ) : null}
+                    {item.checked ? (
+                      <Check className="ml-auto h-4 w-4 shrink-0 text-text-secondary" />
                     ) : null}
                   </button>
                 )

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -3313,6 +3313,143 @@ describe('DesktopSidebar', () => {
     expect(onArchiveRuntimeTask).not.toHaveBeenCalled()
   })
 
+  test('shows offline device projects and tasks by default and persists hiding them', async () => {
+    const user = userEvent.setup()
+    const runtimeWork = {
+      projects: [
+        {
+          project: { id: 7, key: 'project:7', name: 'Online project' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'local-device',
+              deviceName: 'Local Mac',
+              deviceStatus: 'online' as const,
+              available: true,
+              workspacePath: '/repo/online',
+              tasks: [
+                {
+                  taskId: 'online-project-task',
+                  workspacePath: '/repo/online',
+                  title: 'Online project task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          project: { id: 8, key: 'project:8', name: 'Offline project' },
+          deviceWorkspaces: [
+            {
+              deviceId: 'remote-device',
+              deviceName: 'Remote Host',
+              deviceStatus: 'offline' as const,
+              available: false,
+              workspacePath: '/repo/offline',
+              tasks: [
+                {
+                  taskId: 'offline-project-task',
+                  workspacePath: '/repo/offline',
+                  title: 'Offline project task',
+                  runtime: 'codex',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      chats: [
+        {
+          deviceId: 'local-device',
+          deviceName: 'Local Mac',
+          deviceStatus: 'online' as const,
+          available: true,
+          workspacePath: '/chats/online',
+          workspaceKind: 'chat',
+          tasks: [
+            {
+              taskId: 'online-chat-task',
+              workspacePath: '/chats/online',
+              workspaceKind: 'chat',
+              title: 'Online chat task',
+              runtime: 'codex',
+            },
+          ],
+        },
+        {
+          deviceId: 'remote-device',
+          deviceName: 'Remote Host',
+          deviceStatus: 'offline' as const,
+          available: false,
+          workspacePath: '/chats/offline',
+          workspaceKind: 'chat',
+          tasks: [
+            {
+              taskId: 'offline-chat-task',
+              workspacePath: '/chats/offline',
+              workspaceKind: 'chat',
+              title: 'Offline chat task',
+              runtime: 'codex',
+            },
+          ],
+        },
+      ],
+      totalTasks: 4,
+    }
+    const props = {
+      devices: [
+        localDevice(),
+        localDevice({
+          id: 2,
+          device_id: 'remote-device',
+          name: 'Remote Host',
+          status: 'offline' as const,
+          is_default: false,
+          device_type: 'remote',
+        }),
+      ],
+      runtimeWork,
+      onArchiveProjectsConversations: vi.fn().mockResolvedValue(undefined),
+    }
+
+    const view = renderSidebar(props)
+
+    expect(screen.getByTestId('project-row-7')).toBeInTheDocument()
+    expect(screen.getByTestId('project-row-8')).toBeInTheDocument()
+    expect(screen.getByTestId('runtime-local-task-row-online-chat-task')).toBeInTheDocument()
+    expect(screen.getByTestId('runtime-local-task-row-offline-chat-task')).toBeInTheDocument()
+
+    const offlineProjectToggle = screen
+      .getByTestId('project-row-8')
+      .querySelector<HTMLButtonElement>('[data-testid="project-item-button"]')
+    expect(offlineProjectToggle).not.toBeNull()
+    await user.click(offlineProjectToggle!)
+    expect(screen.getByTestId('runtime-local-task-row-offline-project-task')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('projects-section-menu'))
+    const visibilityItem = screen.getByTestId('projects-section-show-offline-device-items')
+    expect(visibilityItem).toHaveAttribute('role', 'menuitemcheckbox')
+    expect(visibilityItem).toHaveAttribute('aria-checked', 'true')
+    await user.click(visibilityItem)
+
+    expect(screen.getByTestId('project-row-7')).toBeInTheDocument()
+    expect(screen.queryByTestId('project-row-8')).not.toBeInTheDocument()
+    expect(screen.getByTestId('runtime-local-task-row-online-chat-task')).toBeInTheDocument()
+    expect(screen.queryByTestId('runtime-local-task-row-offline-chat-task')).not.toBeInTheDocument()
+    expect(localStorage.getItem('wework.desktop.sidebar.showOfflineDeviceItems.1')).toBe('false')
+
+    view.unmount()
+    renderSidebar(props)
+
+    expect(screen.queryByTestId('project-row-8')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('runtime-local-task-row-offline-chat-task')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('projects-section-menu'))
+    expect(screen.getByTestId('projects-section-show-offline-device-items')).toHaveAttribute(
+      'aria-checked',
+      'false'
+    )
+  })
+
   test('shows an available remote project IP with green status', () => {
     renderSidebar({
       devices: [

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -741,6 +741,27 @@ function getRuntimeProjectDeviceState(
   }
 }
 
+function isRuntimeWorkspaceOffline(
+  workspace: RuntimeDeviceWorkspace,
+  devices: DeviceInfo[]
+): boolean {
+  const resolvedDevice = getSidebarDeviceState(workspace.deviceId, devices)
+  const status = resolvedDevice?.device ? resolvedDevice.status : workspace.deviceStatus
+  return status === 'offline'
+}
+
+function filterOfflineRuntimeProjectWorkspaces(
+  projects: RuntimeProjectWork[],
+  devices: DeviceInfo[]
+): RuntimeProjectWork[] {
+  return projects.flatMap(projectWork => {
+    const deviceWorkspaces = projectWork.deviceWorkspaces.filter(
+      workspace => !isRuntimeWorkspaceOffline(workspace, devices)
+    )
+    return deviceWorkspaces.length > 0 ? [{ ...projectWork, deviceWorkspaces }] : []
+  })
+}
+
 function isRuntimeRemoteProject(runtimeProjectWork: RuntimeProjectWork | undefined): boolean {
   const workspaces = runtimeProjectWork?.deviceWorkspaces ?? []
   return (
@@ -3058,6 +3079,10 @@ export function DesktopSidebar({
   const projectsExpandedStorageKey = getDesktopSidebarStorageKey(storageScope, 'projectsExpanded')
   const chatsExpandedStorageKey = getDesktopSidebarStorageKey(storageScope, 'chatsExpanded')
   const priorityPinnedStorageKey = getDesktopSidebarStorageKey(storageScope, 'priorityShowPinned')
+  const showOfflineDeviceItemsStorageKey = getDesktopSidebarStorageKey(
+    storageScope,
+    'showOfflineDeviceItems'
+  )
   const expandedProjectIdsStorageKey = getDesktopSidebarStorageKey(
     storageScope,
     'expandedProjectIds'
@@ -3108,6 +3133,9 @@ export function DesktopSidebar({
   const priorityFilterShortcut = useConfiguredKeybinding(TOGGLE_PRIORITY_FILTER_COMMAND)
   const [priorityShowPinned, setPriorityShowPinned] = useState(() =>
     readStoredBoolean(priorityPinnedStorageKey, false)
+  )
+  const [showOfflineDeviceItems, setShowOfflineDeviceItems] = useState(() =>
+    readStoredBoolean(showOfflineDeviceItemsStorageKey, true)
   )
   const [expandedProjectIds, setExpandedProjectIds] = useState<Set<number>>(() =>
     readStoredNumberSet(expandedProjectIdsStorageKey)
@@ -3175,7 +3203,7 @@ export function DesktopSidebar({
       reconcileRuntimeTaskPinOverrides(current, runtimeTaskPersistedPinStates, revision)
     )
   }, [runtimeTaskPersistedPinStates])
-  const sidebarRuntimeProjects = useMemo(
+  const allSidebarRuntimeProjects = useMemo(
     () =>
       sidebarRuntimeProjectSource.map(projectWork => ({
         ...projectWork,
@@ -3199,12 +3227,35 @@ export function DesktopSidebar({
       })),
     [runtimeTaskPinOverrides, sidebarRuntimeProjectSource]
   )
+  const sidebarRuntimeProjects = useMemo(
+    () =>
+      showOfflineDeviceItems
+        ? allSidebarRuntimeProjects
+        : filterOfflineRuntimeProjectWorkspaces(allSidebarRuntimeProjects, devices),
+    [allSidebarRuntimeProjects, devices, showOfflineDeviceItems]
+  )
+  const allSidebarProjects = useMemo(() => {
+    if (runtimeWork || standaloneProjectWork) {
+      return allSidebarRuntimeProjects.map(runtimeProjectToProject)
+    }
+    return projects
+  }, [allSidebarRuntimeProjects, projects, runtimeWork, standaloneProjectWork])
   const sidebarProjects = useMemo(() => {
     if (runtimeWork || standaloneProjectWork) {
       return sidebarRuntimeProjects.map(runtimeProjectToProject)
     }
-    return projects
-  }, [projects, runtimeWork, sidebarRuntimeProjects, standaloneProjectWork])
+    if (showOfflineDeviceItems) return projects
+    return projects.filter(
+      project => getSidebarDeviceState(getProjectDeviceId(project), devices)?.status !== 'offline'
+    )
+  }, [
+    devices,
+    projects,
+    runtimeWork,
+    showOfflineDeviceItems,
+    sidebarRuntimeProjects,
+    standaloneProjectWork,
+  ])
   const visibleExpandedProjectIds = useMemo(
     () => pruneProjectIdSet(expandedProjectIds, sidebarProjects),
     [expandedProjectIds, sidebarProjects]
@@ -3239,12 +3290,16 @@ export function DesktopSidebar({
     () => new Set(sidebarProjects.map(project => project.id)),
     [sidebarProjects]
   )
+  const allSidebarProjectIds = useMemo(
+    () => new Set(allSidebarProjects.map(project => project.id)),
+    [allSidebarProjects]
+  )
   const standaloneLocalHarnessSessions = useMemo(
     () =>
       localHarnessSessions.filter(
-        session => session.projectId === null || !sidebarProjectIds.has(session.projectId)
+        session => session.projectId === null || !allSidebarProjectIds.has(session.projectId)
       ),
-    [localHarnessSessions, sidebarProjectIds]
+    [allSidebarProjectIds, localHarnessSessions]
   )
   const localHarnessSessionsByProjectId = useMemo(() => {
     const sessionsByProjectId = new Map<number, LocalHarnessWorkbenchSession[]>()
@@ -3261,9 +3316,18 @@ export function DesktopSidebar({
     () => getRuntimeChatSidebarTaskItems(chatWorkspaces),
     [chatWorkspaces]
   )
+  const visibleChatTaskItems = useMemo(
+    () =>
+      showOfflineDeviceItems
+        ? chatTaskItems
+        : getRuntimeChatSidebarTaskItems(
+            chatWorkspaces.filter(workspace => !isRuntimeWorkspaceOffline(workspace, devices))
+          ),
+    [chatTaskItems, chatWorkspaces, devices, showOfflineDeviceItems]
+  )
   const chatTaskItemsWithPinState = useMemo(
     () =>
-      chatTaskItems.map(item => {
+      visibleChatTaskItems.map(item => {
         const threadId = getRuntimeTaskThreadId(item.task)
         const persistedPinned = Boolean(item.task.pinned)
         const override = threadId
@@ -3274,7 +3338,7 @@ export function DesktopSidebar({
         const pinned = getRuntimeTaskPinnedValue(persistedPinned, override)
         return pinned === persistedPinned ? item : { ...item, task: { ...item.task, pinned } }
       }),
-    [chatTaskItems, runtimeTaskPinOverrides]
+    [runtimeTaskPinOverrides, visibleChatTaskItems]
   )
   const regularChatTaskItems = useMemo(
     () => chatTaskItemsWithPinState.filter(({ task }) => !task.pinned),
@@ -3539,13 +3603,13 @@ export function DesktopSidebar({
     }
   }
   const projectSectionArchiveItems = useMemo(() => {
-    return sidebarRuntimeProjects
+    return allSidebarRuntimeProjects
       .map(projectWork => ({
         key: projectWork.project.key,
         count: getRuntimeSidebarTaskItems(projectWork.deviceWorkspaces).length,
       }))
       .filter(item => item.count > 0)
-  }, [sidebarRuntimeProjects])
+  }, [allSidebarRuntimeProjects])
   const projectSectionArchiveKeys = useMemo(
     () => projectSectionArchiveItems.map(item => item.key),
     [projectSectionArchiveItems]
@@ -3794,6 +3858,11 @@ export function DesktopSidebar({
 
   useEffect(() => {
     if (storageScopeRef.current !== storageScope) return
+    writeStoredBoolean(showOfflineDeviceItemsStorageKey, showOfflineDeviceItems)
+  }, [showOfflineDeviceItems, showOfflineDeviceItemsStorageKey, storageScope])
+
+  useEffect(() => {
+    if (storageScopeRef.current !== storageScope) return
     writeStoredNumberSet(expandedProjectIdsStorageKey, expandedProjectIds)
   }, [expandedProjectIds, expandedProjectIdsStorageKey, storageScope])
 
@@ -3806,12 +3875,14 @@ export function DesktopSidebar({
     setPriorityFilterActive(false)
     setPrioritySession(null)
     setPriorityShowPinned(readStoredBoolean(priorityPinnedStorageKey, false))
+    setShowOfflineDeviceItems(readStoredBoolean(showOfflineDeviceItemsStorageKey, true))
     setExpandedProjectIds(readStoredNumberSet(expandedProjectIdsStorageKey))
   }, [
     chatsExpandedStorageKey,
     expandedProjectIdsStorageKey,
     priorityPinnedStorageKey,
     projectsExpandedStorageKey,
+    showOfflineDeviceItemsStorageKey,
     storageScope,
   ])
 
@@ -4271,6 +4342,15 @@ export function DesktopSidebar({
                                 projectSectionArchiveCount === 0 ||
                                 isArchivingProjectSection,
                               onSelect: () => setArchiveSectionMode('projects'),
+                            },
+                            {
+                              label: t(
+                                'workbench.show_offline_device_items',
+                                '显示离线设备中的项目和任务'
+                              ),
+                              testId: 'projects-section-show-offline-device-items',
+                              checked: showOfflineDeviceItems,
+                              onSelect: () => setShowOfflineDeviceItems(visible => !visible),
                             },
                           ]}
                           triggerClassName="flex h-8 w-8 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -584,6 +584,7 @@
     "worktree_unavailable_preflight_failed": "Could not verify worktree availability.",
     "worktree_unavailable_workspace_identity_mismatch": "The workspace repository has changed. Reconnect the code workspace before creating a worktree.",
     "archive_all_chats": "Archive all chats",
+    "show_offline_device_items": "Show projects and tasks from offline devices",
     "archive_chats": "Archive chats",
     "archive_chat": "Archive chat",
     "archive_runtime_task": "Archive task",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -583,6 +583,7 @@
     "worktree_unavailable_preflight_failed": "无法确认工作树是否可用。",
     "worktree_unavailable_workspace_identity_mismatch": "工作区仓库已经变化，请重新关联代码工作区后再创建工作树。",
     "archive_all_chats": "归档所有聊天",
+    "show_offline_device_items": "显示离线设备中的项目和任务",
     "archive_chats": "归档会话",
     "archive_chat": "归档会话",
     "archive_runtime_task": "归档任务",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to show or hide projects, tasks, and chats from offline devices in the desktop sidebar.
  - The preference is saved and restored for future sessions.
  - Added checkable menu items with checkmarks and accessibility states.

- **Localization**
  - Added English and Simplified Chinese labels for the offline-device visibility option.

- **Tests**
  - Added coverage for checkable menu items and persisted offline-device visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->