### PR TITLE
fix(frontend): simplify mobile video settings

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -124,15 +124,18 @@ jest.mock('@/features/tasks/components/selector/VideoSettingsPopover', () => ({
   default: ({
     showDuration,
     hiddenVideoParams,
+    inline,
   }: {
     showDuration?: boolean
     hiddenVideoParams?: string[]
+    inline?: boolean
   }) => (
     <button
       type="button"
       data-testid="mobile-video-settings"
       data-show-duration={showDuration === false ? 'false' : 'true'}
       data-hidden-video-params={hiddenVideoParams?.join(',')}
+      data-inline={inline ? 'true' : 'false'}
     />
   ),
 }))
@@ -504,13 +507,21 @@ describe('MobileChatInputControls layout', () => {
       />
     )
 
-    expect(screen.getByTestId('mobile-video-model-selector')).toBeInTheDocument()
     expect(screen.getByTestId('mobile-team-selector-slot')).toContainElement(
       screen.getByTestId('mobile-team-selector')
     )
     expect(screen.queryByTestId('mobile-model-selector-slot')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-video-model-selector')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByTestId('mobile-input-more-actions-button'))
+    expect(screen.getByTestId('mobile-video-configuration-button')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('mobile-video-configuration-button'))
+    expect(screen.getByTestId('mobile-video-configuration')).toContainElement(
+      screen.getByTestId('mobile-video-model-selector')
+    )
+    expect(screen.getByTestId('mobile-video-model-selector')).toHaveAttribute(
+      'data-trigger-variant',
+      'settings-row'
+    )
     expect(screen.getByTestId('mobile-video-settings')).toHaveAttribute(
       'data-show-duration',
       'false'
@@ -518,6 +529,46 @@ describe('MobileChatInputControls layout', () => {
     expect(screen.getByTestId('mobile-video-settings')).toHaveAttribute(
       'data-hidden-video-params',
       'duration'
+    )
+    expect(screen.getByTestId('mobile-video-settings')).toHaveAttribute('data-inline', 'true')
+  })
+
+  it('moves video mode and model out of the primary row', () => {
+    render(
+      <MobileChatInputControls
+        {...buildProps()}
+        taskType="video"
+        videoGenerationModes={[
+          { id: 'text_to_video', label: 'Text to video' },
+          { id: 'omni_reference', label: 'Omni reference' },
+        ]}
+        selectedVideoGenerationMode="omni_reference"
+        onVideoGenerationModeChange={jest.fn()}
+        selectedVideoModel={null}
+        onVideoModelChange={jest.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('mobile-team-selector-slot')).toContainElement(
+      screen.getByTestId('mobile-team-selector')
+    )
+    expect(screen.queryByTestId('video-generation-mode-selector')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-video-model-selector')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mobile-video-configuration-button')).toHaveClass('h-11', 'w-11')
+
+    fireEvent.click(screen.getByTestId('mobile-video-configuration-button'))
+
+    const videoConfiguration = screen.getByTestId('mobile-video-configuration')
+    expect(videoConfiguration).toContainElement(screen.getByTestId('video-generation-mode-options'))
+    expect(videoConfiguration).toContainElement(screen.getByTestId('mobile-video-model-selector'))
+    expect(screen.queryByTestId('video-generation-mode-selector')).not.toBeInTheDocument()
+    expect(screen.getByTestId('video-generation-mode-omni_reference')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(screen.getByTestId('mobile-video-model-selector')).toHaveAttribute(
+      'data-trigger-variant',
+      'settings-row'
     )
   })
 
@@ -548,6 +599,7 @@ describe('MobileChatInputControls layout', () => {
 
     expect(screen.queryByTestId('mobile-video-model-selector')).not.toBeInTheDocument()
     expect(screen.queryByTestId('mobile-video-settings')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-video-configuration-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('mobile-input-more-actions-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('send-button')).toBeInTheDocument()
   })

--- a/frontend/src/__tests__/features/tasks/components/selector/VideoGenerationModeSelector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/VideoGenerationModeSelector.test.tsx
@@ -3,9 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import VideoGenerationModeSelector from '@/features/tasks/components/selector/VideoGenerationModeSelector'
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === 'video.generation_mode_section' ? '视频模式' : key),
+  }),
+}))
 
 describe('VideoGenerationModeSelector', () => {
   it('renders the selected mode as a labeled menu item', () => {
@@ -25,5 +31,31 @@ describe('VideoGenerationModeSelector', () => {
 
     expect(trigger).toHaveTextContent('全能参考')
     expect(trigger).toHaveClass('h-11', 'w-full', 'rounded-md')
+  })
+
+  it('renders mobile video modes inline without a nested popover', () => {
+    const onChange = jest.fn()
+
+    render(
+      <VideoGenerationModeSelector
+        modes={[
+          { id: 'omni_reference', label: '全能模式' },
+          { id: 'first_last_frame', label: '首尾帧' },
+        ]}
+        value="omni_reference"
+        onChange={onChange}
+        inline
+      />
+    )
+
+    expect(screen.getByTestId('video-generation-mode-options')).toHaveTextContent('视频模式')
+    expect(screen.queryByTestId('video-generation-mode-selector')).not.toBeInTheDocument()
+    expect(screen.getByTestId('video-generation-mode-omni_reference')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+
+    fireEvent.click(screen.getByTestId('video-generation-mode-first_last_frame'))
+    expect(onChange).toHaveBeenCalledWith('first_last_frame')
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/selector/VideoSettingsPopover.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/VideoSettingsPopover.test.tsx
@@ -104,6 +104,8 @@ describe('VideoSettingsPopover', () => {
 
     expect(screen.getByTestId('video-settings-inline')).toBeInTheDocument()
     expect(screen.queryByTestId('video-settings-trigger')).not.toBeInTheDocument()
+    expect(screen.getByTestId('video-duration-option-5')).toHaveClass('min-h-11')
+    expect(screen.getByTestId('video-resolution-option-720p')).toHaveClass('min-h-11')
 
     fireEvent.click(screen.getByTestId('video-ratio-option-9:16'))
     expect(onRatioChange).toHaveBeenCalledWith('9:16')

--- a/frontend/src/__tests__/features/tasks/components/selector/VideoSettingsPopover.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/VideoSettingsPopover.test.tsx
@@ -84,6 +84,31 @@ describe('VideoSettingsPopover', () => {
     expect(trigger).toHaveClass('min-h-14', 'w-full')
   })
 
+  it('renders settings inline without a nested trigger', () => {
+    const onRatioChange = jest.fn()
+
+    render(
+      <VideoSettingsPopover
+        selectedRatio="16:9"
+        onRatioChange={onRatioChange}
+        availableRatios={['16:9', '9:16']}
+        selectedDuration={5}
+        onDurationChange={jest.fn()}
+        availableDurations={[5, 10]}
+        selectedResolution="720p"
+        onResolutionChange={jest.fn()}
+        availableResolutions={['720p', '1080p']}
+        inline
+      />
+    )
+
+    expect(screen.getByTestId('video-settings-inline')).toBeInTheDocument()
+    expect(screen.queryByTestId('video-settings-trigger')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('video-ratio-option-9:16'))
+    expect(onRatioChange).toHaveBeenCalledWith('9:16')
+  })
+
   it('hides the settings trigger when every video parameter is hidden', () => {
     render(
       <VideoSettingsPopover

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useMemo, useState, useCallback, type Dispatch, type SetStateAction } from 'react'
-import { ChevronRight, CircleStop, Hand, Plus, Zap } from 'lucide-react'
+import { ChevronRight, CircleStop, Hand, Plus, SlidersHorizontal, Zap } from 'lucide-react'
 import MobileModelSelector from '../selector/MobileModelSelector'
 import type { Model } from '../selector/ModelSelector'
 import VideoGenerationModeSelector from '../selector/VideoGenerationModeSelector'
@@ -233,6 +233,7 @@ export function MobileChatInputControls({
 }: MobileChatInputControlsProps) {
   const { t } = useTranslation('chat')
   const [resourceDrawerOpen, setResourceDrawerOpen] = useState(false)
+  const [videoConfigurationDrawerOpen, setVideoConfigurationDrawerOpen] = useState(false)
   const [nestedSelectorOpen, setNestedSelectorOpen] = useState(false)
   const [skillDrawerOpen, setSkillDrawerOpen] = useState(false)
   const showChatContexts = canUseChatContexts(taskType, selectedTeam)
@@ -268,6 +269,14 @@ export function MobileChatInputControls({
     onRatioChange &&
     onDurationChange
   )
+  const showVideoGenerationModeAction = Boolean(
+    isVideoMode && onVideoGenerationModeChange && videoGenerationModes.length > 1
+  )
+  const showVideoModelAction = Boolean(
+    isVideoMode && videoParamVisibility.showModel && onVideoModelChange
+  )
+  const showVideoConfiguration =
+    showVideoGenerationModeAction || showVideoModelAction || showVideoSettings
   const hasMoreActions =
     showAttachmentAction ||
     showChatContexts ||
@@ -275,8 +284,7 @@ export function MobileChatInputControls({
     showRepositoryAction ||
     showClarificationAction ||
     showCorrectionAction ||
-    showGuidanceAction ||
-    showVideoSettings
+    showGuidanceAction
   const handleAttachmentFileSelect = useCallback(
     (files: File | File[]) => {
       setResourceDrawerOpen(false)
@@ -455,28 +463,6 @@ export function MobileChatInputControls({
           </div>
         )}
 
-        {isVideoMode && onVideoGenerationModeChange && (
-          <VideoGenerationModeSelector
-            modes={videoGenerationModes}
-            value={selectedVideoGenerationMode}
-            onChange={onVideoGenerationModeChange}
-            disabled={isStreaming}
-          />
-        )}
-        {isVideoMode && videoParamVisibility.showModel && onVideoModelChange && (
-          <div className="min-w-0 flex-1 overflow-hidden">
-            <MobileModelSelector
-              selectedModel={selectedVideoModel ?? null}
-              setSelectedModel={model => model && onVideoModelChange(model)}
-              forceOverride={false}
-              setForceOverride={() => {}}
-              selectedTeam={selectedTeam}
-              disabled={isStreaming}
-              isLoading={isVideoModelsLoading}
-              modelCategoryType="video"
-            />
-          </div>
-        )}
         {isImageMode && onImageModelChange && (
           <div
             className="min-w-0 flex-1 overflow-hidden"
@@ -494,6 +480,25 @@ export function MobileChatInputControls({
               triggerVariant="compact"
             />
           </div>
+        )}
+        {showVideoConfiguration && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-expanded={videoConfigurationDrawerOpen}
+            aria-label={t('video.settings_title')}
+            data-testid="mobile-video-configuration-button"
+            title={t('video.settings_title')}
+            onClick={() => {
+              setResourceDrawerOpen(false)
+              setVideoConfigurationDrawerOpen(true)
+            }}
+            disabled={isStreaming || Boolean(hideSelectors)}
+            className="h-11 w-11 shrink-0 rounded-xl border border-border bg-base text-text-muted hover:bg-hover hover:text-text-primary"
+          >
+            <SlidersHorizontal className="h-5 w-5" />
+          </Button>
         )}
         <div className="shrink-0">{renderSendButton()}</div>
       </div>
@@ -597,28 +602,6 @@ export function MobileChatInputControls({
                   )}
                 </div>
               )}
-              {showVideoSettings && onResolutionChange && onRatioChange && onDurationChange && (
-                <div className="mt-3 overflow-hidden rounded-xl bg-white dark:bg-[#2c2c2e]">
-                  <VideoSettingsPopover
-                    selectedRatio={selectedRatio}
-                    onRatioChange={onRatioChange}
-                    availableRatios={availableRatios ?? ['16:9', '9:16', '1:1']}
-                    ratioOptions={ratioOptions}
-                    selectedDuration={selectedDuration}
-                    onDurationChange={onDurationChange}
-                    availableDurations={availableDurations ?? [5, 10]}
-                    selectedResolution={selectedResolution}
-                    onResolutionChange={onResolutionChange}
-                    availableResolutions={availableResolutions ?? ['480p', '720p', '1080p']}
-                    resolutionOptions={resolutionOptions}
-                    disabled={isStreaming}
-                    showDuration={!hideDurationSelector}
-                    hiddenVideoParams={hiddenVideoParams}
-                    triggerVariant="menu-item"
-                  />
-                </div>
-              )}
-
               {showGuidanceAction && onSendGuidance && (
                 <div className="mt-3 overflow-hidden rounded-xl bg-white dark:bg-[#2c2c2e]">
                   <Button
@@ -634,6 +617,74 @@ export function MobileChatInputControls({
                   </Button>
                 </div>
               )}
+            </div>
+          </DrawerContent>
+        )}
+      </Drawer>
+
+      <Drawer open={videoConfigurationDrawerOpen} onOpenChange={setVideoConfigurationDrawerOpen}>
+        {videoConfigurationDrawerOpen && (
+          <DrawerContent
+            className="max-h-[85vh] bg-[#f2f2f7] dark:bg-[#1c1c1e]"
+            showHandle={false}
+            data-testid="mobile-video-configuration-menu"
+          >
+            <div className="flex justify-center pb-3 pt-2">
+              <div className="h-1 w-9 rounded-full bg-[#3c3c43]/30 dark:bg-[#5c5c5e]" />
+            </div>
+            <div
+              className="max-h-[65vh] min-h-0 flex-1 overflow-y-auto px-4 pb-4"
+              style={{ paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}
+            >
+              <div className="px-1 pb-2 text-xs font-medium text-[#8e8e93]">
+                {t('video.settings_title')}
+              </div>
+              <div
+                className="divide-y divide-border overflow-hidden rounded-xl bg-white dark:bg-[#2c2c2e]"
+                data-testid="mobile-video-configuration"
+              >
+                {showVideoGenerationModeAction && onVideoGenerationModeChange && (
+                  <VideoGenerationModeSelector
+                    modes={videoGenerationModes}
+                    value={selectedVideoGenerationMode}
+                    onChange={onVideoGenerationModeChange}
+                    disabled={isStreaming}
+                    inline
+                  />
+                )}
+                {showVideoModelAction && onVideoModelChange && (
+                  <MobileModelSelector
+                    selectedModel={selectedVideoModel ?? null}
+                    setSelectedModel={model => model && onVideoModelChange(model)}
+                    forceOverride={false}
+                    setForceOverride={() => {}}
+                    selectedTeam={selectedTeam}
+                    disabled={isStreaming}
+                    isLoading={isVideoModelsLoading}
+                    modelCategoryType="video"
+                    triggerVariant="settings-row"
+                  />
+                )}
+                {showVideoSettings && onResolutionChange && onRatioChange && onDurationChange && (
+                  <VideoSettingsPopover
+                    selectedRatio={selectedRatio}
+                    onRatioChange={onRatioChange}
+                    availableRatios={availableRatios ?? ['16:9', '9:16', '1:1']}
+                    ratioOptions={ratioOptions}
+                    selectedDuration={selectedDuration}
+                    onDurationChange={onDurationChange}
+                    availableDurations={availableDurations ?? [5, 10]}
+                    selectedResolution={selectedResolution}
+                    onResolutionChange={onResolutionChange}
+                    availableResolutions={availableResolutions ?? ['480p', '720p', '1080p']}
+                    resolutionOptions={resolutionOptions}
+                    disabled={isStreaming}
+                    showDuration={!hideDurationSelector}
+                    hiddenVideoParams={hiddenVideoParams}
+                    inline
+                  />
+                )}
+              </div>
             </div>
           </DrawerContent>
         )}

--- a/frontend/src/features/tasks/components/selector/VideoGenerationModeSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/VideoGenerationModeSelector.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react'
 
 import type { VideoGenerationMode } from '@/apis/models'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 
 interface VideoGenerationModeSelectorProps {
@@ -18,6 +19,7 @@ interface VideoGenerationModeSelectorProps {
   disabled?: boolean
   triggerVariant?: 'default' | 'menu-item'
   popoverSide?: 'top' | 'right' | 'bottom' | 'left'
+  inline?: boolean
 }
 
 export default function VideoGenerationModeSelector({
@@ -27,12 +29,48 @@ export default function VideoGenerationModeSelector({
   disabled = false,
   triggerVariant = 'default',
   popoverSide,
+  inline = false,
 }: VideoGenerationModeSelectorProps) {
+  const { t } = useTranslation('chat')
   const [open, setOpen] = useState(false)
   const selectedMode = modes.find(mode => mode.id === value) ?? modes[0]
 
   if (!selectedMode || modes.length <= 1) {
     return null
+  }
+
+  if (inline) {
+    return (
+      <div className="p-4" data-testid="video-generation-mode-options">
+        <h4 className="mb-2 text-sm font-medium text-text-primary">
+          {t('video.generation_mode_section')}
+        </h4>
+        <div className="grid grid-cols-2 gap-2">
+          {modes.map(mode => {
+            const isSelected = mode.id === selectedMode.id
+            return (
+              <button
+                key={mode.id}
+                type="button"
+                disabled={disabled}
+                aria-pressed={isSelected}
+                className={cn(
+                  'min-h-11 rounded-lg border px-3 py-2 text-sm transition-colors',
+                  isSelected
+                    ? 'border-primary bg-primary/5 text-primary'
+                    : 'border-border bg-surface text-text-secondary hover:bg-hover',
+                  'disabled:cursor-not-allowed disabled:opacity-50'
+                )}
+                onClick={() => onChange(mode.id)}
+                data-testid={`video-generation-mode-${mode.id}`}
+              >
+                {mode.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/features/tasks/components/selector/VideoSettingsPopover.tsx
+++ b/frontend/src/features/tasks/components/selector/VideoSettingsPopover.tsx
@@ -42,6 +42,7 @@ export interface VideoSettingsPopoverProps {
   hiddenVideoParams?: string[]
   triggerVariant?: 'default' | 'menu-item'
   iconOnly?: boolean
+  inline?: boolean
 }
 
 // Aspect ratio icon dimensions for visual representation
@@ -84,6 +85,7 @@ export function VideoSettingsPopover({
   hiddenVideoParams = [],
   triggerVariant = 'default',
   iconOnly = false,
+  inline = false,
 }: VideoSettingsPopoverProps) {
   const { t } = useTranslation('chat')
   const [isOpen, setIsOpen] = useState(false)
@@ -115,6 +117,101 @@ export function VideoSettingsPopover({
   const displayedResolutions = resolutionOptions?.length
     ? resolutionOptions
     : availableResolutions.map(value => ({ label: value.toUpperCase(), value }))
+
+  const settingsContent = (
+    <div className="space-y-4">
+      <div hidden={!showRatio}>
+        <h4 className="mb-2 text-sm font-medium text-text-primary">{t('video.ratio_section')}</h4>
+        <div className="flex flex-wrap gap-2">
+          {displayedRatios.map(option => (
+            <button
+              key={option.value}
+              type="button"
+              data-testid={`video-ratio-option-${option.value}`}
+              onClick={() => onRatioChange(option.value)}
+              disabled={disabled}
+              className={cn(
+                'flex min-w-[52px] flex-col items-center gap-1 rounded-lg border px-3 py-2 transition-colors',
+                selectedRatio === option.value
+                  ? 'border-primary bg-primary/5 text-primary'
+                  : 'border-border bg-surface text-text-secondary hover:bg-hover',
+                'disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            >
+              <RatioIcon ratio={option.value} selected={selectedRatio === option.value} />
+              <span className="text-xs">{option.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {showVideoDuration && (
+        <div>
+          <h4 className="mb-2 text-sm font-medium text-text-primary">
+            {t('video.duration_section')}
+          </h4>
+          <div className="flex gap-2">
+            {availableDurations.map(duration => (
+              <button
+                key={duration}
+                type="button"
+                data-testid={`video-duration-option-${duration}`}
+                onClick={() => onDurationChange(duration)}
+                disabled={disabled}
+                className={cn(
+                  'flex-1 rounded-lg border py-2 text-sm transition-colors',
+                  selectedDuration === duration
+                    ? 'border-primary bg-primary/5 text-primary'
+                    : 'border-border bg-surface text-text-secondary hover:bg-hover',
+                  'disabled:cursor-not-allowed disabled:opacity-50'
+                )}
+              >
+                {formatVideoDuration(duration, autoDurationLabel)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div hidden={!showResolution}>
+        <h4 className="mb-2 text-sm font-medium text-text-primary">
+          {t('video.resolution_section')}
+        </h4>
+        <div className="flex gap-2">
+          {displayedResolutions.map(option => {
+            const value = option.value ?? option.label
+            return (
+              <button
+                key={value}
+                type="button"
+                data-testid={`video-resolution-option-${value}`}
+                onClick={() => onResolutionChange(value)}
+                disabled={disabled}
+                title={'tooltip' in option ? option.tooltip : undefined}
+                className={cn(
+                  'flex-1 rounded-lg border py-2 text-sm transition-colors',
+                  selectedResolution === value
+                    ? 'border-primary bg-primary/5 text-primary'
+                    : 'border-border bg-surface text-text-secondary hover:bg-hover',
+                  'disabled:cursor-not-allowed disabled:opacity-50'
+                )}
+              >
+                {option.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+
+  if (inline) {
+    return (
+      <div className="p-4" data-testid="video-settings-inline">
+        {settingsContent}
+      </div>
+    )
+  }
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -161,89 +258,7 @@ export function VideoSettingsPopover({
         align="start"
         sideOffset={4}
       >
-        <div className="space-y-4">
-          {/* Aspect Ratio Section */}
-          <div hidden={!showRatio}>
-            <h4 className="text-sm font-medium text-text-primary mb-2">
-              {t('video.ratio_section')}
-            </h4>
-            <div className="flex flex-wrap gap-2">
-              {displayedRatios.map(option => (
-                <button
-                  key={option.value}
-                  type="button"
-                  data-testid={`video-ratio-option-${option.value}`}
-                  onClick={() => onRatioChange(option.value)}
-                  className={cn(
-                    'flex flex-col items-center gap-1 px-3 py-2 rounded-lg',
-                    'border transition-colors min-w-[52px]',
-                    selectedRatio === option.value
-                      ? 'border-primary bg-primary/5 text-primary'
-                      : 'border-border bg-surface hover:bg-hover text-text-secondary'
-                  )}
-                >
-                  <RatioIcon ratio={option.value} selected={selectedRatio === option.value} />
-                  <span className="text-xs">{option.label}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {showVideoDuration && (
-            <div>
-              <h4 className="text-sm font-medium text-text-primary mb-2">
-                {t('video.duration_section')}
-              </h4>
-              <div className="flex gap-2">
-                {availableDurations.map(duration => (
-                  <button
-                    key={duration}
-                    type="button"
-                    data-testid={`video-duration-option-${duration}`}
-                    onClick={() => onDurationChange(duration)}
-                    className={cn(
-                      'flex-1 py-2 rounded-lg border transition-colors text-sm',
-                      selectedDuration === duration
-                        ? 'border-primary bg-primary/5 text-primary'
-                        : 'border-border bg-surface hover:bg-hover text-text-secondary'
-                    )}
-                  >
-                    {formatVideoDuration(duration, autoDurationLabel)}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Resolution Section */}
-          <div hidden={!showResolution}>
-            <h4 className="text-sm font-medium text-text-primary mb-2">
-              {t('video.resolution_section')}
-            </h4>
-            <div className="flex gap-2">
-              {displayedResolutions.map(option => {
-                const value = option.value ?? option.label
-                return (
-                  <button
-                    key={value}
-                    type="button"
-                    data-testid={`video-resolution-option-${value}`}
-                    onClick={() => onResolutionChange(value)}
-                    title={'tooltip' in option ? option.tooltip : undefined}
-                    className={cn(
-                      'flex-1 py-2 rounded-lg border transition-colors text-sm',
-                      selectedResolution === value
-                        ? 'border-primary bg-primary/5 text-primary'
-                        : 'border-border bg-surface hover:bg-hover text-text-secondary'
-                    )}
-                  >
-                    {option.label}
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-        </div>
+        {settingsContent}
       </PopoverContent>
     </Popover>
   )

--- a/frontend/src/features/tasks/components/selector/VideoSettingsPopover.tsx
+++ b/frontend/src/features/tasks/components/selector/VideoSettingsPopover.tsx
@@ -159,7 +159,7 @@ export function VideoSettingsPopover({
                 onClick={() => onDurationChange(duration)}
                 disabled={disabled}
                 className={cn(
-                  'flex-1 rounded-lg border py-2 text-sm transition-colors',
+                  'min-h-11 flex-1 rounded-lg border py-2 text-sm transition-colors',
                   selectedDuration === duration
                     ? 'border-primary bg-primary/5 text-primary'
                     : 'border-border bg-surface text-text-secondary hover:bg-hover',
@@ -189,7 +189,7 @@ export function VideoSettingsPopover({
                 disabled={disabled}
                 title={'tooltip' in option ? option.tooltip : undefined}
                 className={cn(
-                  'flex-1 rounded-lg border py-2 text-sm transition-colors',
+                  'min-h-11 flex-1 rounded-lg border py-2 text-sm transition-colors',
                   selectedResolution === value
                     ? 'border-primary bg-primary/5 text-primary'
                     : 'border-border bg-surface text-text-secondary hover:bg-hover',

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -757,6 +757,7 @@
     "reference_image": "Reference Image (Optional)",
     "no_models": "No video models available",
     "settings_title": "Video settings",
+    "generation_mode_section": "Video mode",
     "ratio_section": "Aspect ratio",
     "duration_section": "Duration",
     "duration_auto": "Auto",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -757,6 +757,7 @@
     "reference_image": "参考图片（可选）",
     "no_models": "暂无可用的视频模型",
     "settings_title": "视频设置",
+    "generation_mode_section": "视频模式",
     "ratio_section": "比例",
     "duration_section": "时长",
     "duration_auto": "智能时长",


### PR DESCRIPTION
## Summary
- keep the mobile composer primary row compact by replacing video mode/model controls with one settings icon
- move video mode, model, aspect ratio, duration, and resolution into one bottom drawer
- render video mode and video parameters inline to avoid nested mobile popovers

## Testing
- `pnpm --dir frontend exec jest --runInBand` (356 suites, 2278 passed, 1 todo)
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- focused ESLint and Prettier checks
- pre-push quality checks (Frontend, Wework, Backend syntax/format, Executor)

Related: WORK-403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated mobile video generation options—including mode, model, aspect ratio, duration, and resolution—into a dedicated configuration panel.
  * Added inline video settings and generation-mode selection for easier access within the panel.
  * Selected video modes are now clearly indicated for accessibility.
  * Added English and Chinese labels for the video mode section.

* **Tests**
  * Added coverage for the new video configuration panel and inline selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->