### PR TITLE
feat(wework): support GPT-6 Astra in Codex

### DIFF
--- a/wework/codex-binaries.lock.json
+++ b/wework/codex-binaries.lock.json
@@ -1,40 +1,40 @@
 {
-  "codexVersion": "0.152.1",
+  "codexVersion": "0.153.3",
   "registry": "https://registry.npmjs.org",
   "targets": {
     "aarch64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.152.1-darwin-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-darwin-arm64.tgz",
-      "integrity": "sha512-H8i0uZHILM0Z2Ep+MryCF5rGXmXjmXTzXf5ZK6bobKtZc2yfomi42ZrQWuYQ5P02H0oLG7B5jLaSWZQ+VFgjbA==",
+      "version": "0.153.3-darwin-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-darwin-arm64.tgz",
+      "integrity": "sha512-cIJh2xhww3ZBXmgBt6e9gQjrdL2c9xiiq7yimDHtTGdg3wiUOADD/OsmIu/RJOitwM8OgImdHFjR59doBBdo8A==",
       "binaryPath": "vendor/aarch64-apple-darwin/bin/codex"
     },
     "x86_64-apple-darwin": {
       "package": "@openai/codex",
-      "version": "0.152.1-darwin-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-darwin-x64.tgz",
-      "integrity": "sha512-M2qW7YkRx+JeSFoZQsrjgA5yNglowuNAFOwRJoIjlgeP8bsyOqPtbSolu3w4Us7IyCH8f/yuKtlt/v/MdDqbfA==",
+      "version": "0.153.3-darwin-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-darwin-x64.tgz",
+      "integrity": "sha512-82Jxir4LygzF32z4y9KOMhK8rVlA4T6c10I9/MK+FhkEmTnDYcL4+VyttHdnMrX0I/Bdqj2M71gFellIaJHiDQ==",
       "binaryPath": "vendor/x86_64-apple-darwin/bin/codex"
     },
     "x86_64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.152.1-linux-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-linux-x64.tgz",
-      "integrity": "sha512-ar59rr3CX5j4MLMnRcHqcE0eHZPsZlmXlz37ZS2yP3BsV5pNhO+wFXTOzXFdaYmg2cALX7a3Eqv+vB2jQlXnjQ==",
+      "version": "0.153.3-linux-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-linux-x64.tgz",
+      "integrity": "sha512-CyLvuM9Ij7sQuNtnHrzHtF+DtNISaauZZakyhy+MoFS1XxKTGv3FN4/qh6c94YZtLStZ7aUmfYQz59V3PV4zng==",
       "binaryPath": "vendor/x86_64-unknown-linux-musl/bin/codex"
     },
     "aarch64-unknown-linux-gnu": {
       "package": "@openai/codex",
-      "version": "0.152.1-linux-arm64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-linux-arm64.tgz",
-      "integrity": "sha512-qZXqf7fxn/SCmaJW6tYrzWqwcDo0gMDJjj1Pm4OtrWXR7Oc0Y2e8ngAh/Mep9iFhVbsqntY1eGLaQaXssGvFgA==",
+      "version": "0.153.3-linux-arm64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-linux-arm64.tgz",
+      "integrity": "sha512-uayZKgz5lk7Pz3JPjL98FGQGFRcrax3sGEQ9CtduyZscbIcnn3iYszRvGcubqVwiHi3B9oAVqy8V2NcWGwImLg==",
       "binaryPath": "vendor/aarch64-unknown-linux-musl/bin/codex"
     },
     "x86_64-pc-windows-msvc": {
       "package": "@openai/codex",
-      "version": "0.152.1-win32-x64",
-      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-win32-x64.tgz",
-      "integrity": "sha512-B8h0/2Kt+rKQv2+vqBhlhWkMEdhf4dsn46FNKMEBTXj3YC5hwSioOcTX2hMgJxMEMtKIMH6Ire1eNrQPvaL9og==",
+      "version": "0.153.3-win32-x64",
+      "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.3-win32-x64.tgz",
+      "integrity": "sha512-+3BNGznK6xRYrBi8Ivsz50gQdViIKWjQ6I4zC5ELYLgBB0ETD/VBMP51LnybywJUKnZ6ow3VE/koImgfCl4Eiw==",
       "binaryPath": "vendor/x86_64-pc-windows-msvc/bin/codex.exe"
     }
   }

