### PR TITLE
perf(wework): lint pushed files incrementally

### DIFF
--- a/.github/scripts/test-ci-cache-policy.sh
+++ b/.github/scripts/test-ci-cache-policy.sh
@@ -340,10 +340,13 @@ if ! sed -n '/^  e2e-tests:/,/^  executor-e2e-tests:/p' \
   ! sed -n '/^  e2e-tests:/,/^  executor-e2e-tests:/p' \
   "$workflow_dir/e2e-tests.yml" |
     grep -F 'setup-toolchain: "false"' >/dev/null ||
+  ! sed -n '/^  e2e-tests:/,/^  executor-e2e-tests:/p' \
+  "$workflow_dir/e2e-tests.yml" |
+    grep -F 'setup-uv: "false"' >/dev/null ||
   sed -n '/^  e2e-tests:/,/^  executor-e2e-tests:/p' \
     "$workflow_dir/e2e-tests.yml" |
     grep -E 'install-playwright-(browser|system-deps)' >/dev/null; then
-  fail "Platform E2E shards must consume the immutable Playwright image without runtime installs"
+  fail "Platform E2E shards must consume the immutable toolchain image without runtime installs"
 fi
 
 # GitHub expressions are matched literally in workflow source.
@@ -413,6 +416,13 @@ fi
 wework_workflow="$workflow_dir/wework-e2e.yml"
 wework_browser_image="$script_dir/../../docker/wework-e2e/browser.Dockerfile"
 wework_desktop_image="$script_dir/../../docker/wework-e2e/desktop.Dockerfile"
+if ! grep -Fq 'ARG UV_VERSION=0.11.17' "$wework_browser_image" ||
+  ! grep -Fq '"https://astral.sh/uv/${UV_VERSION}/install.sh"' \
+    "$wework_browser_image" ||
+  ! grep -Fq 'uv --version' "$wework_browser_image"; then
+  fail "The platform E2E image must provide the pinned uv toolchain"
+fi
+
 if ! grep -Fq 'file: docker/wework-e2e/browser.Dockerfile' "$wework_workflow" ||
   ! grep -Fq 'file: docker/wework-e2e/desktop.Dockerfile' "$wework_workflow" ||
   [[ "$(grep -c 'push: true' "$wework_workflow")" -ne 2 ]] ||

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -361,6 +361,7 @@ jobs:
         uses: ./.github/actions/setup-python-uv-cache
         with:
           python-version: "3.11"
+          setup-uv: "false"
 
       - name: Install shared module
         working-directory: ./shared

--- a/docker/wework-e2e/browser.Dockerfile
+++ b/docker/wework-e2e/browser.Dockerfile
@@ -1,18 +1,24 @@
 FROM mcr.microsoft.com/playwright:v1.60.0-noble
 
 ARG PNPM_VERSION=11.7.0
