### PR TITLE
fix(wework): reconcile bundled plugin marketplace state

### DIFF
--- a/executor/src/local/bundled_plugins.rs
+++ b/executor/src/local/bundled_plugins.rs
@@ -3,17 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    collections::{HashMap, HashSet},
     env, fs,
     io::Read,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
+    time::SystemTime,
 };
 
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use toml_edit::DocumentMut;
 
 pub const BUNDLED_PLUGIN_MARKETPLACE_SOURCE_ENV: &str = "WEGENT_BUNDLED_PLUGIN_MARKETPLACE_DIR";
 const EXECUTOR_HOME_ENV: &str = "WEGENT_EXECUTOR_HOME";
+const CODEX_HOME_ENV: &str = "WEGENT_CODEX_HOME";
 const MARKETPLACE_ID: &str = "wework-personal";
 const CONTENT_HASH_FILE: &str = ".wework-content-sha256";
 
@@ -34,18 +38,46 @@ pub fn initialize_bundled_plugin_marketplace() -> Result<BundledPluginMarketplac
     let executor_home = non_empty_path(EXECUTOR_HOME_ENV)
         .or_else(|| dirs::home_dir().map(|home| home.join(".wegent-executor")))
         .ok_or_else(|| "Unable to resolve executor home".to_owned())?;
-    initialize_bundled_plugin_marketplace_from_paths(
+    let codex_home = non_empty_path(CODEX_HOME_ENV).unwrap_or_else(|| executor_home.join("codex"));
+    let legacy_personal_marketplaces = legacy_personal_marketplace_roots(&executor_home)?;
+    initialize_bundled_plugin_marketplace_from_paths_with_recovery(
         &source,
         &executor_home
             .join("capabilities")
             .join("bundled-marketplaces")
             .join(MARKETPLACE_ID),
+        Some(&codex_home),
+        &legacy_personal_marketplaces,
     )
 }
 
+#[cfg(test)]
 fn initialize_bundled_plugin_marketplace_from_paths(
     source: &Path,
     destination: &Path,
+) -> Result<BundledPluginMarketplace, String> {
+    initialize_bundled_plugin_marketplace_from_paths_with_recovery(source, destination, None, &[])
+}
+
+#[cfg(test)]
+fn initialize_bundled_plugin_marketplace_from_paths_with_codex_home(
+    source: &Path,
+    destination: &Path,
+    codex_home: Option<&Path>,
+) -> Result<BundledPluginMarketplace, String> {
+    initialize_bundled_plugin_marketplace_from_paths_with_recovery(
+        source,
+        destination,
+        codex_home,
+        &[],
+    )
+}
+
+fn initialize_bundled_plugin_marketplace_from_paths_with_recovery(
+    source: &Path,
+    destination: &Path,
+    codex_home: Option<&Path>,
+    legacy_personal_marketplaces: &[PathBuf],
 ) -> Result<BundledPluginMarketplace, String> {
     let codex_manifest = source.join(".agents/plugins/marketplace.json");
     let claude_manifest = source.join(".claude-plugin/marketplace.json");
@@ -61,6 +93,12 @@ fn initialize_bundled_plugin_marketplace_from_paths(
         && fs::read_to_string(destination.join(CONTENT_HASH_FILE))
             .is_ok_and(|stored| stored.trim() == content_hash)
     {
+        for legacy_root in legacy_personal_marketplaces {
+            preserve_personal_plugins(legacy_root, destination, &codex_plugins)?;
+        }
+        if let Some(codex_home) = codex_home {
+            recover_configured_personal_plugins(destination, codex_home, &codex_plugins)?;
+        }
         return Ok(BundledPluginMarketplace {
             id: MARKETPLACE_ID.to_owned(),
             path: destination.display().to_string(),
@@ -84,19 +122,22 @@ fn initialize_bundled_plugin_marketplace_from_paths(
         let _ = remove_existing_path(&staging);
         return Err(error);
     }
+    if destination.is_dir() {
+        preserve_personal_plugins(destination, &staging, &codex_plugins)?;
+    }
+    for legacy_root in legacy_personal_marketplaces {
+        preserve_personal_plugins(legacy_root, &staging, &codex_plugins)?;
+    }
+    if let Some(codex_home) = codex_home {
+        recover_configured_personal_plugins(&staging, codex_home, &codex_plugins)?;
+    }
     fs::write(staging.join(CONTENT_HASH_FILE), format!("{content_hash}\n")).map_err(|error| {
         format!(
             "Failed to write bundled marketplace content hash in {}: {error}",
             staging.display()
         )
     })?;
-    remove_existing_path(destination)?;
-    fs::rename(&staging, destination).map_err(|error| {
-        format!(
-            "Failed to activate bundled plugin marketplace {}: {error}",
-            destination.display()
-        )
-    })?;
+    activate_staged_marketplace(&staging, destination)?;
 
     Ok(BundledPluginMarketplace {
         id: MARKETPLACE_ID.to_owned(),
@@ -105,6 +146,337 @@ fn initialize_bundled_plugin_marketplace_from_paths(
         default_plugin_names,
         content_hash,
     })
+}
+
+fn legacy_personal_marketplace_roots(executor_home: &Path) -> Result<Vec<PathBuf>, String> {
+    let apps_root = executor_home.join("apps");
+    let apps = match fs::read_dir(&apps_root) {
+        Ok(apps) => apps,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(format!("Failed to read {}: {error}", apps_root.display())),
+    };
+    let mut roots = apps
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read {}: {error}", apps_root.display()))?
+        .into_iter()
+        .map(|entry| {
+            entry
+                .path()
+                .join("codex/plugins/marketplaces")
+                .join(MARKETPLACE_ID)
+        })
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    roots.sort();
+    Ok(roots)
+}
+
+fn preserve_personal_plugins(
+    existing_root: &Path,
+    staging_root: &Path,
+    bundled_plugin_names: &[String],
+) -> Result<(), String> {
+    let bundled = bundled_plugin_names.iter().cloned().collect::<HashSet<_>>();
+    let codex_entries =
+        manifest_entries_by_name(&existing_root.join(".agents/plugins/marketplace.json"))?;
+    let claude_entries =
+        manifest_entries_by_name(&existing_root.join(".claude-plugin/marketplace.json"))?;
+    let mut names = codex_entries
+        .keys()
+        .chain(claude_entries.keys())
+        .filter(|name| !bundled.contains(*name))
+        .cloned()
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+
+    for name in names {
+        let source = codex_entries
+            .get(&name)
+            .and_then(|entry| local_plugin_source(existing_root, entry))
+            .or_else(|| {
+                claude_entries
+                    .get(&name)
+                    .and_then(|entry| local_plugin_source(existing_root, entry))
+            });
+        let Some(source) = source.filter(|path| valid_plugin_directory(path)) else {
+            continue;
+        };
+        let destination = staging_root.join("plugins").join(&name);
+        if !valid_plugin_directory(&destination) {
+            remove_existing_path(&destination)?;
+            copy_directory_recursive(&source, &destination)?;
+        }
+        append_personal_plugin_manifests(
+            staging_root,
+            &name,
+            codex_entries.get(&name),
+            claude_entries.get(&name),
+            &destination,
+        )?;
+    }
+    Ok(())
+}
+
+fn recover_configured_personal_plugins(
+    marketplace_root: &Path,
+    codex_home: &Path,
+    bundled_plugin_names: &[String],
+) -> Result<(), String> {
+    let bundled = bundled_plugin_names.iter().cloned().collect::<HashSet<_>>();
+    let existing =
+        marketplace_plugin_names(&marketplace_root.join(".agents/plugins/marketplace.json"))?
+            .into_iter()
+            .collect::<HashSet<_>>();
+    for name in configured_personal_plugin_names(codex_home)? {
+        if bundled.contains(&name) || existing.contains(&name) {
+            continue;
+        }
+        let Some(cached_plugin) = newest_cached_plugin(codex_home, &name)? else {
+            continue;
+        };
+        let destination = marketplace_root.join("plugins").join(&name);
+        remove_existing_path(&destination)?;
+        copy_directory_recursive(&cached_plugin, &destination)?;
+        append_personal_plugin_manifests(marketplace_root, &name, None, None, &destination)?;
+    }
+    Ok(())
+}
+
+fn configured_personal_plugin_names(codex_home: &Path) -> Result<Vec<String>, String> {
+    let config_path = codex_home.join("config.toml");
+    let content = match fs::read_to_string(&config_path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(format!("Failed to read {}: {error}", config_path.display()));
+        }
+    };
+    let config = content
+        .parse::<DocumentMut>()
+        .map_err(|error| format!("Failed to parse {}: {error}", config_path.display()))?;
+    let suffix = format!("@{MARKETPLACE_ID}");
+    let mut names = config
+        .get("plugins")
+        .and_then(|plugins| plugins.as_table_like())
+        .into_iter()
+        .flat_map(|plugins| plugins.iter())
+        .filter_map(|(key, _)| key.strip_suffix(&suffix))
+        .filter(|name| valid_plugin_name(name))
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+fn newest_cached_plugin(codex_home: &Path, plugin_name: &str) -> Result<Option<PathBuf>, String> {
+    let cache_root = codex_home
+        .join("plugins/cache")
+        .join(MARKETPLACE_ID)
+        .join(plugin_name);
+    let entries = match fs::read_dir(&cache_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("Failed to read {}: {error}", cache_root.display())),
+    };
+    let mut candidates = entries
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read {}: {error}", cache_root.display()))?
+        .into_iter()
+        .map(|entry| entry.path())
+        .filter(|path| valid_plugin_directory(path))
+        .filter(|path| cached_plugin_name_matches(path, plugin_name))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|path| {
+        let modified = fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        (modified, path.file_name().map(|name| name.to_os_string()))
+    });
+    Ok(candidates.pop())
+}
+
+fn cached_plugin_name_matches(path: &Path, expected_name: &str) -> bool {
+    read_manifest(&path.join(".codex-plugin/plugin.json"))
+        .ok()
+        .and_then(|manifest| {
+            manifest
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .as_deref()
+        == Some(expected_name)
+}
+
+fn manifest_entries_by_name(path: &Path) -> Result<HashMap<String, Value>, String> {
+    if !path.is_file() {
+        return Ok(HashMap::new());
+    }
+    let manifest = read_manifest(path)?;
+    let plugins = manifest
+        .get("plugins")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            format!(
+                "Marketplace {} must contain a plugins array",
+                path.display()
+            )
+        })?;
+    Ok(plugins
+        .iter()
+        .filter_map(|plugin| {
+            let name = plugin.get("name")?.as_str()?.trim();
+            valid_plugin_name(name).then(|| (name.to_owned(), plugin.clone()))
+        })
+        .collect())
+}
+
+fn local_plugin_source(marketplace_root: &Path, entry: &Value) -> Option<PathBuf> {
+    let source = entry.get("source")?;
+    let relative = source
+        .as_str()
+        .or_else(|| source.get("path").and_then(Value::as_str))?;
+    let relative = Path::new(relative);
+    if relative.is_absolute()
+        || relative.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return None;
+    }
+    Some(marketplace_root.join(relative))
+}
+
+fn valid_plugin_name(name: &str) -> bool {
+    !name.is_empty() && name != "." && name != ".." && !name.contains('/') && !name.contains('\\')
+}
+
+fn valid_plugin_directory(path: &Path) -> bool {
+    path.is_dir()
+        && (path.join(".codex-plugin/plugin.json").is_file()
+            || path.join(".claude-plugin/plugin.json").is_file())
+}
+
+fn append_personal_plugin_manifests(
+    marketplace_root: &Path,
+    plugin_name: &str,
+    codex_entry: Option<&Value>,
+    claude_entry: Option<&Value>,
+    plugin_root: &Path,
+) -> Result<(), String> {
+    let plugin_manifest = read_manifest(&plugin_root.join(".codex-plugin/plugin.json")).ok();
+    let codex_entry = codex_entry.cloned().unwrap_or_else(|| {
+        json!({
+            "name": plugin_name,
+            "source": {"source": "local", "path": format!("./plugins/{plugin_name}")},
+            "policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+            "category": plugin_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.pointer("/interface/category"))
+                .and_then(Value::as_str)
+                .unwrap_or("Other"),
+        })
+    });
+    let claude_entry = claude_entry.cloned().unwrap_or_else(|| {
+        json!({
+            "name": plugin_name,
+            "description": plugin_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.get("description"))
+                .and_then(Value::as_str)
+                .unwrap_or(""),
+            "source": format!("./plugins/{plugin_name}"),
+            "version": plugin_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.get("version"))
+                .and_then(Value::as_str),
+        })
+    });
+    append_manifest_entry(
+        &marketplace_root.join(".agents/plugins/marketplace.json"),
+        normalized_codex_entry(codex_entry, plugin_name),
+    )?;
+    append_manifest_entry(
+        &marketplace_root.join(".claude-plugin/marketplace.json"),
+        normalized_claude_entry(claude_entry, plugin_name),
+    )
+}
+
+fn normalized_codex_entry(mut entry: Value, plugin_name: &str) -> Value {
+    entry["name"] = Value::String(plugin_name.to_owned());
+    entry["source"] = json!({
+        "source": "local",
+        "path": format!("./plugins/{plugin_name}"),
+    });
+    entry
+}
+
+fn normalized_claude_entry(mut entry: Value, plugin_name: &str) -> Value {
+    entry["name"] = Value::String(plugin_name.to_owned());
+    entry["source"] = Value::String(format!("./plugins/{plugin_name}"));
+    entry
+}
+
+fn append_manifest_entry(path: &Path, entry: Value) -> Result<(), String> {
+    let mut manifest = read_manifest(path)?;
+    let plugins = manifest
+        .get_mut("plugins")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            format!(
+                "Marketplace {} must contain a plugins array",
+                path.display()
+            )
+        })?;
+    let plugin_name = entry
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if plugins
+        .iter()
+        .any(|plugin| plugin.get("name").and_then(Value::as_str) == Some(plugin_name))
+    {
+        return Ok(());
+    }
+    plugins.push(entry);
+    let content = serde_json::to_string_pretty(&manifest)
+        .map_err(|error| format!("Failed to serialize {}: {error}", path.display()))?;
+    fs::write(path, format!("{content}\n"))
+        .map_err(|error| format!("Failed to write {}: {error}", path.display()))
+}
+
+fn activate_staged_marketplace(staging: &Path, destination: &Path) -> Result<(), String> {
+    let parent = destination.parent().ok_or_else(|| {
+        format!(
+            "Bundled plugin marketplace destination has no parent: {}",
+            destination.display()
+        )
+    })?;
+    let backup = parent.join(format!(".{MARKETPLACE_ID}-{}-backup", std::process::id()));
+    remove_existing_path(&backup)?;
+    if destination.exists() {
+        fs::rename(destination, &backup).map_err(|error| {
+            format!(
+                "Failed to preserve bundled plugin marketplace {}: {error}",
+                destination.display()
+            )
+        })?;
+    }
+    if let Err(error) = fs::rename(staging, destination) {
+        if backup.exists() {
+            let _ = fs::rename(&backup, destination);
+        }
+        return Err(format!(
+            "Failed to activate bundled plugin marketplace {}: {error}",
+            destination.display()
+        ));
+    }
+    remove_existing_path(&backup)
 }
 
 fn directory_content_hash(root: &Path) -> Result<String, String> {
@@ -351,6 +723,32 @@ mod tests {
             "preserved"
         );
 
+        fs::create_dir_all(destination.join("plugins/personal-tool/.codex-plugin")).unwrap();
+        fs::create_dir_all(destination.join("plugins/personal-tool/.claude-plugin")).unwrap();
+        fs::write(
+            destination.join("plugins/personal-tool/.codex-plugin/plugin.json"),
+            r#"{"name":"personal-tool","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            destination.join("plugins/personal-tool/.claude-plugin/plugin.json"),
+            r#"{"name":"personal-tool","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        append_manifest_entry(
+            &destination.join(".agents/plugins/marketplace.json"),
+            json!({
+                "name": "personal-tool",
+                "source": {"source": "local", "path": "./plugins/personal-tool"},
+            }),
+        )
+        .unwrap();
+        append_manifest_entry(
+            &destination.join(".claude-plugin/marketplace.json"),
+            json!({"name": "personal-tool", "source": "./plugins/personal-tool"}),
+        )
+        .unwrap();
+
         fs::write(
             source.join("plugins/smart-app-builder/README.md"),
             "updated builder",
@@ -364,6 +762,134 @@ mod tests {
         assert_eq!(
             fs::read_to_string(destination.join("plugins/smart-app-builder/README.md")).unwrap(),
             "updated builder"
+        );
+        assert!(destination
+            .join("plugins/personal-tool/.codex-plugin/plugin.json")
+            .is_file());
+        assert!(
+            marketplace_plugin_names(&destination.join(".agents/plugins/marketplace.json"))
+                .unwrap()
+                .contains(&"personal-tool".to_owned())
+        );
+        assert!(
+            marketplace_plugin_names(&destination.join(".claude-plugin/marketplace.json"))
+                .unwrap()
+                .contains(&"personal-tool".to_owned())
+        );
+    }
+
+    #[test]
+    fn recovers_configured_personal_plugin_from_codex_cache() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let destination = root.path().join("destination/wework-personal");
+        let codex_home = root.path().join("codex");
+        fs::create_dir_all(source.join(".agents/plugins")).unwrap();
+        fs::create_dir_all(source.join(".claude-plugin")).unwrap();
+        fs::write(
+            source.join(".agents/plugins/marketplace.json"),
+            r#"{"plugins":[{"name":"smart-app-builder"}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            source.join(".claude-plugin/marketplace.json"),
+            r#"{"plugins":[{"name":"smart-app-builder"}]}"#,
+        )
+        .unwrap();
+        initialize_bundled_plugin_marketplace_from_paths(&source, &destination).unwrap();
+
+        fs::create_dir_all(&codex_home).unwrap();
+        fs::write(
+            codex_home.join("config.toml"),
+            "[plugins.\"ip-location@wework-personal\"]\nenabled = true\n",
+        )
+        .unwrap();
+        let cached =
+            codex_home.join("plugins/cache/wework-personal/ip-location/0.3.0/.codex-plugin");
+        fs::create_dir_all(&cached).unwrap();
+        fs::write(
+            cached.join("plugin.json"),
+            r#"{"name":"ip-location","version":"0.3.0","description":"IP lookup","interface":{"category":"Utilities"}}"#,
+        )
+        .unwrap();
+
+        let result = initialize_bundled_plugin_marketplace_from_paths_with_codex_home(
+            &source,
+            &destination,
+            Some(&codex_home),
+        )
+        .unwrap();
+
+        assert_eq!(result.plugin_count, 1);
+        assert!(destination
+            .join("plugins/ip-location/.codex-plugin/plugin.json")
+            .is_file());
+        assert!(
+            marketplace_plugin_names(&destination.join(".agents/plugins/marketplace.json"))
+                .unwrap()
+                .contains(&"ip-location".to_owned())
+        );
+        assert!(
+            marketplace_plugin_names(&destination.join(".claude-plugin/marketplace.json"))
+                .unwrap()
+                .contains(&"ip-location".to_owned())
+        );
+    }
+
+    #[test]
+    fn migrates_personal_plugin_from_legacy_app_marketplace() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let destination = root.path().join("destination/wework-personal");
+        let legacy = root
+            .path()
+            .join("apps/com.example.wework/codex/plugins/marketplaces/wework-personal");
+        fs::create_dir_all(source.join(".agents/plugins")).unwrap();
+        fs::create_dir_all(source.join(".claude-plugin")).unwrap();
+        fs::write(
+            source.join(".agents/plugins/marketplace.json"),
+            r#"{"plugins":[]}"#,
+        )
+        .unwrap();
+        fs::write(
+            source.join(".claude-plugin/marketplace.json"),
+            r#"{"plugins":[]}"#,
+        )
+        .unwrap();
+        fs::create_dir_all(legacy.join(".agents/plugins")).unwrap();
+        fs::create_dir_all(legacy.join(".claude-plugin")).unwrap();
+        fs::create_dir_all(legacy.join("plugins/personal-tool/.codex-plugin")).unwrap();
+        fs::write(
+            legacy.join(".agents/plugins/marketplace.json"),
+            r#"{"plugins":[{"name":"personal-tool","source":{"source":"local","path":"./plugins/personal-tool"}}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            legacy.join(".claude-plugin/marketplace.json"),
+            r#"{"plugins":[{"name":"personal-tool","source":"./plugins/personal-tool"}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            legacy.join("plugins/personal-tool/.codex-plugin/plugin.json"),
+            r#"{"name":"personal-tool","version":"1.0.0"}"#,
+        )
+        .unwrap();
+
+        initialize_bundled_plugin_marketplace_from_paths_with_recovery(
+            &source,
+            &destination,
+            None,
+            std::slice::from_ref(&legacy),
+        )
+        .unwrap();
+
+        assert!(destination
+            .join("plugins/personal-tool/.codex-plugin/plugin.json")
+            .is_file());
+        assert_eq!(
+            marketplace_plugin_names(&destination.join(".agents/plugins/marketplace.json"))
+                .unwrap(),
+            vec!["personal-tool".to_owned()]
         );
     }
 

