### PR TITLE
fix(wework): allow closing commit panel

### DIFF
--- a/wework/dsh/ui-git/src/environment-section.tsx
+++ b/wework/dsh/ui-git/src/environment-section.tsx
@@ -1,6 +1,5 @@
 import {
   Check,
-  ChevronDown,
   CircleDot,
   CornerDownLeft,
   GitBranch,
@@ -9,8 +8,9 @@ import {
   LoaderCircle,
   Square,
   Upload,
+  X,
 } from 'lucide-react'
-import { useState, type FormEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
 
 import { BranchSelector } from '@/components/common/BranchSelector'
@@ -61,12 +61,50 @@ export default function GitEnvironmentSection({
   const [commitStatus, setCommitStatus] = useState<'idle' | 'committing' | 'success'>('idle')
   const [commitProgressLabel, setCommitProgressLabel] = useState('')
   const [commitError, setCommitError] = useState<string | null>(null)
+  const commitButtonRef = useRef<HTMLButtonElement>(null)
+  const commitFormRef = useRef<HTMLFormElement>(null)
   const gitRepositoryAvailable = info.isGitRepository !== false
   const hasGitInfo = gitRepositoryAvailable && Boolean(info.branchName?.trim())
   const canShowBranchSelector = Boolean(
     gitRepositoryAvailable && onListBranches && onCheckoutBranch
   )
   const hasDiffStats = gitRepositoryAvailable && Boolean(info.additions || info.deletions)
+
+  const closeCommitForm = useCallback(() => {
+    setCommitFormOpen(false)
+    setCommitError(null)
+  }, [])
+
+  useEffect(() => {
+    if (!commitFormOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (
+        !(target instanceof Node) ||
+        commitFormRef.current?.contains(target) ||
+        commitButtonRef.current?.contains(target)
+      ) {
+        return
+      }
+      closeCommitForm()
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      event.stopPropagation()
+      closeCommitForm()
+      commitButtonRef.current?.focus()
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown, true)
+    }
+  }, [closeCommitForm, commitFormOpen])
+
   if (!hasDiffStats && !hasGitInfo && !canShowBranchSelector) return null
 
   const additions = info.additions || '+0'
@@ -190,9 +228,11 @@ export default function GitEnvironmentSection({
               </div>
             ) : (
               <button
+                ref={commitButtonRef}
                 type="button"
                 data-testid="environment-commit-button"
                 disabled={!onCommitChanges && !onCommitAndPushChanges && !onPushChanges}
+                aria-expanded={commitFormOpen}
                 onClick={() => {
                   setCommitFormOpen(open => !open)
                   setCommitError(null)
@@ -271,6 +311,7 @@ export default function GitEnvironmentSection({
       {commitFormOpen && typeof document !== 'undefined'
         ? createPortal(
             <form
+              ref={commitFormRef}
               data-testid="environment-commit-form"
               className="fixed left-1/2 top-[36vh] z-system-popover w-[430px] max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-xl border border-border bg-background text-text-primary shadow-[0_18px_48px_rgba(0,0,0,0.20)]"
               onSubmit={handleSubmitCommit}
@@ -278,11 +319,22 @@ export default function GitEnvironmentSection({
               <div className="flex h-10 items-center gap-2 px-4 text-sm leading-[18px] text-text-secondary">
                 <GitBranch className="h-4 w-4 shrink-0" />
                 <span className="min-w-0 flex-1 truncate font-medium">{branchLabel}</span>
-                <ChevronDown className="h-4 w-4 shrink-0" />
                 <span className="ml-3 flex shrink-0 gap-1.5 font-medium">
                   <span className="text-green-500">{additions}</span>
                   <span className="text-red-500">{deletions}</span>
                 </span>
+                <button
+                  type="button"
+                  data-testid="environment-cancel-commit-button"
+                  onClick={() => {
+                    closeCommitForm()
+                    commitButtonRef.current?.focus()
+                  }}
+                  aria-label={t('common.close', '关闭')}
+                  className="-mr-2 ml-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-text-muted hover:bg-hover hover:text-text-primary"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
               </div>
               <textarea
                 data-testid="environment-commit-message-input"
@@ -350,17 +402,6 @@ export default function GitEnvironmentSection({
                   <span className="min-w-0 flex-1 truncate">
                     {t('workbench.environment_push', '推送')}
                   </span>
-                </button>
-                <button
-                  type="button"
-                  data-testid="environment-cancel-commit-button"
-                  onClick={() => {
-                    setCommitFormOpen(false)
-                    setCommitError(null)
-                  }}
-                  className="hidden"
-                >
-                  {t('workbench.environment_commit_cancel', '取消')}
                 </button>
               </div>
             </form>,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -9959,8 +9959,13 @@ describe('DesktopWorkbenchLayout', () => {
     expect(commitMenuButton).toHaveFocus()
 
     await userEvent.click(commitMenuButton)
-    fireEvent.pointerDown(document.body)
+    const commitMessageInput = screen.getByTestId('environment-commit-message-input')
+    await userEvent.click(commitMessageInput)
+    expect(commitMessageInput).toHaveFocus()
+    const outsideControl = screen.getByTestId('toggle-bottom-workspace-panel-button')
+    await userEvent.click(outsideControl)
     expect(screen.queryByTestId('environment-commit-form')).not.toBeInTheDocument()
+    expect(outsideControl).toHaveFocus()
 
     await userEvent.click(commitMenuButton)
     await userEvent.click(screen.getByTestId('environment-commit-and-push-button'))

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -9947,11 +9947,27 @@ describe('DesktopWorkbenchLayout', () => {
     )
     expect(scopedPanel.getByTestId('environment-push-button')).toHaveTextContent('推送')
 
-    await userEvent.click(scopedPanel.getByTestId('environment-commit-and-push-button'))
+    await userEvent.type(screen.getByTestId('environment-commit-message-input'), 'keep this')
+    await userEvent.click(screen.getByTestId('environment-cancel-commit-button'))
+    expect(screen.queryByTestId('environment-commit-form')).not.toBeInTheDocument()
+    expect(commitMenuButton).toHaveFocus()
+
+    await userEvent.click(commitMenuButton)
+    expect(screen.getByTestId('environment-commit-message-input')).toHaveValue('keep this')
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByTestId('environment-commit-form')).not.toBeInTheDocument()
+    expect(commitMenuButton).toHaveFocus()
+
+    await userEvent.click(commitMenuButton)
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByTestId('environment-commit-form')).not.toBeInTheDocument()
+
+    await userEvent.click(commitMenuButton)
+    await userEvent.click(screen.getByTestId('environment-commit-and-push-button'))
     await waitFor(() =>
       expect(onCommitAndPushEnvironmentChanges).toHaveBeenCalledWith(
         null,
-        '',
+        'keep this',
         activeProjectRuntimeTarget
       )
     )


### PR DESCRIPTION
## Summary
- replace the non-interactive chevron and hidden cancel control with a visible close button
- close the commit panel on Escape or an outside pointer press and restore trigger focus
- preserve the commit message when the panel is reopened

## Verification
- `pnpm --filter wework test src/components/layout/DesktopWorkbenchLayout.test.tsx -t "environment commit|environment push"`
- `pnpm --filter wework typecheck`
- targeted Prettier and ESLint checks
- isolated Electron verification for close button and Escape dismissal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an X button to close the environment commit form.
  * Added support for closing the form by clicking outside it or pressing Escape.
  * Preserved draft commit messages when the form is dismissed and reopened.
  * Restored focus to the commit control after the form is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->