+ARG UV_VERSION=0.11.17
 
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
+    curl \
     libmagic1 \
     zstd \
   && rm -rf /var/lib/apt/lists/* \
-  && npm install --global "pnpm@${PNPM_VERSION}"
+  && npm install --global "pnpm@${PNPM_VERSION}" \
+  && curl --proto '=https' --tlsv1.2 -LsSf \
+    "https://astral.sh/uv/${UV_VERSION}/install.sh" \
+    | env UV_INSTALL_DIR=/usr/local/bin sh
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 RUN node --version \
   && pnpm --version \
+  && uv --version \
   && zstd --version \
   && ldconfig -p | grep -q 'libmagic\.so\.1' \
   && find /ms-playwright -type f \

--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -39,16 +39,29 @@ should_run_full_tests() {
     [ "${AI_PUSH_FULL_TESTS:-0}" = "1" ]
 }
 
-collect_wework_test_scope() {
+collect_wework_check_scope() {
     WEWORK_RENDERER_CHANGED=0
     WEWORK_RENDERER_FULL_TESTS=0
     WEWORK_ELECTRON_CHANGED=0
     WEWORK_DSH_CHANGED=0
     WEWORK_SCRIPTS_CHANGED=0
+    WEWORK_LINT_FULL=0
+    WEWORK_LINT_FILES=()
     WEWORK_RELATED_FILES=()
 
     while IFS= read -r changed_file; do
         [ -z "$changed_file" ] && continue
+
+        case "$changed_file" in
+            wework/package.json|wework/eslint.config.*)
+                WEWORK_LINT_FULL=1
+                ;;
+            wework/*.[cm]ts|wework/*.[cm]tsx|wework/*.ts|wework/*.tsx)
+                if [ -f "$changed_file" ]; then
+                    WEWORK_LINT_FILES+=("${changed_file#wework/}")
+                fi
+                ;;
+        esac
 
         case "$changed_file" in
             wework/electron/*)
@@ -78,6 +91,35 @@ collect_wework_test_scope() {
                 ;;
         esac
     done < <(printf '%s\n' "$CHANGED_FILES")
+}
+
+run_wework_lint() {
+    : > "$TEMP_DIR/wework_eslint.log"
+
+    if [ "$WEWORK_LINT_FULL" -eq 1 ]; then
+        pnpm --filter wework lint > "$TEMP_DIR/wework_eslint.log" 2>&1
+        return $?
+    fi
+
+    if [ "${#WEWORK_LINT_FILES[@]}" -gt 0 ]; then
+        if ! pnpm --filter wework exec eslint \
+            "${WEWORK_LINT_FILES[@]}" >> "$TEMP_DIR/wework_eslint.log" 2>&1; then
+            return 1
+        fi
+    fi
+
+    if [ "$WEWORK_RENDERER_CHANGED" -eq 1 ]; then
+        if ! pnpm --filter wework run lint:typography \
+            >> "$TEMP_DIR/wework_eslint.log" 2>&1; then
+            return 1
+        fi
+        if ! pnpm --filter wework run lint:task-lifecycle \
+            >> "$TEMP_DIR/wework_eslint.log" 2>&1; then
+            return 1
+        fi
+    fi
+
+    return 0
 }
 
 collect_node_test_files() {
@@ -547,10 +589,10 @@ if [ "$WEWORK_COUNT" -gt 0 ] 2>/dev/null; then
         echo -e "   ${YELLOW}   Run 'pnpm install' from the repository root to install dependencies${NC}"
         WARNINGS+=("Wework: node_modules not found, checks skipped")
     else
-        collect_wework_test_scope
+        collect_wework_check_scope
         echo -e "   Running static checks and unit tests in parallel..."
 
-        pnpm --filter wework lint > "$TEMP_DIR/wework_eslint.log" 2>&1 &
+        run_wework_lint &
         ESLINT_PID=$!
 
         TSC_PID=""

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -175,6 +175,20 @@ if ! grep -qE '^pnpm --filter wework typecheck$' "$CALL_LOG"; then
     exit 1
 fi
 
+if ! grep -qE '^pnpm --filter wework exec eslint src/features/workbench/WorkbenchProvider.test.tsx src/features/workbench/runtimeModelSelection.test.ts src/features/workbench/runtimeModelSelection.ts$' "$CALL_LOG"; then
+    echo "Expected Wework changes to lint only changed TypeScript files."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
+if grep -qE '^pnpm --filter wework lint$' "$CALL_LOG"; then
+    echo "Expected ordinary Wework changes to avoid the full lint suite."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
 if ! grep -qE '^pnpm --filter wework exec vitest run --pool=threads src/features/workbench/WorkbenchProvider.test.tsx src/features/workbench/runtimeModelSelection.test.ts$' "$CALL_LOG"; then
     echo "Expected renderer source changes to run changed and sibling test files."
     echo "Calls:"
@@ -322,6 +336,13 @@ EOF
 
 if ! grep -qE '^pnpm --filter wework exec vitest run --pool=threads src/api/changeRequests.test.ts$' "$CALL_LOG"; then
     echo "Expected merge-like Wework changes to run only the related renderer test."
+    echo "Calls:"
+    cat "$CALL_LOG"
+    exit 1
+fi
+
+if ! grep -qE '^pnpm --filter wework lint$' "$CALL_LOG"; then
+    echo "Expected Wework package metadata changes to run the full lint suite."
     echo "Calls:"
     cat "$CALL_LOG"
     exit 1


### PR DESCRIPTION
## Summary

- lint only changed Wework TypeScript files during ordinary pre-push checks
- preserve full Wework lint when package metadata or ESLint configuration changes
- keep renderer typography and runtime lifecycle policy checks enabled
- add push-gate regression coverage for incremental and full-lint selection

## Evidence

Using the same historical three-file renderer change on the same worktree:

- before: 74.75s
- after: 23.08s
- reduction: about 69%

The isolated full-directory ESLint command took 63.71s, confirming it was the dominant critical-path cost.

## Verification

- `bash -n scripts/hooks/ai-push-gate.sh scripts/hooks/test-ai-push-gate.sh`
- `bash scripts/hooks/test-ai-push-gate.sh`
- real pre-push sample with focused renderer tests, TypeScript, and incremental ESLint
- `AI_VERIFIED=1 git push` repository gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-push validation to run more targeted lint checks for changed TypeScript files.
  * Configuration and package changes now trigger comprehensive linting to help catch broader issues.
  * Renderer-related changes now include additional typography and task-lifecycle checks.

* **Tests**
  * Expanded automated coverage to verify linting behavior for targeted files, full-suite scenarios, and mixed changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->