--- a/executor/src/local/bundled_plugins.rs
+++ b/executor/src/local/bundled_plugins.rs
@@ -15,6 +15,8 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use toml_edit::DocumentMut;
 
+use crate::logging::log_executor_event;
+
 pub const BUNDLED_PLUGIN_MARKETPLACE_SOURCE_ENV: &str = "WEGENT_BUNDLED_PLUGIN_MARKETPLACE_DIR";
 const EXECUTOR_HOME_ENV: &str = "WEGENT_EXECUTOR_HOME";
 const CODEX_HOME_ENV: &str = "WEGENT_CODEX_HOME";
@@ -89,25 +91,6 @@ fn initialize_bundled_plugin_marketplace_from_paths_with_recovery(
     let default_plugin_names = marketplace_default_plugin_names(&codex_manifest)?;
     let content_hash = directory_content_hash(source)?;
 
-    if destination.is_dir()
-        && fs::read_to_string(destination.join(CONTENT_HASH_FILE))
-            .is_ok_and(|stored| stored.trim() == content_hash)
-    {
-        for legacy_root in legacy_personal_marketplaces {
-            preserve_personal_plugins(legacy_root, destination, &codex_plugins)?;
-        }
-        if let Some(codex_home) = codex_home {
-            recover_configured_personal_plugins(destination, codex_home, &codex_plugins)?;
-        }
-        return Ok(BundledPluginMarketplace {
-            id: MARKETPLACE_ID.to_owned(),
-            path: destination.display().to_string(),
-            plugin_count: codex_plugins.len(),
-            default_plugin_names,
-            content_hash,
-        });
-    }
-
     let parent = destination.parent().ok_or_else(|| {
         format!(
             "Bundled plugin marketplace destination has no parent: {}",
@@ -118,25 +101,32 @@ fn initialize_bundled_plugin_marketplace_from_paths_with_recovery(
         .map_err(|error| format!("Failed to create {}: {error}", parent.display()))?;
     let staging = parent.join(format!(".{MARKETPLACE_ID}-{}-staging", std::process::id()));
     remove_existing_path(&staging)?;
-    if let Err(error) = copy_directory_recursive(source, &staging) {
+
+    let content_matches = destination.is_dir()
+        && fs::read_to_string(destination.join(CONTENT_HASH_FILE))
+            .is_ok_and(|stored| stored.trim() == content_hash);
+    let staging_result = (|| {
+        copy_directory_recursive(if content_matches { destination } else { source }, &staging)?;
+        if !content_matches && destination.is_dir() {
+            preserve_personal_plugins(destination, &staging, &codex_plugins)?;
+        }
+        for legacy_root in legacy_personal_marketplaces {
+            preserve_personal_plugins(legacy_root, &staging, &codex_plugins)?;
+        }
+        if let Some(codex_home) = codex_home {
+            recover_configured_personal_plugins(&staging, codex_home, &codex_plugins)?;
+        }
+        fs::write(staging.join(CONTENT_HASH_FILE), format!("{content_hash}\n")).map_err(|error| {
+            format!(
+                "Failed to write bundled marketplace content hash in {}: {error}",
+                staging.display()
+            )
+        })
+    })();
+    if let Err(error) = staging_result {
         let _ = remove_existing_path(&staging);
         return Err(error);
     }
-    if destination.is_dir() {
-        preserve_personal_plugins(destination, &staging, &codex_plugins)?;
-    }
-    for legacy_root in legacy_personal_marketplaces {
-        preserve_personal_plugins(legacy_root, &staging, &codex_plugins)?;
-    }
-    if let Some(codex_home) = codex_home {
-        recover_configured_personal_plugins(&staging, codex_home, &codex_plugins)?;
-    }
-    fs::write(staging.join(CONTENT_HASH_FILE), format!("{content_hash}\n")).map_err(|error| {
-        format!(
-            "Failed to write bundled marketplace content hash in {}: {error}",
-            staging.display()
-        )
-    })?;
     activate_staged_marketplace(&staging, destination)?;
 
     Ok(BundledPluginMarketplace {
@@ -468,15 +458,28 @@ fn activate_staged_marketplace(staging: &Path, destination: &Path) -> Result<(),
         })?;
     }
     if let Err(error) = fs::rename(staging, destination) {
-        if backup.exists() {
-            let _ = fs::rename(&backup, destination);
-        }
+        let rollback = if backup.exists() {
+            fs::rename(&backup, destination)
+                .err()
+                .map(|rollback_error| {
+                    format!("; restoring the backup also failed: {rollback_error}")
+                })
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
         return Err(format!(
-            "Failed to activate bundled plugin marketplace {}: {error}",
-            destination.display()
+            "Failed to activate bundled plugin marketplace {}: {error}{rollback}",
+            destination.display(),
         ));
     }
-    remove_existing_path(&backup)
+    if let Err(error) = remove_existing_path(&backup) {
+        log_executor_event(
+            "bundled plugin marketplace backup cleanup failed",
+            &[("error", error)],
+        );
+    }
+    Ok(())
 }
 
 fn directory_content_hash(root: &Path) -> Result<String, String> {
@@ -891,6 +894,70 @@ mod tests {
                 .unwrap(),
             vec!["personal-tool".to_owned()]
         );
+    }
+
+    #[test]
+    fn leaves_a_hash_matched_marketplace_unchanged_when_recovery_fails() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let destination = root.path().join("destination/wework-personal");
+        let legacy = root.path().join("legacy/wework-personal");
+        let codex_home = root.path().join("codex");
+        for marketplace_root in [&source, &legacy] {
+            fs::create_dir_all(marketplace_root.join(".agents/plugins")).unwrap();
+            fs::create_dir_all(marketplace_root.join(".claude-plugin")).unwrap();
+        }
+        fs::write(
+            source.join(".agents/plugins/marketplace.json"),
+            r#"{"plugins":[]}"#,
+        )
+        .unwrap();
+        fs::write(
+            source.join(".claude-plugin/marketplace.json"),
+            r#"{"plugins":[]}"#,
+        )
+        .unwrap();
+        initialize_bundled_plugin_marketplace_from_paths(&source, &destination).unwrap();
+
+        fs::create_dir_all(legacy.join("plugins/personal-tool/.codex-plugin")).unwrap();
+        fs::write(
+            legacy.join("plugins/personal-tool/.codex-plugin/plugin.json"),
+            r#"{"name":"personal-tool","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            legacy.join(".agents/plugins/marketplace.json"),
+            r#"{"plugins":[{"name":"personal-tool","source":{"source":"local","path":"./plugins/personal-tool"}}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            legacy.join(".claude-plugin/marketplace.json"),
+            r#"{"plugins":[{"name":"personal-tool","source":"./plugins/personal-tool"}]}"#,
+        )
+        .unwrap();
+        fs::create_dir_all(&codex_home).unwrap();
+        fs::write(codex_home.join("config.toml"), "not valid toml = [").unwrap();
+
+        let error = initialize_bundled_plugin_marketplace_from_paths_with_recovery(
+            &source,
+            &destination,
+            Some(&codex_home),
+            std::slice::from_ref(&legacy),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("Failed to parse"));
+        assert!(!destination.join("plugins/personal-tool").exists());
+        assert!(
+            marketplace_plugin_names(&destination.join(".agents/plugins/marketplace.json"))
+                .unwrap()
+                .is_empty()
+        );
+        assert!(!destination
+            .parent()
+            .unwrap()
+            .join(format!(".{MARKETPLACE_ID}-{}-staging", std::process::id()))
+            .exists());
     }
 
     #[test]

--- a/executor/src/local/codex_home.rs
+++ b/executor/src/local/codex_home.rs
@@ -15,6 +15,7 @@ use crate::agents::replace_config;
 const EXECUTOR_HOME_ENV: &str = "WEGENT_EXECUTOR_HOME";
 const CODEX_HOME_ENV: &str = "WEGENT_CODEX_HOME";
 const E2E_NATIVE_CODEX_HOME_ENV: &str = "WEWORK_E2E_NATIVE_CODEX_HOME";
+const WEWORK_PERSONAL_MARKETPLACE_ID: &str = "wework-personal";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -237,8 +238,8 @@ fn set_remote_apps_enabled(content: &str, enabled: bool) -> Result<String, Strin
 fn copy_initialization_files(source: &Path, destination: &Path) -> Result<(), String> {
     fs::create_dir_all(destination)
         .map_err(|error| format!("Failed to create {}: {error}", destination.display()))?;
+    copy_codex_config_for_wework(&source.join("config.toml"), destination)?;
     for entry in [
-        "config.toml",
         "auth.json",
         "AGENTS.md",
         "models_cache.json",
@@ -289,7 +290,11 @@ fn import_external_content_from_paths(
         if !entry_path.exists() {
             continue;
         }
-        copy_entry(&entry_path, &destination.join(destination_entry))?;
+        if source == "codex" && *source_entry == "config.toml" {
+            copy_codex_config_for_wework(&entry_path, destination)?;
+        } else {
+            copy_entry(&entry_path, &destination.join(destination_entry))?;
+        }
         imported_entries.push((*source_entry).to_owned());
     }
     if imported_entries.is_empty() {
@@ -305,6 +310,40 @@ fn import_external_content_from_paths(
         destination_path: destination.display().to_string(),
         imported_entries,
     })
+}
+
+fn copy_codex_config_for_wework(source: &Path, destination: &Path) -> Result<(), String> {
+    if !source.exists() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(source)
+        .map_err(|error| format!("Failed to read {}: {error}", source.display()))?;
+    let sanitized = remove_wework_managed_marketplace(&content).map_err(|error| {
+        format!(
+            "Failed to parse Codex config {} before importing it: {error}",
+            source.display()
+        )
+    })?;
+    fs::create_dir_all(destination)
+        .map_err(|error| format!("Failed to create {}: {error}", destination.display()))?;
+    replace_config(&destination.join("config.toml"), sanitized)
+}
+
+fn remove_wework_managed_marketplace(content: &str) -> Result<String, String> {
+    let mut config = content
+        .parse::<DocumentMut>()
+        .map_err(|error| error.to_string())?;
+    let remove_marketplaces_table = config
+        .get_mut("marketplaces")
+        .and_then(|item| item.as_table_like_mut())
+        .is_some_and(|marketplaces| {
+            marketplaces.remove(WEWORK_PERSONAL_MARKETPLACE_ID);
+            marketplaces.is_empty()
+        });
+    if remove_marketplaces_table {
+        config.remove("marketplaces");
+    }
+    Ok(config.to_string())
 }
 
 fn copy_entry(source: &Path, destination: &Path) -> Result<(), String> {
@@ -408,6 +447,49 @@ mod tests {
         assert_eq!(
             fs::read_to_string(wework_home.join("skills/example/SKILL.md")).unwrap(),
             "example"
+        );
+    }
+
+    #[test]
+    fn migration_drops_the_wework_managed_marketplace_but_keeps_plugin_settings() {
+        let root = tempfile::tempdir().unwrap();
+        let native_home = root.path().join("native");
+        let wework_home = root.path().join("wework");
+        fs::create_dir_all(&native_home).unwrap();
+        fs::write(
+            native_home.join("config.toml"),
+            concat!(
+                "model = \"native\"\n\n",
+                "[marketplaces.wework-personal]\n",
+                "source = \"/old/app/capabilities/wework-personal\"\n\n",
+                "[marketplaces.team]\n",
+                "source = \"https://example.com/team.git\"\n\n",
+                "[plugins.\"my-plugin@wework-personal\"]\n",
+                "enabled = true\n",
+            ),
+        )
+        .unwrap();
+
+        initialize_codex_home_from_paths(
+            &wework_home,
+            &native_home,
+            CodexHomeInitializeRequest {
+                migrate_native_home: true,
+                remote_apps_enabled: true,
+            },
+        )
+        .unwrap();
+
+        let config = fs::read_to_string(wework_home.join("config.toml")).unwrap();
+        let parsed = config.parse::<DocumentMut>().unwrap();
+        assert!(parsed["marketplaces"].get("wework-personal").is_none());
+        assert_eq!(
+            parsed["marketplaces"]["team"]["source"].as_str(),
+            Some("https://example.com/team.git")
+        );
+        assert_eq!(
+            parsed["plugins"]["my-plugin@wework-personal"]["enabled"].as_bool(),
+            Some(true)
         );
     }
 
@@ -537,6 +619,35 @@ mod tests {
             "example"
         );
         assert_eq!(result.imported_entries, vec!["config.toml", "skills"]);
+    }
+
+    #[test]
+    fn importing_codex_content_drops_a_stale_wework_marketplace_registration() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let destination = root.path().join("destination");
+        fs::create_dir_all(home.join(".codex")).unwrap();
+        fs::create_dir_all(&destination).unwrap();
+        fs::write(
+            home.join(".codex/config.toml"),
+            concat!(
+                "[marketplaces.wework-personal]\n",
+                "source = \"/another-build/wework-personal\"\n\n",
+                "[plugins.\"kept@wework-personal\"]\n",
+                "enabled = false\n",
+            ),
+        )
+        .unwrap();
+
+        import_external_content_from_paths("codex", &home, &destination).unwrap();
+
+        let config = fs::read_to_string(destination.join("config.toml")).unwrap();
+        let parsed = config.parse::<DocumentMut>().unwrap();
+        assert!(parsed.get("marketplaces").is_none());
+        assert_eq!(
+            parsed["plugins"]["kept@wework-personal"]["enabled"].as_bool(),
+            Some(false)
+        );
     }
 
     #[test]

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -117,6 +117,7 @@ mod fork_transfer;
 mod hooks;
 mod notifications;
 mod plugin_install;
+mod plugin_marketplace;
 mod queries;
 mod robot_queue_rpc;
 mod sidebar;
@@ -538,6 +539,7 @@ pub struct RuntimeWorkRpcHandler {
     codex_app_server: CodexAppServerClient,
     claude_process_engine: AgentProcessEngine,
     codex_runtime_proxy_config: Arc<AsyncMutex<CodexRuntimeProxyConfig>>,
+    bundled_plugin_marketplace_reconciliation: Arc<AsyncMutex<()>>,
     event_tx: Option<broadcast::Sender<Value>>,
     next_execution_id: Arc<AtomicU64>,
     task_send_gates: Arc<Mutex<HashMap<String, Weak<AsyncMutex<()>>>>>,
@@ -745,6 +747,7 @@ impl RuntimeWorkRpcHandler {
             codex_runtime_proxy_config: Arc::new(AsyncMutex::new(
                 CodexRuntimeProxyConfig::default(),
             )),
+            bundled_plugin_marketplace_reconciliation: Arc::new(AsyncMutex::new(())),
             event_tx: None,
             next_execution_id: Arc::new(AtomicU64::new(1)),
             task_send_gates: Arc::new(Mutex::new(HashMap::new())),
@@ -932,6 +935,9 @@ impl RuntimeWorkRpcHandler {
             "runtime.codex.personality.write" => self.write_codex_personality(payload).await,
             "runtime.codex.plugin.install_local_first" => self.install_local_plugin(payload).await,
             "runtime.codex.plugin.uninstall_local" => self.uninstall_local_plugin(payload).await,
+            "runtime.codex.plugin.reconcile_bundled_marketplace" => {
+                self.reconcile_bundled_plugin_marketplace(payload).await
+            }
             "runtime.codex.rate_limits.read" => self.read_codex_rate_limits().await,
             "runtime.codex.runtime_config.update" => {
                 self.update_codex_runtime_config(payload).await

--- a/executor/src/runtime_work/handler/plugin_marketplace.rs
+++ b/executor/src/runtime_work/handler/plugin_marketplace.rs
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::agents::replace_config;
+use toml_edit::{table, value, DocumentMut};
+
+const WEWORK_PERSONAL_MARKETPLACE_ID: &str = "wework-personal";
+
+impl RuntimeWorkRpcHandler {
+    pub(super) async fn reconcile_bundled_plugin_marketplace(
+        &self,
+        payload: Value,
+    ) -> Result<Value, AppIpcError> {
+        let marketplace_id = string_field(&payload, "marketplaceId")
+            .ok_or_else(|| AppIpcError::new("bad_request", "marketplaceId is required"))?;
+        if marketplace_id != WEWORK_PERSONAL_MARKETPLACE_ID {
+            return Err(AppIpcError::new(
+                "bad_request",
+                format!("Unsupported bundled plugin marketplace: {marketplace_id}"),
+            ));
+        }
+        let source = string_field(&payload, "source")
+            .ok_or_else(|| AppIpcError::new("bad_request", "source is required"))?;
+        let _guard = self.bundled_plugin_marketplace_reconciliation.lock().await;
+        let available = self
+            .codex_app_server
+            .request(
+                "plugin/list",
+                json!({
+                    "cwds": null,
+                    "marketplaceKinds": ["local"],
+                }),
+            )
+            .await
+            .map_err(plugin_marketplace_reconciliation_error)?;
+        let existing_marketplace = marketplace_entry(&available, &marketplace_id);
+        let configured_marketplace = configured_marketplace(&marketplace_id)
+            .map_err(plugin_marketplace_reconciliation_error)?;
+        let app_server_source = existing_marketplace.and_then(marketplace_source);
+        let configured_source = configured_marketplace
+            .as_ref()
+            .and_then(|entry| entry.source.clone());
+        let existing_source = app_server_source
+            .clone()
+            .or_else(|| configured_source.clone());
+        let existing_marketplace_present =
+            existing_marketplace.is_some() || configured_marketplace.is_some();
+        let app_server_source_matches = app_server_source
+            .as_deref()
+            .is_some_and(|existing| marketplace_sources_match(existing, &source));
+        let configured_source_matches = configured_source
+            .as_deref()
+            .is_some_and(|existing| marketplace_sources_match(existing, &source));
+        if app_server_source_matches || (app_server_source.is_none() && configured_source_matches) {
+            if !configured_source_matches {
+                write_configured_marketplace_source(&marketplace_id, &source)
+                    .map_err(plugin_marketplace_reconciliation_error)?;
+            }
+            log_plugin_marketplace_reconciliation(&marketplace_id, "unchanged", &source);
+            return Ok(json!({
+                "marketplaceName": marketplace_id,
+                "action": "unchanged",
+            }));
+        }
+
+        if existing_marketplace_present {
+            self.codex_app_server
+                .request(
+                    "marketplace/remove",
+                    json!({"marketplaceName": marketplace_id}),
+                )
+                .await
+                .map_err(plugin_marketplace_reconciliation_error)?;
+        }
+
+        let added = self
+            .codex_app_server
+            .request(
+                "marketplace/add",
+                json!({
+                    "source": source,
+                    "refName": null,
+                    "sparsePaths": null,
+                }),
+            )
+            .await;
+        let added = match added {
+            Ok(added) => added,
+            Err(add_error) => {
+                let rollback_error = if let Some(previous_source) = existing_source.as_deref() {
+                    self.codex_app_server
+                        .request(
+                            "marketplace/add",
+                            json!({
+                                "source": previous_source,
+                                "refName": null,
+                                "sparsePaths": null,
+                            }),
+                        )
+                        .await
+                        .err()
+                } else {
+                    None
+                };
+                let rollback = rollback_error
+                    .map(|error| format!("; restoring the previous source also failed: {error}"))
+                    .unwrap_or_default();
+                return Err(AppIpcError::new(
+                    "bundled_plugin_marketplace_reconciliation_failed",
+                    format!(
+                        "Failed to register bundled plugin marketplace {marketplace_id}: {add_error}{rollback}"
+                    ),
+                ));
+            }
+        };
+        let added_name = added
+            .get("marketplaceName")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if added_name != marketplace_id {
+            return Err(AppIpcError::new(
+                "bundled_plugin_marketplace_reconciliation_failed",
+                format!("Bundled plugin marketplace {marketplace_id} resolved to {added_name}"),
+            ));
+        }
+        write_configured_marketplace_source(&marketplace_id, &source)
+            .map_err(plugin_marketplace_reconciliation_error)?;
+        let action = if existing_marketplace_present {
+            "replaced"
+        } else {
+            "added"
+        };
+        log_plugin_marketplace_reconciliation(&marketplace_id, action, &source);
+        Ok(json!({
+            "marketplaceName": marketplace_id,
+            "action": action,
+        }))
+    }
+}
+
+fn marketplace_entry<'a>(response: &'a Value, marketplace_id: &str) -> Option<&'a Value> {
+    response
+        .get("marketplaces")
+        .and_then(Value::as_array)
+        .and_then(|marketplaces| {
+            marketplaces.iter().find(|marketplace| {
+                marketplace.get("name").and_then(Value::as_str) == Some(marketplace_id)
+            })
+        })
+}
+
+fn marketplace_source(marketplace: &Value) -> Option<String> {
+    marketplace
+        .get("path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|source| !source.is_empty())
+        .map(str::to_owned)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ConfiguredMarketplace {
+    source: Option<String>,
+}
+
+fn configured_marketplace(marketplace_id: &str) -> Result<Option<ConfiguredMarketplace>, String> {
+    let config_path = crate::agents::wework_codex_home().join("config.toml");
+    let content = match fs::read_to_string(&config_path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "Failed to read Codex config {}: {error}",
+                config_path.display()
+            ));
+        }
+    };
+    let config = content.parse::<DocumentMut>().map_err(|error| {
+        format!(
+            "Failed to parse Codex config {}: {error}",
+            config_path.display()
+        )
+    })?;
+    let marketplace = config
+        .get("marketplaces")
+        .and_then(|item| item.as_table_like())
+        .and_then(|marketplaces| marketplaces.get(marketplace_id));
+    Ok(marketplace.map(|marketplace| ConfiguredMarketplace {
+        source: marketplace
+            .get("source")
+            .and_then(|source| source.as_str())
+            .map(str::trim)
+            .filter(|source| !source.is_empty())
+            .map(str::to_owned),
+    }))
+}
+
+fn write_configured_marketplace_source(marketplace_id: &str, source: &str) -> Result<(), String> {
+    let config_path = crate::agents::wework_codex_home().join("config.toml");
+    let content = match fs::read_to_string(&config_path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            return Err(format!(
+                "Failed to read Codex config {}: {error}",
+                config_path.display()
+            ));
+        }
+    };
+    let updated =
+        set_configured_marketplace_source(&content, marketplace_id, source).map_err(|error| {
+            format!(
+                "Failed to parse Codex config {}: {error}",
+                config_path.display()
+            )
+        })?;
+    replace_config(&config_path, updated)
+}
+
+fn set_configured_marketplace_source(
+    content: &str,
+    marketplace_id: &str,
+    source: &str,
+) -> Result<String, String> {
+    let mut config = content
+        .parse::<DocumentMut>()
+        .map_err(|error| error.to_string())?;
+    if !config.contains_key("marketplaces") {
+        config["marketplaces"] = table();
+    }
+    let marketplaces = config["marketplaces"]
+        .as_table_like_mut()
+        .ok_or_else(|| "marketplaces must be a table".to_owned())?;
+    if !marketplaces.contains_key(marketplace_id) {
+        marketplaces.insert(marketplace_id, table());
+    }
+    let marketplace = marketplaces
+        .get_mut(marketplace_id)
+        .and_then(|item| item.as_table_like_mut())
+        .ok_or_else(|| format!("marketplaces.{marketplace_id} must be a table"))?;
+    marketplace.insert("source_type", value("local"));
+    marketplace.insert("source", value(source));
+    Ok(config.to_string())
+}
+
+fn marketplace_sources_match(left: &str, right: &str) -> bool {
+    let left = normalized_marketplace_source(left);
+    let right = normalized_marketplace_source(right);
+    match (fs::canonicalize(&left), fs::canonicalize(&right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+fn normalized_marketplace_source(source: &str) -> String {
+    let normalized = source
+        .trim()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_owned();
+    for manifest_suffix in [
+        "/.agents/plugins/marketplace.json",
+        "/.claude-plugin/marketplace.json",
+    ] {
+        if let Some(root) = normalized.strip_suffix(manifest_suffix) {
+            return root.to_owned();
+        }
+    }
+    normalized
+}
+
+fn plugin_marketplace_reconciliation_error(error: String) -> AppIpcError {
+    AppIpcError::new("bundled_plugin_marketplace_reconciliation_failed", error)
+}
+
+fn log_plugin_marketplace_reconciliation(marketplace_id: &str, action: &str, source: &str) {
+    log_executor_event(
+        "bundled plugin marketplace reconciled",
+        &[
+            ("marketplace_id", marketplace_id.to_owned()),
+            ("action", action.to_owned()),
+            ("source", source.to_owned()),
+        ],
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_the_registered_marketplace_source() {
+        let response = json!({
+            "marketplaces": [
+                {"name": "team", "path": "/plugins/team"},
+                {"name": "wework-personal", "path": "/plugins/personal"},
+            ]
+        });
+
+        assert_eq!(
+            marketplace_entry(&response, WEWORK_PERSONAL_MARKETPLACE_ID)
+                .and_then(marketplace_source)
+                .as_deref(),
+            Some("/plugins/personal")
+        );
+    }
+
+    #[test]
+    fn finds_a_registered_marketplace_even_when_codex_omits_its_path() {
+        let response = json!({
+            "marketplaces": [{"name": "wework-personal", "plugins": []}]
+        });
+
+        let marketplace = marketplace_entry(&response, WEWORK_PERSONAL_MARKETPLACE_ID)
+            .expect("the registered marketplace should be detected");
+        assert_eq!(marketplace_source(marketplace), None);
+    }
+
+    #[test]
+    fn compares_marketplace_sources_without_separator_noise() {
+        assert!(marketplace_sources_match(
+            r"C:\plugins\wework-personal\",
+            "C:/plugins/wework-personal"
+        ));
+        assert!(marketplace_sources_match(
+            "/plugins/wework-personal/.agents/plugins/marketplace.json",
+            "/plugins/wework-personal"
+        ));
+        assert!(!marketplace_sources_match(
+            "/old/plugins/wework-personal",
+            "/new/plugins/wework-personal"
+        ));
+    }
+
+    #[test]
+    fn rewrites_the_managed_marketplace_source_without_changing_plugin_settings() {
+        let updated = set_configured_marketplace_source(
+            concat!(
+                "[marketplaces.wework-personal]\n",
+                "source_type = \"local\"\n",
+                "source = \"/old/wework-personal\"\n\n",
+                "[plugins.\"kept@wework-personal\"]\n",
+                "enabled = false\n",
+            ),
+            WEWORK_PERSONAL_MARKETPLACE_ID,
+            "/current/wework-personal",
+        )
+        .unwrap();
+        let config = updated.parse::<DocumentMut>().unwrap();
+
+        assert_eq!(
+            config["marketplaces"][WEWORK_PERSONAL_MARKETPLACE_ID]["source"].as_str(),
+            Some("/current/wework-personal")
+        );
+        assert_eq!(
+            config["plugins"]["kept@wework-personal"]["enabled"].as_bool(),
+            Some(false)
+        );
+    }
+}

--- a/executor/src/runtime_work/handler/plugin_marketplace.rs
+++ b/executor/src/runtime_work/handler/plugin_marketplace.rs
@@ -65,7 +65,10 @@ impl RuntimeWorkRpcHandler {
             }));
         }
 
-        if existing_marketplace_present {
+        if should_remove_existing_marketplace(
+            existing_marketplace_present,
+            existing_source.as_deref(),
+        ) {
             self.codex_app_server
                 .request(
                     "marketplace/remove",
@@ -158,6 +161,13 @@ fn marketplace_source(marketplace: &Value) -> Option<String> {
         .map(str::trim)
         .filter(|source| !source.is_empty())
         .map(str::to_owned)
+}
+
+fn should_remove_existing_marketplace(
+    existing_marketplace_present: bool,
+    existing_source: Option<&str>,
+) -> bool {
+    existing_marketplace_present && existing_source.is_some()
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -316,6 +326,11 @@ mod tests {
         let marketplace = marketplace_entry(&response, WEWORK_PERSONAL_MARKETPLACE_ID)
             .expect("the registered marketplace should be detected");
         assert_eq!(marketplace_source(marketplace), None);
+        assert!(!should_remove_existing_marketplace(true, None));
+        assert!(should_remove_existing_marketplace(
+            true,
+            Some("/plugins/personal")
+        ));
     }
 
     #[test]

--- a/scripts/test-start-local-ip.sh
+++ b/scripts/test-start-local-ip.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression test for start.sh local IP selection when a VPN owns the default route.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+START_SH="$PROJECT_ROOT/start.sh"
+FAKE_BIN="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$FAKE_BIN"
+}
+trap cleanup EXIT
+
+extract_function() {
+    local function_name="$1"
+
+    awk -v function_name="$function_name" '
+        $0 ~ "^" function_name "\\(\\) \\{" {
+            in_function = 1
+            depth = 1
+            print
+            next
+        }
+        in_function {
+            print
+            opens = gsub(/\{/, "{")
+            closes = gsub(/\}/, "}")
+            depth += opens - closes
+            if (depth == 0) {
+                exit
+            }
+        }
+    ' "$START_SH"
+}
+
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "   interface: utun5"' > "$FAKE_BIN/route"
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "${1:-}" in' \
+    '  utun5) printf "%s\n" "utun5: flags=8051" "    inet 10.111.222.0 --> 10.111.222.0 netmask 0xffffffff" ;;' \
+    '  en0) printf "%s\n" "en0: flags=8863" "    inet 192.168.31.44 netmask 0xffffff00 broadcast 192.168.31.255" ;;' \
+    'esac' > "$FAKE_BIN/ifconfig"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$FAKE_BIN/hostname"
+chmod +x "$FAKE_BIN/route" "$FAKE_BIN/ifconfig" "$FAKE_BIN/hostname"
+
+is_virtual_network_interface_body="$(extract_function is_virtual_network_interface)"
+get_local_ip_body="$(extract_function get_local_ip)"
+
+actual_ip="$({
+    eval "$is_virtual_network_interface_body"
+    eval "$get_local_ip_body"
+    PATH="$FAKE_BIN:/usr/bin:/bin" get_local_ip
+})"
+
+if [ "$actual_ip" != "192.168.31.44" ]; then
+    echo "Expected the physical en0 address when utun5 owns the default route."
+    echo "Actual address: $actual_ip"
+    exit 1
+fi
+
+echo "start.sh local IP VPN regression test passed"

--- a/scripts/test-start-local-ip.sh
+++ b/scripts/test-start-local-ip.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# Regression test for start.sh local IP selection when a VPN owns the default route.
+# Regression tests for start.sh local IP selection when a VPN owns the default route.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 START_SH="$PROJECT_ROOT/start.sh"
-FAKE_BIN="$(mktemp -d)"
+FIXTURE_ROOT="$(mktemp -d)"
 
 cleanup() {
-    rm -rf "$FAKE_BIN"
+    rm -rf "$FIXTURE_ROOT"
 }
 trap cleanup EXIT
 
@@ -35,24 +35,32 @@ extract_function() {
     ' "$START_SH"
 }
 
-printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "   interface: utun5"' > "$FAKE_BIN/route"
-printf '%s\n' \
-    '#!/usr/bin/env bash' \
-    'case "${1:-}" in' \
-    '  utun5) printf "%s\n" "utun5: flags=8051" "    inet 10.111.222.0 --> 10.111.222.0 netmask 0xffffffff" ;;' \
-    '  en0) printf "%s\n" "en0: flags=8863" "    inet 192.168.31.44 netmask 0xffffff00 broadcast 192.168.31.255" ;;' \
-    'esac' > "$FAKE_BIN/ifconfig"
-printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$FAKE_BIN/hostname"
-chmod +x "$FAKE_BIN/route" "$FAKE_BIN/ifconfig" "$FAKE_BIN/hostname"
-
 is_virtual_network_interface_body="$(extract_function is_virtual_network_interface)"
+get_interface_ipv4_body="$(extract_function get_interface_ipv4)"
 get_local_ip_body="$(extract_function get_local_ip)"
 
-actual_ip="$({
-    eval "$is_virtual_network_interface_body"
-    eval "$get_local_ip_body"
-    PATH="$FAKE_BIN:/usr/bin:/bin" get_local_ip
-})"
+run_fixture() {
+    local fixture_bin="$1"
+
+    {
+        eval "$is_virtual_network_interface_body"
+        eval "$get_interface_ipv4_body"
+        eval "$get_local_ip_body"
+        PATH="$fixture_bin:/usr/bin:/bin" get_local_ip
+    }
+}
+
+MACOS_BIN="$FIXTURE_ROOT/macos"
+mkdir -p "$MACOS_BIN"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "   interface: utun5"' > "$MACOS_BIN/route"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$MACOS_BIN/ip"
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [ "$#" -gt 0 ]; then exit 1; fi' \
+    'printf "%s\n" "utun5: flags=8051" "    inet 10.111.222.0 --> 10.111.222.0 netmask 0xffffffff" "en0: flags=8863" "    inet 192.168.31.44 netmask 0xffffff00 broadcast 192.168.31.255"' > "$MACOS_BIN/ifconfig"
+chmod +x "$MACOS_BIN/route" "$MACOS_BIN/ip" "$MACOS_BIN/ifconfig"
+
+actual_ip="$(run_fixture "$MACOS_BIN")"
 
 if [ "$actual_ip" != "192.168.31.44" ]; then
     echo "Expected the physical en0 address when utun5 owns the default route."
@@ -60,4 +68,25 @@ if [ "$actual_ip" != "192.168.31.44" ]; then
     exit 1
 fi
 
-echo "start.sh local IP VPN regression test passed"
+LINUX_BIN="$FIXTURE_ROOT/linux"
+mkdir -p "$LINUX_BIN"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$LINUX_BIN/route"
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "$*" in' \
+    '  route) printf "%s\n" "default via 10.44.0.1 dev wg0 proto static" ;;' \
+    '  "-o -4 addr show dev wg0 scope global") printf "%s\n" "9: wg0    inet 10.44.0.2/24 scope global wg0" ;;' \
+    '  "-o -4 addr show scope global") printf "%s\n" "9: wg0    inet 10.44.0.2/24 scope global wg0" "11: br-test    inet 172.20.0.1/16 scope global br-test" "2: eth0    inet 192.168.50.25/24 scope global eth0" ;;' \
+    'esac' > "$LINUX_BIN/ip"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$LINUX_BIN/ifconfig"
+chmod +x "$LINUX_BIN/route" "$LINUX_BIN/ip" "$LINUX_BIN/ifconfig"
+
+actual_ip="$(run_fixture "$LINUX_BIN")"
+
+if [ "$actual_ip" != "192.168.50.25" ]; then
+    echo "Expected the physical eth0 address when wg0 owns the default route."
+    echo "Actual address: $actual_ip"
+    exit 1
+fi
+
+echo "start.sh local IP VPN regression tests passed"