--- a/wework/e2e/desktop/modules/desktop-server.mjs
+++ b/wework/e2e/desktop/modules/desktop-server.mjs
@@ -30,6 +30,7 @@ import {
   parseTelemetryPayload,
   readRawRequestBody,
   readRequestBody,
+  requestAdvertisesProgrammaticExec,
   requestAdvertisesShellTool,
   requestAdvertisesViewImageTool,
   requestContainsToolOutput,
@@ -41,10 +42,12 @@ import {
   selectConvertedTool,
   selectMcpTool,
   selectOfficialPluginMcpTool,
+  selectProgrammaticExec,
   selectShellTool,
   selectShellToolCommand,
   selectTool,
   selectToolSearch,
+  serializedOutputReportsSuccess,
   toolSearchResponseEvents,
   selectViewImageTool,
   streamingMarkdownReport,
@@ -2132,7 +2135,8 @@ class DesktopE2EServer {
     if (
       this.scenario === 'embedded_browser_setup' &&
       !this.embeddedBrowserSetupToolLessPrewarmHandled &&
-      !requestAdvertisesShellTool(body)
+      !requestAdvertisesShellTool(body) &&
+      !requestAdvertisesProgrammaticExec(body)
     ) {
       this.embeddedBrowserSetupToolLessPrewarmHandled = true
       this.writeSse(response, [responseCreated(responseId), responseCompleted(responseId)])
@@ -2359,10 +2363,45 @@ class DesktopE2EServer {
       )
 
       if (requestNumber === 1) {
+        if (requestAdvertisesProgrammaticExec(body)) {
+          const browserUrl = new URL('/embedded-browser-agent-fixture', this.url).href
+          const program = [
+            "const browserOpen = ALL_TOOLS.find(tool => tool.name === 'browser_open' || (tool.name.includes('wework_browser') && tool.name.endsWith('browser_open')))",
+            "if (!browserOpen) throw new Error('Wework browser_open unavailable')",
+            `await tools[browserOpen.name](${JSON.stringify({ url: browserUrl })})`,
+            'text(JSON.stringify({ ok: true }))',
+          ].join('\n')
+          const exec = selectProgrammaticExec(body, program)
+          this.writeSse(response, [
+            responseCreated(responseId),
+            customToolCall(EMBEDDED_BROWSER_SETUP_OPEN_ID, exec.name, exec.input),
+            responseCompleted(responseId),
+          ])
+          return
+        }
         const search = selectToolSearch(body, 'Wework browser open')
         this.writeSse(response, [
           responseCreated(responseId),
           ...toolSearchResponseEvents(EMBEDDED_BROWSER_SETUP_SEARCH_ID, search),
+          responseCompleted(responseId),
+        ])
+        return
+      }
+
+      if (requestAdvertisesProgrammaticExec(body)) {
+        assert.equal(requestNumber, 2, `Unexpected embedded-browser setup request ${requestNumber}`)
+        assert.equal(
+          requestContainsToolOutput(body, EMBEDDED_BROWSER_SETUP_OPEN_ID),
+          true,
+          'The embedded-browser programmatic exec output did not return to the model'
+        )
+        assert.ok(
+          findNestedString(body, serializedOutputReportsSuccess),
+          'The programmatic Wework browser_open call did not complete successfully'
+        )
+        this.writeSse(response, [
+          responseCreated(responseId),
+          assistantMessage(EMBEDDED_BROWSER_SETUP_COMPLETION_TEXT),
           responseCompleted(responseId),
         ])
         return

--- a/wework/e2e/desktop/modules/response-protocol.mjs
+++ b/wework/e2e/desktop/modules/response-protocol.mjs
@@ -418,6 +418,34 @@ function requestAdvertisesShellTool(request) {
   return tools.some(tool => tool?.name === 'exec_command' || tool?.name === 'shell_command')
 }
 
+function programmaticExecTools(request) {
+  const input = Array.isArray(request.input) ? request.input : []
+  return input
+    .filter(item => item?.type === 'additional_tools')
+    .flatMap(item => (Array.isArray(item.tools) ? item.tools : []))
+    .filter(namespace => namespace?.type === 'namespace' && namespace.name === 'functions')
+    .flatMap(namespace => (Array.isArray(namespace.tools) ? namespace.tools : []))
+    .filter(tool => tool?.type === 'custom' && tool.name === 'exec')
+}
+
+function serializedOutputReportsSuccess(value) {
+  return typeof value === 'string' && /\\*"ok\\*"\s*:\s*true/u.test(value)
+}
+
+function requestAdvertisesProgrammaticExec(request) {
+  return programmaticExecTools(request).length > 0
+}
+
+function selectProgrammaticExec(request, input) {
+  const tools = programmaticExecTools(request)
+  assert.equal(
+    tools.length,
+    1,
+    `Real Codex did not advertise exactly one programmatic exec tool: ${tools.length}`
+  )
+  return { name: tools[0].name, input }
+}
+
 function requestAdvertisesViewImageTool(request) {
   const tools = Array.isArray(request.tools) ? request.tools : []
   return tools.some(tool => tool?.name === 'view_image')
@@ -693,8 +721,11 @@ export {
   json,
   cors,
   requestContainsToolOutput,
+  requestAdvertisesProgrammaticExec,
+  serializedOutputReportsSuccess,
   requestAdvertisesShellTool,
   requestAdvertisesViewImageTool,
+  selectProgrammaticExec,
   selectTool,
   selectOfficialPluginMcpTool,
   selectMcpTool,

--- a/wework/electron/src/runtime/core-dsh-runtime.test.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.test.ts
@@ -82,6 +82,7 @@ describe('core DSH runtime', () => {
         PATH: '/usr/bin',
         WEWORK_CORE_PLUGIN_ROOT: runtime.pluginsRoot,
         WEWORK_CORE_PLUGINS_SHA256: 'f'.repeat(64),
+        WEWORK_APP_WEB_ROOT: join(root.path, 'source-app-web'),
         WEWORK_NODE_PATH: '/managed/node',
       },
       port: 3080,
@@ -102,10 +103,13 @@ describe('core DSH runtime', () => {
     expect(first.args).toContain('3080')
     expect(first.environment).toMatchObject({
       DSH_HOME: join(dataDirectory, 'dsh-core'),
-      WEWORK_APP_WEB_ROOT: join(runtime.pluginRoots['@wegent/dsh-app-wework'], 'web'),
+      WEWORK_APP_WEB_ROOT: join(root.path, 'source-app-web'),
       WEWORK_HARNESS_API_KEY: 'wework-local-router',
     })
     expect(second.args).toContain('3081')
+    expect(second.environment.WEWORK_APP_WEB_ROOT).toBe(
+      join(runtime.pluginRoots['@wegent/dsh-app-wework'], 'web')
+    )
     expect(
       JSON.parse(
         await readFile(

--- a/wework/electron/src/runtime/core-dsh-runtime.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.ts
@@ -137,7 +137,9 @@ export async function prepareCoreDshLaunch(options: PrepareCoreDshOptions): Prom
     environment: {
       ...options.environment,
       DSH_HOME: dshHome,
-      WEWORK_APP_WEB_ROOT: join(runtime.pluginRoots['@wegent/dsh-app-wework'], 'web'),
+      WEWORK_APP_WEB_ROOT:
+        options.environment.WEWORK_APP_WEB_ROOT?.trim() ||
+        join(runtime.pluginRoots['@wegent/dsh-app-wework'], 'web'),
       WEWORK_HARNESS_API_KEY: 'wework-local-router',
     },
     profile: PROFILE_NAME,

--- a/wework/scripts/response-protocol.test.mjs
+++ b/wework/scripts/response-protocol.test.mjs
@@ -2,8 +2,11 @@ import { describe, expect, test } from 'vitest'
 import {
   cors,
   mcpToolRequestEvents,
+  requestAdvertisesProgrammaticExec,
+  serializedOutputReportsSuccess,
   selectMcpTool,
   selectMcpToolRequest,
+  selectProgrammaticExec,
 } from '../e2e/desktop/modules/response-protocol.mjs'
 
 function searchResult(...tools) {
@@ -37,6 +40,54 @@ describe('cors', () => {
     expect(headers.get('Access-Control-Allow-Methods')).toBe(
       'GET, POST, PUT, PATCH, DELETE, OPTIONS'
     )
+  })
+})
+
+describe('programmatic exec', () => {
+  const request = {
+    input: [
+      {
+        type: 'additional_tools',
+        tools: [
+          {
+            type: 'namespace',
+            name: 'functions',
+            tools: [
+              { type: 'custom', name: 'exec' },
+              { type: 'function', name: 'wait' },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+
+  test('recognizes and selects the Codex additional_tools exec tool', () => {
+    expect(requestAdvertisesProgrammaticExec(request)).toBe(true)
+    expect(selectProgrammaticExec(request, 'text("ok")')).toEqual({
+      name: 'exec',
+      input: 'text("ok")',
+    })
+  })
+
+  test('rejects requests without exactly one exec tool', () => {
+    expect(requestAdvertisesProgrammaticExec({ input: [] })).toBe(false)
+    expect(() => selectProgrammaticExec({ input: [] }, 'text("ok")')).toThrow(
+      'Real Codex did not advertise exactly one programmatic exec tool: 0'
+    )
+
+    const duplicateExecRequest = { input: [request.input[0], request.input[0]] }
+    expect(requestAdvertisesProgrammaticExec(duplicateExecRequest)).toBe(true)
+    expect(() => selectProgrammaticExec(duplicateExecRequest, 'text("ok")')).toThrow(
+      'Real Codex did not advertise exactly one programmatic exec tool: 2'
+    )
+  })
+
+  test('recognizes compact, formatted, and escaped success output', () => {
+    expect(serializedOutputReportsSuccess('{"ok":true}')).toBe(true)
+    expect(serializedOutputReportsSuccess('{"ok": true}')).toBe(true)
+    expect(serializedOutputReportsSuccess('{\\"ok\\":true}')).toBe(true)
+    expect(serializedOutputReportsSuccess('{"ok":false}')).toBe(false)
   })
 })
 

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -17,6 +17,7 @@ import { createDefaultLocalModelCatalogEntry } from '@/features/model-settings/l
 import type { TurnFileChangesSummary, User } from '@/types/api'
 
 const OFFICIAL_CODEX_MODEL_DEFINITIONS: Array<[string, string, string, string[]]> = [
+  ['gpt-6-astra', 'GPT-6-Astra', 'low', ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']],
   ['gpt-5.6-sol', 'GPT-5.6-Sol', 'low', ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']],
   ['gpt-5.6-terra', 'GPT-5.6-Terra', 'medium', ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']],
   ['gpt-5.6-luna', 'GPT-5.6-Luna', 'medium', ['low', 'medium', 'high', 'xhigh', 'max']],
@@ -27,11 +28,12 @@ const OFFICIAL_CODEX_MODEL_DEFINITIONS: Array<[string, string, string, string[]]
 ]
 
 const OFFICIAL_CODEX_MODELS = OFFICIAL_CODEX_MODEL_DEFINITIONS.map(
-  ([model, displayName, defaultReasoningEffort, efforts], index) => ({
+  ([model, displayName, defaultReasoningEffort, efforts]) => ({
     id: model,
     model,
     displayName,
-    isDefault: index === 0,
+    hidden: model === 'gpt-6-astra',
+    isDefault: model === 'gpt-5.6-sol',
     defaultReasoningEffort,
     supportedReasoningEfforts: efforts.map(reasoningEffort => ({ reasoningEffort })),
   })
@@ -126,6 +128,12 @@ describe('createLocalAppServices', () => {
     expect(models).toEqual({
       data: expect.arrayContaining([
         expect.objectContaining({
+          name: 'gpt-6-astra',
+          type: 'runtime',
+          modelId: 'gpt-6-astra',
+          runtime: { family: 'openai.openai-responses', provider: 'local' },
+        }),
+        expect.objectContaining({
           name: 'gpt-5.6-sol',
           type: 'runtime',
           modelId: 'gpt-5.6-sol',
@@ -150,6 +158,7 @@ describe('createLocalAppServices', () => {
     const modelIds = models.data.map(model => model.modelId)
     expect(modelIds).toEqual(
       expect.arrayContaining([
+        'gpt-6-astra',
         'gpt-5.6-sol',
         'gpt-5.6-terra',
         'gpt-5.6-luna',

--- a/wework/src/features/model-settings/codexOfficialModels.test.ts
+++ b/wework/src/features/model-settings/codexOfficialModels.test.ts
@@ -36,6 +36,7 @@ describe('codexOfficialModels', () => {
       'gpt-5.6-terra',
       'gpt-5.6-sol',
       'gpt-5.5',
+      'gpt-6-astra',
     ]
     const result = normalizeCodexOfficialModelList({
       providers: [
@@ -56,6 +57,7 @@ describe('codexOfficialModels', () => {
     })
 
     expect(result.models.map(model => codexModelPickerLabel(model.modelId))).toEqual([
+      'GPT-6 Astra',
       'GPT 5.6 Sol',
       'GPT 5.6 Terra',
       'GPT 5.6 Luna',
@@ -77,10 +79,12 @@ describe('codexOfficialModels', () => {
         { model: 'gpt-5.6-luna' },
         { model: 'gpt-5.6-terra' },
         { model: 'gpt-5.6-sol' },
+        { model: 'gpt-6-astra', hidden: true },
       ],
     })
 
     expect(result.models.map(model => model.modelId)).toEqual([
+      'gpt-6-astra',
       'gpt-5.6-sol',
       'gpt-5.6-terra',
       'gpt-5.6-luna',

--- a/wework/src/features/model-settings/codexOfficialModels.ts
+++ b/wework/src/features/model-settings/codexOfficialModels.ts
@@ -35,6 +35,7 @@ export const CODEX_RUNTIME_MODEL_ID = 'gpt-5.6-sol'
 export const CODEX_OFFICIAL_UNAVAILABLE_MODEL_NAME = 'codex-official-unavailable'
 
 const CODEX_PICKER_MODELS = [
+  { modelId: 'gpt-6-astra', label: 'GPT-6 Astra' },
   { modelId: 'gpt-5.6-sol', label: 'GPT 5.6 Sol' },
   { modelId: 'gpt-5.6-terra', label: 'GPT 5.6 Terra' },
   { modelId: 'gpt-5.6-luna', label: 'GPT 5.6 Luna' },


### PR DESCRIPTION
## Summary

- upgrade the bundled desktop Codex CLI from 0.152.1 to 0.153.3 and expose `gpt-6-astra` in the curated Wework model picker
- preserve the explicit development `WEWORK_APP_WEB_ROOT` while preparing Core DSH, so local app assets and health checks remain available
- adapt the embedded-browser desktop E2E mock to GPT-6 Programmatic Tool Calling (`additional_tools` namespace + custom `exec`)

## Root cause

- the local 120-second DSH timeout was not stale cache: componentized desktop packaging overwrote the development app web root with a plugin root that intentionally has no bundled web assets
- the original shard-4 CI failure occurred because GPT-6 advertises programmatic `exec` through `additional_tools`; the old mock misclassified that request as tool-less prewarm and returned an empty completion

## Verification

- `pnpm --dir wework exec vitest run scripts/response-protocol.test.mjs src/features/model-settings/codexOfficialModels.test.ts src/api/local/localServices.test.ts` (90 tests)
- `pnpm --dir wework/electron test -- src/runtime/core-dsh-runtime.test.ts` (398 tests)
- `pnpm --dir wework typecheck`
- repository pre-push checks: frontend, Wework, Electron, backend formatting/syntax, settings, and Alembic checks passed
- `pnpm --filter wework e2e:desktop:embedded-browser` passed with real Codex 0.153.3, including compact programmatic output
- fresh local Electron launch completed Core DSH health checks and a real `gpt-6-astra` turn returned `GPT6_ASTRA_LOCAL_OK`
- a standalone GPT-6 Astra programmatic `exec` call completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPT-6 Astra to the official model options with the display name “GPT-6 Astra.”
  * Improved embedded browser setup to support programmatic browser actions.

* **Updates**
  * Updated the bundled Codex runtime to version 0.153.3 across supported macOS, Linux, and Windows platforms.
  * Updated the default official model to GPT-5.6 Sol.
  * Preserved custom web application paths when launching the desktop runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->