### PR TITLE
fix(wework): clear stuck embedded browser navigation errors

### DIFF
--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -301,6 +301,53 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     await rm(directory, { recursive: true, force: true })
   })
 
+  test('ignores aborted load rejections instead of recording a navigation error', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockRejectedValue(
+      new Error('ERR_ABORTED (-3) loading "https://example.test/"')
+    )
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+
+    const state = await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    expect(state.navigationError).toBeNull()
+    expect(manager.state('workspace-browser').navigationError).toBeNull()
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('clears a stale navigation error when a main-frame navigation commits', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    contents.emit('did-fail-load', {}, -105, 'ERR_NAME_NOT_RESOLVED', 'https://example.test/', true)
+    expect(manager.state('workspace-browser').navigationError).toMatchObject({ code: -105 })
+
+    contents.commitUrl('https://example.test/')
+    contents.emit('did-navigate', {}, 'https://example.test/')
+    expect(manager.state('workspace-browser').navigationError).toBeNull()
+    await rm(directory, { recursive: true, force: true })
+  })
+
   test('keeps the host cursor visible briefly between adjacent agent actions', async () => {
     vi.useFakeTimers()
     const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -131,6 +131,9 @@ export interface BrowserBackgroundPageState {
 }
 
 const AGENT_CURSOR_IDLE_HIDE_MS = 4_000
+// Chromium's ERR_ABORTED: the load was superseded by a newer navigation, which
+// is a normal race, not a user-facing failure.
+const NAVIGATION_ABORTED_ERROR_CODE = -3
 export const EMBEDDED_BROWSER_PARTITION = 'persist:wework-browser'
 export const EMBEDDED_BROWSER_ROUTE_PARTITION_PREFIX = 'persist:wework-browser-app-route:'
 export const EMBEDDED_BROWSER_ROUTE_HOST_SEPARATOR = ':host:'
@@ -452,6 +455,9 @@ export class EmbeddedBrowserManager {
       if (entry.historyId) void this.history.backfillTitle(entry.historyId, title)
     })
     contents.on('did-navigate', (_event, url) => {
+      // A committed main-frame navigation means a page is on screen again, so
+      // any failure recorded by a superseded load is now stale.
+      entry.navigationError = null
       if (url !== entry.previewDisplayUrl) {
         entry.requestedUrl = url
         entry.previewDisplayUrl = null
@@ -468,7 +474,7 @@ export class EmbeddedBrowserManager {
       emitPageState()
     })
     contents.on('did-fail-load', (_event, code, message, validatedURL, isMainFrame) => {
-      if (!isMainFrame || code === -3) return
+      if (!isMainFrame || code === NAVIGATION_ABORTED_ERROR_CODE) return
       this.recordNavigationFailure(entry, code, message, validatedURL || entry.requestedUrl)
     })
     contents.on('did-start-navigation', (_event, _url, _inPlace, isMainFrame) => {
@@ -1146,6 +1152,10 @@ export class EmbeddedBrowserManager {
       if (!entry.navigationError) {
         const message = error instanceof Error ? error.message : String(error)
         const code = Number(message.match(/\((-?\d+)\)/)?.[1] ?? -2)
+        // loadURL rejects with ERR_ABORTED when a newer navigation supersedes
+        // this one. The winning navigation reports its own outcome, so an
+        // aborted load must not leave a sticky failure on the entry.
+        if (code === NAVIGATION_ABORTED_ERROR_CODE) return
         this.recordNavigationFailure(entry, code, message, url)
       }
     }


### PR DESCRIPTION
## Problem

Pages opened by an AI agent in the Wework embedded browser could not be clicked by the user at all. Diagnosis showed a transparent, full-area "page failed to load" overlay stuck on top of the browser panel: it intercepted every click and set the webview container to `pointer-events: none`, while the page underneath had actually loaded and rendered fine.

Root cause: when two navigations race (e.g. the webview's initial load vs. an agent-driven open), the superseded `loadURL` promise rejects with `ERR_ABORTED (-3)`. The `did-fail-load` listener correctly ignores `-3`, but the `load()` catch path did not — so it recorded a sticky `navigationError`. That error was only cleared on the next `did-start-navigation`, so it never went away once the winning navigation committed, permanently blocking user input.

## Fix

- Ignore `ERR_ABORTED` in the `load()` catch path, matching the existing `did-fail-load` filtering. An aborted load is always superseded by a newer navigation that reports its own outcome.
- Clear any stale `navigationError` when a main-frame navigation commits (`did-navigate`), so the state self-heals even if a superseded load reports a failure late.

## Tests

- Added two regression tests: aborted load rejections no longer record a navigation error, and a committed navigation clears a previously recorded error.
- `embedded-browser-manager` suite: 22/22 passing; `tsc --noEmit` clean.
- Verified end-to-end in a dev instance (`dev:mac`): agent-opened pages accept user clicks again, and clicking the page surfaces the "you are controlling the browser" takeover bar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented aborted page loads from being incorrectly reported as navigation errors.
  * Cleared stale navigation errors after a successful main-frame navigation.
  * Improved navigation status accuracy when one page load supersedes another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->