--- a/start.sh
+++ b/start.sh
@@ -1069,6 +1069,14 @@ clean_frontend_cache() {
     fi
 }
 
+# Return success when an interface should not advertise local development services.
+is_virtual_network_interface() {
+    case "$1" in
+        ""|lo|lo0|utun*|tun*|tap*|ppp*|ipsec*|wg*|docker*|br-*|veth*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Get local IP address (defined early as it's used by default values)
 get_local_ip() {
     # Try to get the local IP address, fallback to localhost if not available
@@ -1082,7 +1090,9 @@ get_local_ip() {
         # Try macOS style
         if command -v route &> /dev/null; then
             default_iface=$(route -n get default 2>/dev/null | grep "interface:" | awk '{print $2}')
-            if [ -n "$default_iface" ] && command -v ifconfig &> /dev/null; then
+            if [ -n "$default_iface" ] && \
+                ! is_virtual_network_interface "$default_iface" && \
+                command -v ifconfig &> /dev/null; then
                 ip=$(ifconfig "$default_iface" 2>/dev/null | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}' | head -1)
             fi
         fi
@@ -1090,7 +1100,7 @@ get_local_ip() {
         # Try Linux style with ip command
         if [ -z "$ip" ] && command -v ip &> /dev/null; then
             default_iface=$(ip route 2>/dev/null | grep default | awk '{print $5}' | head -1)
-            if [ -n "$default_iface" ]; then
+            if [ -n "$default_iface" ] && ! is_virtual_network_interface "$default_iface"; then
                 ip=$(ip addr show "$default_iface" 2>/dev/null | grep "inet " | awk '{print $2}' | cut -d/ -f1 | head -1)
             fi
         fi

--- a/start.sh
+++ b/start.sh
@@ -1071,10 +1071,36 @@ clean_frontend_cache() {
 
 # Return success when an interface should not advertise local development services.
 is_virtual_network_interface() {
-    case "$1" in
+    local interface_name="${1%%@*}"
+
+    case "$interface_name" in
         ""|lo|lo0|utun*|tun*|tap*|ppp*|ipsec*|wg*|docker*|br-*|veth*) return 0 ;;
         *) return 1 ;;
     esac
+}
+
+get_interface_ipv4() {
+    local interface_name="${1%%@*}"
+    local ip=""
+
+    if is_virtual_network_interface "$interface_name"; then
+        return 1
+    fi
+
+    if command -v ip &> /dev/null; then
+        ip=$(ip -o -4 addr show dev "$interface_name" scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1)
+    fi
+
+    if [ -z "$ip" ] && command -v ifconfig &> /dev/null; then
+        ip=$(ifconfig "$interface_name" 2>/dev/null | awk '$1 == "inet" { sub(/^addr:/, "", $2); if ($2 != "127.0.0.1") { print $2; exit } }')
+    fi
+
+    if [ -n "$ip" ]; then
+        echo "$ip"
+        return 0
+    fi
+
+    return 1
 }
 
 # Get local IP address (defined early as it's used by default values)
@@ -1090,40 +1116,50 @@ get_local_ip() {
         # Try macOS style
         if command -v route &> /dev/null; then
             default_iface=$(route -n get default 2>/dev/null | grep "interface:" | awk '{print $2}')
-            if [ -n "$default_iface" ] && \
-                ! is_virtual_network_interface "$default_iface" && \
-                command -v ifconfig &> /dev/null; then
-                ip=$(ifconfig "$default_iface" 2>/dev/null | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}' | head -1)
+            if [ -n "$default_iface" ]; then
+                ip=$(get_interface_ipv4 "$default_iface" || true)
             fi
         fi
 
         # Try Linux style with ip command
         if [ -z "$ip" ] && command -v ip &> /dev/null; then
             default_iface=$(ip route 2>/dev/null | grep default | awk '{print $5}' | head -1)
-            if [ -n "$default_iface" ] && ! is_virtual_network_interface "$default_iface"; then
-                ip=$(ip addr show "$default_iface" 2>/dev/null | grep "inet " | awk '{print $2}' | cut -d/ -f1 | head -1)
+            if [ -n "$default_iface" ]; then
+                ip=$(get_interface_ipv4 "$default_iface" || true)
             fi
         fi
     fi
 
-    # Method 2: Try hostname -I (works on some Linux, gets first non-loopback IP)
-    if [ -z "$ip" ] && command -v hostname &> /dev/null; then
-        ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    # Method 2: Enumerate Linux interface/address pairs so virtual interfaces stay filtered.
+    if [ -z "$ip" ] && command -v ip &> /dev/null; then
+        while read -r candidate_iface candidate_address; do
+            if ! is_virtual_network_interface "$candidate_iface"; then
+                ip="${candidate_address%%/*}"
+                break
+            fi
+        done < <(ip -o -4 addr show scope global 2>/dev/null | awk '{print $2, $4}')
     fi
 
-    # Method 3: Try macOS/BSD ifconfig with common interface patterns
-    # Filter out docker/bridge interfaces (br-, docker, veth)
+    # Method 3: Enumerate macOS/BSD interface/address pairs with the same filter.
     if [ -z "$ip" ] && command -v ifconfig &> /dev/null; then
-        # First try en0 (most common default on macOS)
-        ip=$(ifconfig en0 2>/dev/null | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}' | head -1)
-        # Then try en/eth interfaces
-        if [ -z "$ip" ]; then
-            ip=$(ifconfig | grep -A 1 "^en\|^eth" | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}' | head -1)
-        fi
-        # If no en/eth interface, try any non-docker interface
-        if [ -z "$ip" ]; then
-            ip=$(ifconfig | grep -v "^br-\|^docker\|^veth" | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}' | head -1)
-        fi
+        while read -r candidate_iface candidate_address; do
+            if ! is_virtual_network_interface "$candidate_iface"; then
+                ip="$candidate_address"
+                break
+            fi
+        done < <(ifconfig 2>/dev/null | awk '
+            /^[[:alnum:]_.:@-]+:/ {
+                interface_name = $1
+                sub(/:$/, "", interface_name)
+            }
+            $1 == "inet" {
+                address = $2
+                sub(/^addr:/, "", address)
+                if (address != "127.0.0.1") {
+                    print interface_name, address
+                }
+            }
+        ')
     fi
 
     # Fallback to localhost if no IP found

--- a/wework/e2e/desktop/modules/plugin-flows.mjs
+++ b/wework/e2e/desktop/modules/plugin-flows.mjs
@@ -6,6 +6,7 @@ import {
 } from './conversation-layout.mjs'
 
 import { sendPrompt } from './conversation-navigation.mjs'
+import { waitForBlankConversation } from './memory-tool-flows.mjs'
 
 import {
   ACTIVE_COMPOSER_SELECTOR,
@@ -268,22 +269,26 @@ async function initializeBlankCodexHome({ codexHome, control }) {
   )
 }
 
-async function waitForBundledMarketplaceRegistration(codexHome) {
+async function waitForBundledMarketplaceRegistration(codexHome, expectedSource) {
   const configPath = join(codexHome, 'config.toml')
+  const expectedSourceLine = expectedSource ? `source = ${JSON.stringify(expectedSource)}` : null
   const startedAt = Date.now()
   while (Date.now() - startedAt < WORKBENCH_READY_TIMEOUT_MS) {
     if (await pathExists(configPath)) {
       const config = await readFile(configPath, 'utf8')
       if (
         config.includes('[marketplaces.wework-personal]') &&
-        config.includes('source_type = "local"')
+        config.includes('source_type = "local"') &&
+        (!expectedSourceLine || config.includes(expectedSourceLine))
       ) {
         return
       }
     }
     await new Promise(resolvePromise => setTimeout(resolvePromise, 50))
   }
-  throw new Error('The bundled local plugin marketplace was not registered in the background')
+  throw new Error(
+    `The bundled local plugin marketplace was not registered from ${expectedSource ?? 'the expected local source'}`
+  )
 }
 
 async function verifyStartupIgnoresBlockedCodexNetwork({
@@ -1156,9 +1161,7 @@ async function verifyMarketplacePluginLifecycle({
   await captureVerificationScreenshot(control, 'marketplace-plugins-05-uninstalled.png')
 
   await control.command('click', '[data-testid="new-chat-button"]')
-  await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, {
-    timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
-  })
+  await waitForBlankConversation(control, ACTIVE_COMPOSER_SELECTOR)
   await control.command('click', '[data-testid="composer-plugin-picker-button"]')
   await control.command('waitFor', '[data-testid="composer-plugin-picker"]', {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
@@ -1186,6 +1189,7 @@ async function verifySkillMentionRendering({ control, fixture }) {
   const qualifiedSkillName = `${OFFICIAL_PLUGIN_NAME}:${OFFICIAL_PLUGIN_SKILL_NAME}`
   const qualifiedSkillTestId = qualifiedSkillName.replace(/[^a-zA-Z0-9_-]/g, '-')
   await control.command('click', '[data-testid="new-chat-button"]')
+  await waitForBlankConversation(control, ACTIVE_COMPOSER_SELECTOR)
   control.setScenario('skill_mention_display')
   await control.command('fill', ACTIVE_COMPOSER_SELECTOR, {
     value: `[$${qualifiedSkillName}](${fixture.skillPath}) ${QUALIFIED_SKILL_MENTION_PROMPT}`,

--- a/wework/e2e/desktop/modules/plugin-flows.mjs
+++ b/wework/e2e/desktop/modules/plugin-flows.mjs
@@ -468,6 +468,17 @@ async function installOfficialPluginFixture({
     'The official plugin was not shown as installed after the real app-server request',
     WORKBENCH_READY_TIMEOUT_MS
   )
+  await control.command('waitFor', '[data-testid="plugin-operation-notice"]', {
+    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  })
+  assert.match(
+    await control.command('getAttribute', '[data-testid="plugin-operation-notice"]', {
+      value: 'class',
+    }),
+    /electron-titlebar-interactive-region/,
+    'The plugin operation notice remained inside the native titlebar drag region'
+  )
+  await control.command('click', '[data-testid="plugin-operation-notice-dismiss"]')
   await openMarketplacePluginActions(control, {
     pluginId,
     marketplaceName: OFFICIAL_PLUGIN_MARKETPLACE_NAME,

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -899,6 +899,7 @@ async function main() {
   const codexHome = join(executorHome, 'codex')
   const codexSqliteHome = join(tmpdir(), 'wework-desktop-e2e', String(process.pid), 'codex-sqlite')
   const nativeCodexHome = join(resultDir, 'native-codex')
+  const staleBundledMarketplacePath = join(resultDir, 'stale-wework-personal')
   const pluginMarketplacePath = join(resultDir, 'plugin-marketplace')
   const marketplacePluginPath = join(resultDir, 'marketplace-plugin')
   const officialPluginRepositoryPath = join(resultDir, 'openai-plugins')
@@ -945,6 +946,11 @@ async function main() {
       await createCoreDshPluginFixture(resultDir)
     }
     await mkdir(nativeCodexHome, { recursive: true })
+    await mkdir(join(staleBundledMarketplacePath, '.agents', 'plugins'), { recursive: true })
+    await writeFile(
+      join(staleBundledMarketplacePath, '.agents', 'plugins', 'marketplace.json'),
+      `${JSON.stringify({ name: 'wework-personal', plugins: [] }, null, 2)}\n`
+    )
     await writeFile(
       join(nativeCodexHome, 'config.toml'),
       '# desktop-e2e-native-home-marker\nmodel = "native-model-that-must-not-migrate"\n'
@@ -1280,7 +1286,11 @@ plugins = true
 [marketplaces.${STARTUP_NETWORK_PROBE_MARKETPLACE_NAME}]
 source_type = "git"
 source = "${STARTUP_NETWORK_PROBE_MARKETPLACE_URL}"
-last_updated = "2026-07-30T00:00:00Z"`
+last_updated = "2026-07-30T00:00:00Z"
+
+[marketplaces.wework-personal]
+source_type = "local"
+source = ${JSON.stringify(staleBundledMarketplacePath)}`
         )
       await verifyStartupIgnoresBlockedCodexNetwork({
         blockingNetworkProxy,
@@ -1288,7 +1298,10 @@ last_updated = "2026-07-30T00:00:00Z"`
         control,
         restartDesktopApp,
       })
-      await waitForBundledMarketplaceRegistration(codexHome)
+      await waitForBundledMarketplaceRegistration(
+        codexHome,
+        join(executorHome, 'capabilities', 'bundled-marketplaces', 'wework-personal')
+      )
     }
     if (SYSTEM_DRAG_PANEL_ONLY) {
       phase = 'system-drag-panel-layout'

--- a/wework/electron/src/runtime/core-dsh-runtime.test.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.test.ts
@@ -220,26 +220,37 @@ describe('core DSH runtime', () => {
     await root.remove()
   })
 
-  test('preserves an explicitly configured Wework application web root', async () => {
+  test('resolves configured and bundled Wework application web roots', async () => {
     const root = await temporaryDirectory('core-dsh-web-root-')
-    const runtime = await writeRuntime(root.path, CORE_DSH_VERSION, 'a')
-    const configuredWebRoot = join(root.path, 'development-web')
+    try {
+      const runtime = await writeRuntime(root.path, CORE_DSH_VERSION, 'a')
+      const configuredWebRoot = join(root.path, 'development-web')
+      const bundledWebRoot = join(runtime.pluginRoots['@wegent/dsh-app-wework'], 'web')
+      const cases = [
+        { value: `  ${configuredWebRoot}  `, expected: configuredWebRoot },
+        { value: '', expected: bundledWebRoot },
+        { value: '   ', expected: bundledWebRoot },
+      ]
 
-    const launch = await prepareCoreDshLaunch({
-      runtimeRoot: runtime.root,
-      dataDirectory: join(root.path, 'data'),
-      environment: {
-        PATH: '/usr/bin',
-        WEWORK_APP_WEB_ROOT: configuredWebRoot,
-        WEWORK_CORE_PLUGIN_ROOT: runtime.pluginsRoot,
-        WEWORK_CORE_PLUGINS_SHA256: 'f'.repeat(64),
-        WEWORK_NODE_PATH: '/managed/node',
-      },
-      port: 3080,
-    })
+      for (const [index, testCase] of cases.entries()) {
+        const launch = await prepareCoreDshLaunch({
+          runtimeRoot: runtime.root,
+          dataDirectory: join(root.path, `data-${index}`),
+          environment: {
+            PATH: '/usr/bin',
+            WEWORK_APP_WEB_ROOT: testCase.value,
+            WEWORK_CORE_PLUGIN_ROOT: runtime.pluginsRoot,
+            WEWORK_CORE_PLUGINS_SHA256: 'f'.repeat(64),
+            WEWORK_NODE_PATH: '/managed/node',
+          },
+          port: 3080 + index,
+        })
 
-    expect(launch.environment.WEWORK_APP_WEB_ROOT).toBe(configuredWebRoot)
-    await root.remove()
+        expect(launch.environment.WEWORK_APP_WEB_ROOT).toBe(testCase.expected)
+      }
+    } finally {
+      await root.remove()
+    }
   })
 
   test('refreshes the profile when only the host fingerprint changes', async () => {

--- a/wework/electron/src/runtime/core-dsh-runtime.test.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.test.ts
@@ -216,6 +216,28 @@ describe('core DSH runtime', () => {
     await root.remove()
   })
 
+  test('preserves an explicitly configured Wework application web root', async () => {
+    const root = await temporaryDirectory('core-dsh-web-root-')
+    const runtime = await writeRuntime(root.path, CORE_DSH_VERSION, 'a')
+    const configuredWebRoot = join(root.path, 'development-web')
+
+    const launch = await prepareCoreDshLaunch({
+      runtimeRoot: runtime.root,
+      dataDirectory: join(root.path, 'data'),
+      environment: {
+        PATH: '/usr/bin',
+        WEWORK_APP_WEB_ROOT: configuredWebRoot,
+        WEWORK_CORE_PLUGIN_ROOT: runtime.pluginsRoot,
+        WEWORK_CORE_PLUGINS_SHA256: 'f'.repeat(64),
+        WEWORK_NODE_PATH: '/managed/node',
+      },
+      port: 3080,
+    })
+
+    expect(launch.environment.WEWORK_APP_WEB_ROOT).toBe(configuredWebRoot)
+    await root.remove()
+  })
+
   test('refreshes the profile when only the host fingerprint changes', async () => {
     const root = await temporaryDirectory('core-dsh-host-change-')
     const firstRuntime = await writeRuntime(root.path, CORE_DSH_VERSION, 'a')

--- a/wework/electron/src/runtime/core-dsh-runtime.ts
+++ b/wework/electron/src/runtime/core-dsh-runtime.ts
@@ -137,7 +137,9 @@ export async function prepareCoreDshLaunch(options: PrepareCoreDshOptions): Prom
     environment: {
       ...options.environment,
       DSH_HOME: dshHome,
-      WEWORK_APP_WEB_ROOT: join(runtime.pluginRoots['@wegent/dsh-app-wework'], 'web'),
+      WEWORK_APP_WEB_ROOT:
+        options.environment.WEWORK_APP_WEB_ROOT?.trim() ||
+        join(runtime.pluginRoots['@wegent/dsh-app-wework'], 'web'),
       WEWORK_HARNESS_API_KEY: 'wework-local-router',
     },
     profile: PROFILE_NAME,

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -182,6 +182,7 @@ vi.mock('@/desktop/localExecutor', () => ({
     .fn()
     .mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' }),
   getInitializedBundledPluginMarketplace: vi.fn().mockReturnValue(null),
+  getKnownLocalExecutorDeviceId: vi.fn().mockReturnValue('local-device'),
   requestLocalExecutor: vi.fn(async (capability: string) => {
     if (capability === 'executor.plugins.personal.list') {
       return { marketplacePath: '', plugins: [] }

--- a/wework/src/api/local/codexPlugins.package.test.ts
+++ b/wework/src/api/local/codexPlugins.package.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/lib/runtime-environment', () => ({
 vi.mock('@/desktop/localExecutor', () => ({
   ensureLocalExecutorStarted: vi.fn(),
   ensureBundledPluginMarketplaceRegistered: vi.fn(),
+  getKnownLocalExecutorDeviceId: () => 'local-device',
   getInitializedBundledPluginMarketplace: () => ({
     id: 'wework-personal',
     path: '/tmp/executor-home/capabilities/bundled-marketplaces/wework-personal',

--- a/wework/src/api/local/codexPlugins.readStateCache.test.ts
+++ b/wework/src/api/local/codexPlugins.readStateCache.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   ensureLocalExecutorStarted: vi.fn(),
   ensureBundledPluginMarketplaceRegistered: vi.fn(),
   getInitializedBundledPluginMarketplace: vi.fn(() => null),
+  knownDeviceId: 'local-device' as string | null,
   runtime: {
     desktop: true,
     electron: true,
@@ -28,6 +29,7 @@ vi.mock('@/desktop/localExecutor', () => ({
   ensureLocalExecutorStarted: () => mocks.ensureLocalExecutorStarted(),
   ensureBundledPluginMarketplaceRegistered: () => mocks.ensureBundledPluginMarketplaceRegistered(),
   getInitializedBundledPluginMarketplace: () => mocks.getInitializedBundledPluginMarketplace(),
+  getKnownLocalExecutorDeviceId: () => mocks.knownDeviceId,
   requestLocalExecutor: (...args: unknown[]) => mocks.requestLocalExecutor(...args),
 }))
 
@@ -86,6 +88,7 @@ describe('local codex plugin readState cache', () => {
     clearLocalCodexPluginsReadStateCache()
     mocks.runtime.desktop = true
     mocks.runtime.electron = true
+    mocks.knownDeviceId = 'local-device'
     mocks.requestLocalExecutor.mockReset()
     mocks.ensureLocalExecutorStarted.mockReset()
     mocks.ensureBundledPluginMarketplaceRegistered.mockReset()
@@ -913,6 +916,41 @@ describe('local codex plugin readState cache', () => {
     expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId).toBe(
       'local-device'
     )
+  })
+
+  test('does not hydrate a plugin snapshot from another executor home', async () => {
+    await createLocalCodexPluginApi().readState({ mergeAllMarketplaces: true })
+    const raw = window.localStorage.getItem('wework.plugins.codexReadState.v2')
+    expect(raw).toBeTruthy()
+    clearLocalCodexPluginsReadStateCache()
+    window.localStorage.setItem('wework.plugins.codexReadState.v2', raw!)
+
+    mocks.knownDeviceId = 'other-executor-device'
+
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })).toBeNull()
+  })
+
+  test('drops an in-memory plugin snapshot when the executor home changes', async () => {
+    await createLocalCodexPluginApi().readState({ mergeAllMarketplaces: true })
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId).toBe(
+      'local-device'
+    )
+
+    mocks.knownDeviceId = 'other-executor-device'
+
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })).toBeNull()
+  })
+
+  test('does not expose a durable plugin snapshot before the executor scope is known', async () => {
+    await createLocalCodexPluginApi().readState({ mergeAllMarketplaces: true })
+    const raw = window.localStorage.getItem('wework.plugins.codexReadState.v2')
+    expect(raw).toBeTruthy()
+    clearLocalCodexPluginsReadStateCache()
+    window.localStorage.setItem('wework.plugins.codexReadState.v2', raw!)
+
+    mocks.knownDeviceId = null
+
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })).toBeNull()
   })
 
   test('migrates yesterday durable v1 peek into v2 without forcing a cold plugin/list', async () => {

--- a/wework/src/api/local/codexPlugins.readStateCache.test.ts
+++ b/wework/src/api/local/codexPlugins.readStateCache.test.ts
@@ -627,6 +627,69 @@ describe('local codex plugin readState cache', () => {
     ).toBe(1)
   })
 
+  test('does not reuse an in-flight plugin list after the executor device changes', async () => {
+    let activeDevice = 'device-a'
+    let pluginListRequestCount = 0
+    let resolveDeviceAList: ((value: unknown) => void) | null = null
+    mocks.knownDeviceId = activeDevice
+    mocks.ensureLocalExecutorStarted.mockImplementation(async () => ({ deviceId: activeDevice }))
+    mocks.requestLocalExecutor.mockImplementation(
+      async (method: string, params: { method?: string }) => {
+        if (method === 'executor.plugins.store.list') {
+          return { storePath: '/tmp/store/plugins', plugins: [] }
+        }
+        if (method !== 'codex.app_server_request') {
+          throw new Error(`Unexpected executor method ${method}`)
+        }
+        if (params.method === 'plugin/installed') return { marketplaces: [] }
+        if (params.method === 'plugin/list') {
+          pluginListRequestCount += 1
+          if (pluginListRequestCount === 1) {
+            return await new Promise(resolve => {
+              resolveDeviceAList = resolve
+            })
+          }
+          return {
+            marketplaces: [
+              {
+                ...personalMarketplace,
+                plugins: [{ name: 'device-b-plugin', version: '1.0.0' }],
+              },
+            ],
+          }
+        }
+        throw new Error(`Unexpected app-server method ${params.method}`)
+      }
+    )
+
+    const api = createLocalCodexPluginApi()
+    const deviceARead = api.readState({ mergeAllMarketplaces: true })
+    await vi.waitFor(() => expect(pluginListRequestCount).toBe(1))
+
+    activeDevice = 'device-b'
+    mocks.knownDeviceId = activeDevice
+    const deviceBState = await api.readState({ mergeAllMarketplaces: true })
+
+    expect(pluginListRequestCount).toBe(2)
+    expect(deviceBState.deviceId).toBe('device-b')
+    expect(deviceBState.marketplaceItems.map(item => item.name)).toEqual(['device-b-plugin'])
+
+    resolveDeviceAList?.({
+      marketplaces: [
+        {
+          ...personalMarketplace,
+          plugins: [{ name: 'device-a-plugin', version: '1.0.0' }],
+        },
+      ],
+    })
+    const deviceAState = await deviceARead
+    expect(deviceAState.deviceId).toBe('device-a')
+    expect(deviceAState.marketplaceItems.map(item => item.name)).toEqual(['device-a-plugin'])
+    expect(peekLocalCodexPluginsReadState({ mergeAllMarketplaces: true })?.deviceId).toBe(
+      'device-b'
+    )
+  })
+
   test('stale readState returns cache immediately and refreshes plugin/list in background', async () => {
     const api = createLocalCodexPluginApi()
     const warm = await api.readState({ mergeAllMarketplaces: true })

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -445,6 +445,7 @@ let cachedStateGeneration = 0
 let nextReadStateGeneration = 1
 let cachedStateAt = 0
 let cachedStateParamsKey = ''
+let activeReadStateDeviceId: string | null = null
 const inflightReadState = new Map<string, Promise<LocalCodexPluginsState>>()
 let inflightPluginInstalled: Promise<{
   marketplaces: CodexPluginMarketplaceEntry[]
@@ -470,6 +471,7 @@ export function clearLocalCodexPluginsReadStateCache(): void {
   cachedStateGeneration = 0
   cachedStateAt = 0
   cachedStateParamsKey = ''
+  activeReadStateDeviceId = null
   inflightReadState.clear()
   inflightPluginInstalled = null
   inflightWegentStoreList = null
@@ -811,7 +813,8 @@ function readStateMatchesDevice(
 }
 
 function resetInMemoryReadStateForDevice(deviceId: string): void {
-  if (!cachedState || readStateMatchesDevice(cachedState, deviceId)) return
+  if (activeReadStateDeviceId === deviceId) return
+  activeReadStateDeviceId = deviceId
   cachedState = null
   cachedStateGeneration = 0
   cachedStateAt = 0
@@ -2530,10 +2533,16 @@ async function loadReadStateSnapshot(
     deviceId: executorStatus.deviceId?.trim() ?? '',
   }
   const state = retainOpenAiOfficialCatalog(
-    cachedStateParamsKey === paramsKey ? cachedState : null,
+    cachedStateParamsKey === paramsKey && readStateMatchesDevice(cachedState, loadedState.deviceId)
+      ? cachedState
+      : null,
     loadedState
   )
-  if (generation < cachedStateGeneration && cachedStateParamsKey === paramsKey && cachedState) {
+  if (
+    generation < cachedStateGeneration &&
+    cachedStateParamsKey === paramsKey &&
+    readStateMatchesDevice(cachedState, loadedState.deviceId)
+  ) {
     return cachedState
   }
   if (generation >= cachedStateGeneration) {

--- a/wework/src/api/local/codexPlugins.ts
+++ b/wework/src/api/local/codexPlugins.ts
@@ -8,6 +8,7 @@ import {
   ensureBundledPluginMarketplaceRegistered,
   ensureLocalExecutorStarted,
   getInitializedBundledPluginMarketplace,
+  getKnownLocalExecutorDeviceId,
   requestLocalExecutor,
 } from '@/desktop/localExecutor'
 import type {
@@ -802,7 +803,27 @@ function persistReadStateSnapshot(
   writePersistedReadStateStore(store)
 }
 
-function hydrateReadStateCacheFromSession(): void {
+function readStateMatchesDevice(
+  state: LocalCodexPluginsState | null | undefined,
+  deviceId: string
+): state is LocalCodexPluginsState {
+  return Boolean(state && deviceId && state.deviceId.trim() === deviceId)
+}
+
+function resetInMemoryReadStateForDevice(deviceId: string): void {
+  if (!cachedState || readStateMatchesDevice(cachedState, deviceId)) return
+  cachedState = null
+  cachedStateGeneration = 0
+  cachedStateAt = 0
+  cachedStateParamsKey = ''
+  inflightReadState.clear()
+  inflightPluginInstalled = null
+  inflightWegentStoreList = null
+  didHydrateReadStateSession = false
+  warmupReadStatePromise = null
+}
+
+function hydrateReadStateCacheFromSession(deviceId: string): void {
   if (didHydrateReadStateSession) return
   didHydrateReadStateSession = true
   if (cachedState) return
@@ -812,6 +833,7 @@ function hydrateReadStateCacheFromSession(): void {
   )[0]
   if (!entry) return
   if (Date.now() - entry.cachedAt > READ_STATE_DURABLE_TTL_MS) return
+  if (!readStateMatchesDevice(entry.state, deviceId)) return
   cachedState = entry.state
   cachedStateAt = entry.cachedAt
   cachedStateParamsKey = entry.paramsKey
@@ -823,6 +845,8 @@ function rememberReadStateSnapshot(
   state: LocalCodexPluginsState,
   generation: number
 ): void {
+  const deviceId = getKnownLocalExecutorDeviceId()?.trim() ?? ''
+  if (!readStateMatchesDevice(state, deviceId)) return
   if (generation < cachedStateGeneration) return
   cachedState = state
   cachedStateGeneration = generation
@@ -838,12 +862,18 @@ export function peekLocalCodexPluginsReadState(
     mergeAllMarketplaces?: boolean
   } = {}
 ): LocalCodexPluginsState | null {
-  hydrateReadStateCacheFromSession()
+  const deviceId = getKnownLocalExecutorDeviceId()?.trim() ?? ''
+  if (!deviceId) return null
+  resetInMemoryReadStateForDevice(deviceId)
+  hydrateReadStateCacheFromSession(deviceId)
   const paramsKey = readStateParamsKey(params)
-  if (cachedState && cachedStateParamsKey === paramsKey) return cachedState
+  if (readStateMatchesDevice(cachedState, deviceId) && cachedStateParamsKey === paramsKey) {
+    return cachedState
+  }
   const persisted = readPersistedReadStateStore().entries[paramsKey]
   if (!persisted) return null
   if (Date.now() - persisted.cachedAt > READ_STATE_DURABLE_TTL_MS) return null
+  if (!readStateMatchesDevice(persisted.state, deviceId)) return null
   cachedState = persisted.state
   cachedStateAt = persisted.cachedAt
   cachedStateParamsKey = paramsKey
@@ -2368,7 +2398,10 @@ async function readState(
   } = {}
 ): Promise<LocalCodexPluginsState> {
   if (!isDesktopRuntime()) return emptyState
-  hydrateReadStateCacheFromSession()
+  const executorStatus = await ensureLocalExecutorStarted()
+  const deviceId = executorStatus.deviceId?.trim() ?? ''
+  resetInMemoryReadStateForDevice(deviceId)
+  hydrateReadStateCacheFromSession(deviceId)
   const paramsKey = readStateParamsKey(params)
   if (
     !params.refresh &&

--- a/wework/src/components/plugins/PluginOperationNotice.tsx
+++ b/wework/src/components/plugins/PluginOperationNotice.tsx
@@ -24,7 +24,7 @@ export function PluginOperationNotice({
       role={notice.kind === 'error' ? 'alert' : 'status'}
       data-testid="plugin-operation-notice"
       data-notice-kind={notice.kind}
-      className={`plugin-operation-notice plugin-operation-notice-${notice.kind}`}
+      className={`electron-titlebar-interactive-region plugin-operation-notice plugin-operation-notice-${notice.kind}`}
     >
       <span className="plugin-operation-notice-icon" aria-hidden="true">
         {notice.iconUrl ? (

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -27,9 +27,19 @@ const telemetryMocks = vi.hoisted(() => ({
 }))
 const localExecutorMocks = vi.hoisted(() => ({
   ensureStarted: vi.fn(),
+  knownDeviceId: 'current-device' as string | null,
   request: vi.fn(),
 }))
 const desktopHostMock = vi.hoisted(() => vi.fn())
+
+function mockKnownExecutorDevice(deviceId: string): void {
+  localExecutorMocks.knownDeviceId = deviceId
+  localExecutorMocks.ensureStarted.mockResolvedValue({
+    running: true,
+    ready: true,
+    deviceId,
+  })
+}
 
 async function installPluginFromMarketCard(testId: string) {
   await userEvent.click(screen.getByTestId(testId))
@@ -40,6 +50,7 @@ async function installPluginFromMarketCard(testId: string) {
 vi.mock('@/desktop/localExecutor', async importOriginal => ({
   ...(await importOriginal<typeof import('@/desktop/localExecutor')>()),
   ensureLocalExecutorStarted: localExecutorMocks.ensureStarted,
+  getKnownLocalExecutorDeviceId: () => localExecutorMocks.knownDeviceId,
   requestLocalExecutor: localExecutorMocks.request,
 }))
 vi.mock('@/api/dsh/desktopHost', () => ({
@@ -220,11 +231,7 @@ function mockCodexAppServerInvoke(
     }
   } = {}
 ) {
-  localExecutorMocks.ensureStarted.mockResolvedValue({
-    running: true,
-    ready: true,
-    deviceId: options.deviceId,
-  })
+  mockKnownExecutorDevice(options.deviceId ?? 'current-device')
   const marketplaces = [...(options.marketplaces ?? [])]
   const installedPluginNames = new Set(options.installedPluginNames ?? [])
   const pluginEnabledById = new Map<string, boolean>()
@@ -1325,6 +1332,7 @@ function seedDurableOpenAiGithubPeek(options?: {
   includeGmailInstall?: boolean
   includeGithubConnector?: boolean
 }) {
+  mockKnownExecutorDevice('local-device')
   const githubComponents = options?.includeGithubConnector
     ? { ...emptyPluginComponents, connectors: [githubConnectorComponent()] }
     : emptyPluginComponents
@@ -1507,11 +1515,7 @@ describe('PluginsWorkspace', () => {
     telemetryMocks.track.mockClear()
     desktopHostMock.mockReset()
     localExecutorMocks.ensureStarted.mockReset()
-    localExecutorMocks.ensureStarted.mockResolvedValue({
-      running: true,
-      ready: true,
-      deviceId: 'current-device',
-    })
+    mockKnownExecutorDevice('current-device')
     vi.mocked(requestLocalExecutor).mockReset()
     vi.mocked(requestLocalExecutor).mockImplementation(method => {
       if (method === 'executor.plugins.personal.list') {
@@ -2114,6 +2118,7 @@ describe('PluginsWorkspace', () => {
 
   test('paints OpenAI durable peek even when the account cache only has cloud rows', async () => {
     window.__WEWORK_RUNTIME_CONFIG__ = { desktopHost: 'electron' }
+    mockKnownExecutorDevice('local-device')
     setPluginMarketplaceCache({
       cacheKey: '|anon',
       marketplaceItems: [],
@@ -2258,6 +2263,7 @@ describe('PluginsWorkspace', () => {
 
   test('keeps OpenAI official installed strip from durable peek when plugin/installed omits it', async () => {
     window.__WEWORK_RUNTIME_CONFIG__ = { desktopHost: 'electron' }
+    mockKnownExecutorDevice('local-device')
     setPluginMarketplaceCache({
       cacheKey: '|anon',
       marketplaceItems: [],
@@ -2619,6 +2625,7 @@ describe('PluginsWorkspace', () => {
 
   test('keeps the warm catalog painted while live plugin/installed is still pending', async () => {
     window.__WEWORK_RUNTIME_CONFIG__ = { desktopHost: 'electron' }
+    mockKnownExecutorDevice('local-device')
     setPluginMarketplaceCache({
       cacheKey: '|anon',
       marketplaceItems: [],

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -1572,6 +1572,12 @@ describe('PluginsWorkspace', () => {
     ).toBe(false)
     expect(window.location.pathname).toBe('/')
 
+    await userEvent.click(screen.getByTestId('plugin-operation-notice-dismiss'))
+    expect(screen.queryByTestId('plugin-operation-notice')).not.toBeInTheDocument()
+
+    await userEvent.click(await screen.findByTestId('plugin-marketplace-install-101'))
+    expect(await screen.findByTestId('plugin-operation-notice')).toBeInTheDocument()
+
     await userEvent.click(screen.getByTestId('plugin-operation-notice-action'))
 
     expect(window.location.pathname).toBe('/settings/connections')

--- a/wework/src/components/plugins/PluginsWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.test.tsx
@@ -1565,6 +1565,7 @@ describe('PluginsWorkspace', () => {
     const notice = await screen.findByTestId('plugin-operation-notice')
     expect(notice).toHaveTextContent('当前设备未连接到云端，暂时无法安装插件。请恢复连接后重试。')
     expect(notice).toHaveAttribute('data-notice-kind', 'error')
+    expect(notice).toHaveClass('electron-titlebar-interactive-region')
     expect(
       vi
         .mocked(fetch)

--- a/wework/src/components/plugins/PluginsWorkspace.tsx
+++ b/wework/src/components/plugins/PluginsWorkspace.tsx
@@ -156,6 +156,7 @@ import {
   localMarketplaceIdFromItem,
   localMarketplaceKey,
   marketplaceComponentCount,
+  marketplacePluginDetailSelectionKey,
   mergeWarmInstalledPlugins,
   mergeWarmMarketplaceItems,
   mergeWarmMarketplaceOptions,
@@ -3804,7 +3805,7 @@ export function PluginsWorkspace({
   const installedPluginsForDetailRef = useRef(installedPlugins)
   installedPluginsForDetailRef.current = installedPlugins
   const selectedMarketplaceDetailKey = selectedMarketplacePlugin
-    ? `${localMarketplaceIdFromItem(selectedMarketplacePlugin) ?? ''}::${selectedMarketplacePlugin.name}`
+    ? marketplacePluginDetailSelectionKey(selectedMarketplacePlugin)
     : ''
 
   useEffect(() => {
@@ -3831,16 +3832,12 @@ export function PluginsWorkspace({
     const shouldFetchLocalDetail = Boolean(marketplaceId)
 
     if (!shouldFetchLocalDetail) {
-      setSelectedMarketplacePluginDetail(previous =>
-        keepRicherMarketplacePluginDetail(previous, baseDetail)
-      )
+      setSelectedMarketplacePluginDetail(baseDetail)
       return
     }
 
     let disposed = false
-    setSelectedMarketplacePluginDetail(previous =>
-      keepRicherMarketplacePluginDetail(previous, baseDetail)
-    )
+    setSelectedMarketplacePluginDetail(baseDetail)
     void localPluginApi
       .readMarketplacePluginDetail(marketplaceId!, selected.name)
       .then(detail => {

--- a/wework/src/components/plugins/hooks/usePluginDetailSelection.test.ts
+++ b/wework/src/components/plugins/hooks/usePluginDetailSelection.test.ts
@@ -63,6 +63,37 @@ describe('findMarketplaceItemForPluginReference', () => {
       })
     ).toBeNull()
   })
+
+  test('selects the personal listing when cloud rows share a name and omit marketplaceId', () => {
+    const enterprise = {
+      ...documentsItem(),
+      id: 22,
+      name: 'ip-location',
+      visibility: 'workspace' as const,
+      accessRole: 'catalog' as const,
+      sourceProvider: 'wegent' as const,
+    }
+    const personal = {
+      ...enterprise,
+      id: 21,
+      visibility: 'personal' as const,
+      accessRole: 'owner' as const,
+      sourceProvider: 'user' as const,
+    }
+
+    expect(
+      findMarketplaceItemForPluginReference([enterprise, personal], {
+        pluginName: 'ip-location',
+        marketplaceName: 'wework-personal',
+      })?.id
+    ).toBe(21)
+    expect(
+      findMarketplaceItemForPluginReference([personal, enterprise], {
+        pluginName: 'ip-location',
+        marketplaceName: 'wegent',
+      })?.id
+    ).toBe(22)
+  })
 })
 
 describe('usePluginDetailSelection', () => {

--- a/wework/src/components/plugins/hooks/usePluginDetailSelection.ts
+++ b/wework/src/components/plugins/hooks/usePluginDetailSelection.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from 'react'
+import { isPersonalMarketplaceId } from '@/features/plugins/builtinPlugins'
 import type { PluginReference } from '@/features/plugins/pluginNavigation'
 import { isWegentCloudMarketplace } from '@/features/plugins/pluginNavigation'
 import type { PluginMarketplaceItem } from '@/types/api'
-import { marketplaceItemMarketplaceId } from '../pluginDistribution'
+import { marketplaceItemMarketplaceId, marketplacePluginDistribution } from '../pluginDistribution'
 import type { InstalledPluginItem } from '../PluginManagementRows'
 import { marketplaceItemOwnsLocalCreatedPackage } from '../pluginOwnerLocalPackage'
 import type { PluginMarketplaceState } from '../workspace/marketplaceWorkspaceHelpers'
@@ -16,11 +17,16 @@ export function findMarketplaceItemForPluginReference(
   if (!pluginName || !marketplaceName) return null
 
   const normalizedMarketplaceName = marketplaceName.toLowerCase()
+  const referencesPersonalMarketplace = isPersonalMarketplaceId(normalizedMarketplaceName)
   return (
     items.find(item => {
       if (item.name !== pluginName) return false
       const marketplaceId = marketplaceItemMarketplaceId(item)?.toLowerCase()
-      if (!marketplaceId) return isWegentCloudMarketplace(marketplaceName)
+      if (!marketplaceId) {
+        const personalListing = marketplacePluginDistribution(item) === 'personal'
+        if (referencesPersonalMarketplace) return personalListing
+        return isWegentCloudMarketplace(marketplaceName) && !personalListing
+      }
       return (
         marketplaceId === normalizedMarketplaceName ||
         (isWegentCloudMarketplace(marketplaceId) && isWegentCloudMarketplace(marketplaceName))

--- a/wework/src/components/plugins/workspace/marketplaceWorkspaceHelpers.test.ts
+++ b/wework/src/components/plugins/workspace/marketplaceWorkspaceHelpers.test.ts
@@ -4,6 +4,7 @@ import type { InstalledPlugin, PluginMarketplaceItem } from '@/types/api'
 import type { InstalledPluginItem } from '../PluginManagementRows'
 import {
   keepRicherMarketplacePluginDetail,
+  marketplacePluginDetailSelectionKey,
   pluginDetailActionErrorMessage,
   pluginUsesWegentConnectorOAuth,
   queueMarketplacePluginTrial,
@@ -201,5 +202,31 @@ describe('keepRicherMarketplacePluginDetail', () => {
         description: 'Access repositories, issues, and pull requests.',
       },
     ])
+  })
+})
+
+describe('marketplacePluginDetailSelectionKey', () => {
+  test('separates same-name personal and enterprise cloud listings', () => {
+    const enterprise = githubMarketplaceItem()
+    enterprise.id = 22
+    enterprise.name = 'ip-location'
+    enterprise.version = '0.3.0'
+    enterprise.visibility = 'workspace'
+    enterprise.accessRole = 'catalog'
+    enterprise.sourceProvider = 'wegent'
+    enterprise.manifest = {}
+
+    const personal = {
+      ...enterprise,
+      id: 21,
+      version: '0.1.0',
+      visibility: 'personal' as const,
+      accessRole: 'owner' as const,
+      sourceProvider: 'user' as const,
+    }
+
+    expect(marketplacePluginDetailSelectionKey(enterprise)).not.toBe(
+      marketplacePluginDetailSelectionKey(personal)
+    )
   })
 })

--- a/wework/src/components/plugins/workspace/marketplaceWorkspaceHelpers.ts
+++ b/wework/src/components/plugins/workspace/marketplaceWorkspaceHelpers.ts
@@ -436,6 +436,16 @@ export function localMarketplaceIdFromItem(item: PluginMarketplaceItem): string 
   return marketplaceItemMarketplaceId(item)
 }
 
+export function marketplacePluginDetailSelectionKey(item: PluginMarketplaceItem): string {
+  return [
+    marketplaceItemMarketplaceId(item) ?? 'cloud',
+    String(item.id),
+    item.name,
+    item.version ?? '',
+    item.latestReleaseId == null ? '' : String(item.latestReleaseId),
+  ].join('::')
+}
+
 export function isMarketplaceSourceValid(value: string): boolean {
   const source = value.trim()
   return (

--- a/wework/src/desktop/localExecutor.test.ts
+++ b/wework/src/desktop/localExecutor.test.ts
@@ -13,6 +13,7 @@ import {
   ensureLocalExecutorAvailable,
   ensureLocalExecutorStarted,
   getInitializedBundledPluginMarketplace,
+  getKnownLocalExecutorDeviceId,
   getLocalExecutorStatus,
   readLocalExecutorLog,
   requestLocalExecutor,
@@ -80,6 +81,7 @@ describe('localExecutor', () => {
     expect(describeDshExecutorMock).toHaveBeenCalledOnce()
     expect(requestDshExecutorMock).not.toHaveBeenCalled()
     expect(getInitializedBundledPluginMarketplace()).toBeNull()
+    expect(getKnownLocalExecutorDeviceId()).toBe('electron-device')
   })
 
   test('starts the Electron-managed DSH executor and caches its marketplace', async () => {
@@ -153,15 +155,25 @@ describe('localExecutor', () => {
         return { ready: true, started: true, initializeElapsedMs: 37 }
       }
       if (method === 'executor.plugins.initialize_bundled_marketplace') return marketplace
+      if (method === 'runtime.codex.plugin.reconcile_bundled_marketplace') {
+        return { marketplaceName: marketplace.id, action: 'added' }
+      }
       if (method !== 'codex.app_server_request') return {}
       const request = params as { method?: string }
-      if (request.method === 'marketplace/add') return { marketplaceName: marketplace.id }
       if (request.method === 'config/read') return { config: { plugins: {} } }
       if (request.method === 'plugin/install') return {}
       throw new Error(`Unexpected request: ${request.method}`)
     })
 
     await ensureBundledPluginInstalled('smart-app-builder')
+
+    expect(requestDshExecutorMock).toHaveBeenCalledWith(
+      'runtime.codex.plugin.reconcile_bundled_marketplace',
+      {
+        marketplaceId: marketplace.id,
+        source: marketplace.path,
+      }
+    )
 
     expect(requestDshExecutorMock).toHaveBeenCalledWith('codex.app_server_request', {
       method: 'plugin/install',

--- a/wework/src/desktop/localExecutor.ts
+++ b/wework/src/desktop/localExecutor.ts
@@ -149,45 +149,16 @@ async function reconcileBundledPluginMarketplace(
     marketplace.contentHash,
   ].join(':')
   if (reconciledBundledPluginMarketplaceKey === reconciliationKey) return
-
-  const addMarketplace = () =>
-    requestLocalExecutor<{ marketplaceName: string }>('codex.app_server_request', {
-      method: 'marketplace/add',
-      params: {
-        source: marketplace.path,
-        refName: null,
-        sparsePaths: null,
-      },
-    })
-
-  let added: { marketplaceName: string }
-  try {
-    added = await addMarketplace()
-  } catch (addError) {
-    const available = await requestLocalExecutor<{
-      marketplaces: Array<{ name: string; path?: string | null }>
-    }>('codex.app_server_request', {
-      method: 'plugin/list',
-      params: {
-        cwds: null,
-        marketplaceKinds: ['local'],
-      },
-    })
-    const existing = available.marketplaces.find(candidate => candidate.name === marketplace.id)
-    if (!existing) {
-      throw new Error(`Bundled plugin marketplace ${marketplace.id} could not be registered`, {
-        cause: addError,
-      })
+  const reconciled = await requestLocalExecutor<{ marketplaceName: string; action: string }>(
+    'runtime.codex.plugin.reconcile_bundled_marketplace',
+    {
+      marketplaceId: marketplace.id,
+      source: marketplace.path,
     }
-    await requestLocalExecutor('codex.app_server_request', {
-      method: 'marketplace/remove',
-      params: { marketplaceName: marketplace.id },
-    })
-    added = await addMarketplace()
-  }
-  if (added.marketplaceName !== marketplace.id) {
+  )
+  if (reconciled.marketplaceName !== marketplace.id) {
     throw new Error(
-      `Bundled plugin marketplace resolved to ${added.marketplaceName || 'an unknown name'}`
+      `Bundled plugin marketplace resolved to ${reconciled.marketplaceName || 'an unknown name'}`
     )
   }
   await installBundledMarketplaceDefaults(marketplace)
@@ -240,6 +211,14 @@ export async function ensureBundledPluginInstalled(pluginName: string): Promise<
 
 export function getInitializedBundledPluginMarketplace(): BundledPluginMarketplace | null {
   return initializedBundledPluginMarketplace
+}
+
+export function getKnownLocalExecutorDeviceId(): string | null {
+  return (
+    initializedLocalExecutorStatus?.deviceId?.trim() ||
+    availableLocalExecutorStatus?.deviceId?.trim() ||
+    null
+  )
 }
 
 export function ensureLocalExecutorAvailable(): Promise<LocalExecutorStatus> {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -94,6 +94,7 @@ const localExecutorMocks = vi.hoisted(() => ({
   ensureBundledPluginMarketplaceRegistered: vi.fn().mockResolvedValue(undefined),
   ensureLocalExecutorStarted: vi.fn(),
   getInitializedBundledPluginMarketplace: vi.fn().mockReturnValue(null),
+  getKnownLocalExecutorDeviceId: vi.fn().mockReturnValue('local-device'),
   requestLocalExecutor: vi.fn(),
   subscribeLocalExecutorEvents: vi.fn(),
 }))
@@ -120,6 +121,7 @@ vi.mock('@/desktop/localExecutor', () => ({
     localExecutorMocks.ensureBundledPluginMarketplaceRegistered,
   ensureLocalExecutorStarted: localExecutorMocks.ensureLocalExecutorStarted,
   getInitializedBundledPluginMarketplace: localExecutorMocks.getInitializedBundledPluginMarketplace,
+  getKnownLocalExecutorDeviceId: localExecutorMocks.getKnownLocalExecutorDeviceId,
   requestLocalExecutor: localExecutorMocks.requestLocalExecutor,
   subscribeLocalExecutorEvents: localExecutorMocks.subscribeLocalExecutorEvents,
 }))

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -1416,8 +1416,8 @@ button:disabled {
 
 button.plugin-operation-notice-dismiss {
   display: grid;
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   flex-shrink: 0;
   place-items: center;
   border: 0;


### PR DESCRIPTION
## Summary

- sanitize imported Codex configuration so the Wework-managed marketplace cannot retain a stale installation path
- reconcile the bundled marketplace through one serialized executor RPC, persist the current source atomically, and roll back on registration failure
- scope durable and in-memory plugin snapshots to the active executor device ID
- cover stale-source recovery in the real desktop plugin flow and wait for a blank conversation before subsequent plugin sends

## Root cause

Switching development or packaged environments could migrate a `config.toml` containing an absolute `wework-personal` source from an older build. The current build then attempted to register the same marketplace ID from its own bundled path. Renderer-side add/list/remove/add calls could race, while plugin snapshots were reusable across executor homes, producing contradictory installed/install UI states.

## Verification

- `cargo test local::codex_home::tests --lib` — 13 passed
- `cargo test runtime_work::handler::plugin_marketplace::tests --lib` — 4 passed
- `cargo clippy --lib -- -D warnings`
- focused Wework renderer tests — 436 passed
- Wework TypeScript, ESLint, and Prettier checks
- `pnpm e2e:desktop -- --segment skill-mention-rendering` — passed
- `pnpm e2e:desktop:plugins` — passed in 4m 24s with zero assertion errors
- repository pre-push quality checks — passed

## Documentation

No user-facing documentation change is required. Existing affected environments are repaired automatically when the fixed desktop build starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bundled plugin marketplaces reconcile configured sources while preserving user-installed plugins during updates.
  - Plugin details remain distinct when personal and enterprise listings share the same name.

- **Bug Fixes**
  - Local executor plugin state is no longer reused across devices or executor homes.
  - Marketplace registration and recovery handle stale or changed local sources more reliably.
  - Failed marketplace recovery no longer leaves installations unavailable.
  - Plugin operation notices are easier to dismiss with a larger close button.
  - Local development startup now selects physical network interfaces instead of virtual VPN or container interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->