### PR TITLE
fix(export): use tokenized download URL so Safari keeps .docx filename

### DIFF
--- a/backend/app/api/endpoints/adapter/tasks.py
+++ b/backend/app/api/endpoints/adapter/tasks.py
@@ -9,6 +9,7 @@ import logging
 import re
 from datetime import datetime
 from typing import Annotated, Literal, Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
@@ -873,7 +874,7 @@ async def export_task_docx(
             raise HTTPException(status_code=401, detail="Invalid download token")
         current_user = (
             db.query(User)
-            .filter(User.id == token_info.user_id, User.is_active == True)
+            .filter(User.id == token_info.user_id, User.is_active.is_(True))
             .first()
         )
         if current_user is None:
@@ -952,7 +953,7 @@ async def create_task_docx_export_download_url(
     ),
     db: Session = Depends(get_db),
     current_user: User = Depends(security.get_current_user),
-):
+) -> dict:
     """
     Create a short-lived DOCX export download URL for browser-native downloads.
 
@@ -988,9 +989,9 @@ async def create_task_docx_export_download_url(
         expires_delta_minutes=5,
     )
 
-    url = f"/api/tasks/{task_id}/export/docx?download_token={token}"
+    url = f"/api/tasks/{task_id}/export/docx?download_token={quote(token, safe='')}"
     if message_ids:
-        url += f"&message_ids={message_ids}"
+        url += f"&message_ids={quote(message_ids, safe='')}"
 
     return {"download_url": url, "expires_in": 300}
 

--- a/backend/app/api/endpoints/adapter/tasks.py
+++ b/backend/app/api/endpoints/adapter/tasks.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import io
 import json
 import logging
@@ -839,8 +840,16 @@ async def export_task_docx(
         None,
         description="Comma-separated list of message IDs to export. If not provided, exports all messages.",
     ),
+    download_token: Optional[str] = Query(
+        None,
+        description=(
+            "Short-lived token issued by the export DOCX download URL endpoint. "
+            "Lets browsers download with the server-provided filename "
+            "without sending an Authorization header."
+        ),
+    ),
     db: Session = Depends(get_db),
-    current_user: User = Depends(security.get_current_user),
+    current_user: Optional[User] = Depends(security.get_current_user_optional),
 ):
     """
     Export task conversation history to DOCX format.
@@ -851,7 +860,26 @@ async def export_task_docx(
     - Formatted markdown content
     - Embedded images and attachment info
     """
+    from app.services.auth.docx_export_download_token import (
+        verify_docx_export_download_token,
+    )
     from app.services.task_member_service import task_member_service
+
+    if download_token:
+        token_info = verify_docx_export_download_token(
+            download_token, task_id=task_id, message_ids=message_ids
+        )
+        if token_info is None:
+            raise HTTPException(status_code=401, detail="Invalid download token")
+        current_user = (
+            db.query(User)
+            .filter(User.id == token_info.user_id, User.is_active == True)
+            .first()
+        )
+        if current_user is None:
+            raise HTTPException(status_code=401, detail="Invalid download token")
+    elif current_user is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
 
     # Check if user has access to the task (owner or group chat member)
     if not task_member_service.is_member(db, task_id, current_user.id):
@@ -910,6 +938,61 @@ async def export_task_docx(
     except Exception as e:
         logger.error(f"Failed to export task {task_id} to DOCX: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to generate DOCX document")
+
+
+@router.post(
+    "/{task_id}/export/docx/download-url",
+    summary="Create a DOCX export download URL",
+)
+async def create_task_docx_export_download_url(
+    task_id: int,
+    message_ids: Optional[str] = Query(
+        None,
+        description="Comma-separated list of message IDs to export. If not provided, exports all messages.",
+    ),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Create a short-lived DOCX export download URL for browser-native downloads.
+
+    Blob downloads with client-side filenames are unreliable in Safari and
+    in-app browsers, which may ignore the ``download`` attribute and name the
+    file after the page origin. The returned URL carries a short-lived token so
+    the browser can navigate directly to the export endpoint and apply the
+    server-provided ``Content-Disposition`` filename.
+    """
+    from app.services.auth.docx_export_download_token import (
+        create_docx_export_download_token,
+    )
+    from app.services.task_member_service import task_member_service
+
+    if not task_member_service.is_member(db, task_id, current_user.id):
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    from app.models.task import TaskResource
+
+    task = task_store.get_task_by_states(
+        db,
+        task_id=task_id,
+        states=TaskResource.is_active_query(),
+    )
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    token = create_docx_export_download_token(
+        task_id=task_id,
+        user_id=current_user.id,
+        user_name=current_user.user_name,
+        message_ids=message_ids,
+        expires_delta_minutes=5,
+    )
+
+    url = f"/api/tasks/{task_id}/export/docx?download_token={token}"
+    if message_ids:
+        url += f"&message_ids={message_ids}"
+
+    return {"download_url": url, "expires_in": 300}
 
 
 @router.get("/{task_id}/services", response_model=ServiceResponse)

--- a/backend/app/services/auth/__init__.py
+++ b/backend/app/services/auth/__init__.py
@@ -4,6 +4,11 @@
 
 """Authentication services."""
 
+from app.services.auth.docx_export_download_token import (
+    DocxExportDownloadTokenInfo,
+    create_docx_export_download_token,
+    verify_docx_export_download_token,
+)
 from app.services.auth.internal_service_token import (
     verify_internal_service_token,
 )
@@ -27,6 +32,9 @@ from app.services.auth.task_token import (
 )
 
 __all__ = [
+    "DocxExportDownloadTokenInfo",
+    "create_docx_export_download_token",
+    "verify_docx_export_download_token",
     "verify_internal_service_token",
     "TaskTokenData",
     "TaskTokenInfo",

--- a/backend/app/services/auth/docx_export_download_token.py
+++ b/backend/app/services/auth/docx_export_download_token.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Short-lived tokens for DOCX export downloads in browsers.
+
+Browsers such as Safari and in-app webviews may ignore client-side blob
+downloads, so the frontend navigates to the export URL with a tokenized query
+parameter instead. These tokens are bound to a single task, user, and message
+filter, and are only valid for a short period.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import jwt
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+DOCX_EXPORT_TOKEN_TYPE = "docx_export_download_token"
+
+
+@dataclass
+class DocxExportDownloadTokenInfo:
+    """Decoded token data for a DOCX export download."""
+
+    task_id: int
+    user_id: int
+    user_name: str
+    message_ids_hash: Optional[str]
+    expire_at: Optional[int] = None
+
+
+def _normalize_message_ids(message_ids: Optional[str]) -> str:
+    """Normalize the message_ids query parameter into a stable digest input."""
+    if message_ids is None:
+        return ""
+    ids = [part.strip() for part in message_ids.split(",") if part.strip()]
+    return ",".join(ids)
+
+
+def message_ids_hash(message_ids: Optional[str]) -> Optional[str]:
+    """Return a stable SHA-256 hash of the message_ids filter, or None."""
+    normalized = _normalize_message_ids(message_ids)
+    if not normalized:
+        return None
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def create_docx_export_download_token(
+    *,
+    task_id: int,
+    user_id: int,
+    user_name: str,
+    message_ids: Optional[str] = None,
+    expires_delta_minutes: int = 5,
+) -> str:
+    """Create a short-lived token bound to a specific DOCX export request."""
+    expire = datetime.now(timezone.utc) + timedelta(minutes=expires_delta_minutes)
+    payload = {
+        "type": DOCX_EXPORT_TOKEN_TYPE,
+        "task_id": task_id,
+        "user_id": user_id,
+        "user_name": user_name,
+        "message_ids_hash": message_ids_hash(message_ids),
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def verify_docx_export_download_token(
+    token: str,
+    *,
+    task_id: int,
+    message_ids: Optional[str] = None,
+) -> Optional[DocxExportDownloadTokenInfo]:
+    """Verify a DOCX export download token for the given task and filter."""
+    try:
+        payload = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+        )
+    except jwt.ExpiredSignatureError:
+        logger.warning("DOCX export download token has expired")
+        return None
+    except jwt.InvalidTokenError as exc:
+        logger.warning("Invalid DOCX export download token: %s", exc)
+        return None
+
+    if payload.get("type") != DOCX_EXPORT_TOKEN_TYPE:
+        logger.warning("Invalid DOCX export token type")
+        return None
+
+    if payload.get("task_id") != task_id:
+        logger.warning("DOCX export token task mismatch")
+        return None
+
+    expected_hash = message_ids_hash(message_ids)
+    if payload.get("message_ids_hash") != expected_hash:
+        logger.warning("DOCX export token message_ids mismatch")
+        return None
+
+    user_id = payload.get("user_id")
+    user_name = payload.get("user_name")
+    if not isinstance(user_id, int) or not isinstance(user_name, str):
+        logger.warning("DOCX export token missing user info")
+        return None
+
+    return DocxExportDownloadTokenInfo(
+        task_id=task_id,
+        user_id=user_id,
+        user_name=user_name,
+        message_ids_hash=expected_hash,
+        expire_at=payload.get("exp"),
+    )

--- a/backend/tests/api/endpoints/adapter/test_task_export_docx.py
+++ b/backend/tests/api/endpoints/adapter/test_task_export_docx.py
@@ -56,6 +56,7 @@ async def _call_export_docx(monkeypatch, title: str) -> StreamingResponse:
     return await tasks.export_task_docx(
         task_id=42,
         message_ids=None,
+        download_token=None,
         db=Mock(),
         current_user=SimpleNamespace(id=1),
     )

--- a/backend/tests/api/endpoints/adapter/test_task_export_docx_download_token.py
+++ b/backend/tests/api/endpoints/adapter/test_task_export_docx_download_token.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+from types import SimpleNamespace
+from unittest.mock import Mock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from app.services.auth.docx_export_download_token import (
+    create_docx_export_download_token,
+    verify_docx_export_download_token,
+)
+
+
+def _fake_task() -> SimpleNamespace:
+    """Build a minimal active task with an ASCII display title."""
+    return SimpleNamespace(
+        id=42,
+        json={"metadata": {"name": "Task-42"}, "spec": {}},
+    )
+
+
+def _patch_task_access(monkeypatch, task=None) -> Mock:
+    from app.api.endpoints.adapter import tasks
+
+    is_member = Mock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.task_member_service.task_member_service.is_member",
+        is_member,
+    )
+    get_task = Mock(return_value=task if task is not None else _fake_task())
+    monkeypatch.setattr(tasks.task_store, "get_task_by_states", get_task)
+    return is_member
+
+
+def _chain_query_user(user_id: int = 1) -> Mock:
+    """Build a db whose query chain resolves to the token user."""
+
+    class _FakeQuery:
+        def filter(self, *args, **kwargs):
+            return self
+
+        def first(self):
+            return SimpleNamespace(id=user_id, user_name="tester")
+
+    db = Mock()
+    db.query.return_value = _FakeQuery()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_create_download_url_rejects_non_member(monkeypatch) -> None:
+    from app.api.endpoints.adapter import tasks
+
+    _patch_task_access(monkeypatch)
+    from app.services.task_member_service import task_member_service
+
+    task_member_service.is_member = Mock(return_value=False)
+
+    with pytest.raises(Exception) as exc_info:
+        await tasks.create_task_docx_export_download_url(
+            task_id=42,
+            message_ids=None,
+            db=Mock(),
+            current_user=SimpleNamespace(id=1, user_name="tester"),
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_download_url_returns_tokenized_url(monkeypatch) -> None:
+    from app.api.endpoints.adapter import tasks
+
+    _patch_task_access(monkeypatch)
+
+    result = await tasks.create_task_docx_export_download_url(
+        task_id=42,
+        message_ids="3,5,8",
+        db=Mock(),
+        current_user=SimpleNamespace(id=7, user_name="tester"),
+    )
+
+    assert result["expires_in"] == 300
+    url = result["download_url"]
+    parsed = urlparse(url)
+    assert parsed.path == "/api/tasks/42/export/docx"
+    query = parse_qs(parsed.query)
+    token = query["download_token"][0]
+    assert query["message_ids"] == ["3,5,8"]
+    token_info = verify_docx_export_download_token(
+        token, task_id=42, message_ids="3,5,8"
+    )
+    assert token_info is not None
+    assert token_info.task_id == 42
+    assert token_info.user_id == 7
+
+
+@pytest.mark.asyncio
+async def test_export_docx_with_download_token_streams_file(monkeypatch) -> None:
+    from app.api.endpoints.adapter import tasks
+
+    _patch_task_access(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.export.docx_generator.generate_task_docx",
+        Mock(return_value=io.BytesIO(b"fake-docx")),
+    )
+    token = create_docx_export_download_token(
+        task_id=42,
+        user_id=1,
+        user_name="tester",
+        expires_delta_minutes=5,
+    )
+
+    response = await tasks.export_task_docx(
+        task_id=42,
+        message_ids=None,
+        download_token=token,
+        db=_chain_query_user(),
+        current_user=None,
+    )
+
+    assert response.status_code == 200
+    disposition = response.headers["content-disposition"]
+    disposition.encode("latin-1")
+    assert disposition.endswith('.docx"')
+
+
+@pytest.mark.asyncio
+async def test_export_docx_rejects_token_for_other_task(monkeypatch) -> None:
+    from app.api.endpoints.adapter import tasks
+
+    _patch_task_access(monkeypatch)
+    token = create_docx_export_download_token(
+        task_id=99,
+        user_id=1,
+        user_name="tester",
+        expires_delta_minutes=5,
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await tasks.export_task_docx(
+            task_id=42,
+            message_ids=None,
+            download_token=token,
+            db=Mock(),
+            current_user=None,
+        )
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_export_docx_rejects_token_for_other_message_filter(
+    monkeypatch,
+) -> None:
+    from app.api.endpoints.adapter import tasks
+
+    _patch_task_access(monkeypatch)
+    token = create_docx_export_download_token(
+        task_id=42,
+        user_id=1,
+        user_name="tester",
+        message_ids="1,2",
+        expires_delta_minutes=5,
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await tasks.export_task_docx(
+            task_id=42,
+            message_ids="3,4",
+            download_token=token,
+            db=Mock(),
+            current_user=None,
+        )
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_export_docx_requires_auth_without_download_token(monkeypatch) -> None:
+    from app.api.endpoints.adapter import tasks
+
+    _patch_task_access(monkeypatch)
+
+    with pytest.raises(Exception) as exc_info:
+        await tasks.export_task_docx(
+            task_id=42,
+            message_ids=None,
+            download_token=None,
+            db=Mock(),
+            current_user=None,
+        )
+    assert exc_info.value.status_code == 401

--- a/backend/tests/api/endpoints/adapter/test_task_export_docx_download_token.py
+++ b/backend/tests/api/endpoints/adapter/test_task_export_docx_download_token.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io
+import time
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import Mock
 from urllib.parse import parse_qs, urlparse
 
@@ -23,7 +25,9 @@ def _fake_task() -> SimpleNamespace:
     )
 
 
-def _patch_task_access(monkeypatch, task=None) -> Mock:
+def _patch_task_access(
+    monkeypatch: pytest.MonkeyPatch, task: Optional[SimpleNamespace] = None
+) -> Mock:
     from app.api.endpoints.adapter import tasks
 
     is_member = Mock(return_value=True)
@@ -52,7 +56,9 @@ def _chain_query_user(user_id: int = 1) -> Mock:
 
 
 @pytest.mark.asyncio
-async def test_create_download_url_rejects_non_member(monkeypatch) -> None:
+async def test_create_download_url_rejects_non_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.api.endpoints.adapter import tasks
 
     _patch_task_access(monkeypatch)
@@ -71,7 +77,9 @@ async def test_create_download_url_rejects_non_member(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_download_url_returns_tokenized_url(monkeypatch) -> None:
+async def test_create_download_url_returns_tokenized_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.api.endpoints.adapter import tasks
 
     _patch_task_access(monkeypatch)
@@ -96,10 +104,15 @@ async def test_create_download_url_returns_tokenized_url(monkeypatch) -> None:
     assert token_info is not None
     assert token_info.task_id == 42
     assert token_info.user_id == 7
+    assert token_info.expire_at is not None
+    # Token must expire within the advertised window, allowing clock drift.
+    assert 240 < token_info.expire_at - int(time.time()) <= 300
 
 
 @pytest.mark.asyncio
-async def test_export_docx_with_download_token_streams_file(monkeypatch) -> None:
+async def test_export_docx_with_download_token_streams_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.api.endpoints.adapter import tasks
 
     _patch_task_access(monkeypatch)
@@ -129,7 +142,9 @@ async def test_export_docx_with_download_token_streams_file(monkeypatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_export_docx_rejects_token_for_other_task(monkeypatch) -> None:
+async def test_export_docx_rejects_token_for_other_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.api.endpoints.adapter import tasks
 
     _patch_task_access(monkeypatch)
@@ -153,7 +168,7 @@ async def test_export_docx_rejects_token_for_other_task(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_export_docx_rejects_token_for_other_message_filter(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from app.api.endpoints.adapter import tasks
 
@@ -178,7 +193,9 @@ async def test_export_docx_rejects_token_for_other_message_filter(
 
 
 @pytest.mark.asyncio
-async def test_export_docx_requires_auth_without_download_token(monkeypatch) -> None:
+async def test_export_docx_requires_auth_without_download_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.api.endpoints.adapter import tasks
 
     _patch_task_access(monkeypatch)

--- a/frontend/src/apis/tasks.ts
+++ b/frontend/src/apis/tasks.ts
@@ -402,41 +402,26 @@ export const taskApis = {
   },
 
   /**
-   * Export task to DOCX format
+   * Create a DOCX export download URL that works with browser-native downloads.
+   *
+   * Returns a URL carrying a short-lived token. Browsers such as Safari ignore
+   * blob downloads with client-side filenames, so the caller should navigate to
+   * this URL directly and let the server Content-Disposition name the file.
    * @param taskId - Task ID to export
    * @param messageIds - Optional array of message IDs to filter export (if not provided, exports all messages)
    */
-  exportTaskDocx: async (taskId: number, messageIds?: number[]): Promise<Blob> => {
-    const token = getToken()
-    const url = new URL(`/api/tasks/${taskId}/export/docx`, window.location.origin)
-
-    // Add message_ids as query parameter if provided
+  getTaskDocxExportUrl: async (taskId: number, messageIds?: number[]): Promise<string> => {
+    const params = new URLSearchParams()
     if (messageIds && messageIds.length > 0) {
-      url.searchParams.set('message_ids', messageIds.join(','))
+      params.set('message_ids', messageIds.join(','))
     }
 
-    const response = await fetch(url.toString(), {
-      method: 'GET',
-      headers: {
-        ...(token && { Authorization: `Bearer ${token}` }),
-      },
-    })
+    const { download_url: downloadUrl } = await apiClient.post<{
+      download_url: string
+      expires_in: number
+    }>(`/tasks/${taskId}/export/docx/download-url${params.size > 0 ? `?${params.toString()}` : ''}`)
 
-    if (!response.ok) {
-      const errorText = await response.text()
-      let errorMsg = errorText
-      try {
-        const json = JSON.parse(errorText)
-        if (json && typeof json.detail === 'string') {
-          errorMsg = json.detail
-        }
-      } catch {
-        // Not JSON, use original text
-      }
-      throw new Error(errorMsg)
-    }
-
-    return response.blob()
+    return new URL(downloadUrl, window.location.origin).toString()
   },
 
   /**

--- a/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
+++ b/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
@@ -263,10 +263,14 @@ export default function ExportSelectModal({
 
     const url = await taskApis.getTaskDocxExportUrl(taskId, messageIds)
 
-    // Navigate to the real download URL so the browser (including Safari, which
+    // Download through a hidden iframe so the browser (including Safari, which
     // ignores client-side blob download filenames) applies the server-provided
-    // Content-Disposition filename.
-    window.location.assign(url)
+    // Content-Disposition filename without navigating the current page away.
+    const iframe = document.createElement('iframe')
+    iframe.style.display = 'none'
+    iframe.src = url
+    document.body.appendChild(iframe)
+    setTimeout(() => iframe.remove(), 60_000)
   }
 
   /**

--- a/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
+++ b/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
@@ -270,7 +270,9 @@ export default function ExportSelectModal({
     iframe.style.display = 'none'
     iframe.src = url
     document.body.appendChild(iframe)
-    setTimeout(() => iframe.remove(), 60_000)
+    // Keep the iframe alive beyond the download token lifetime (5 minutes) so
+    // slow DOCX generation cannot be aborted by removing the download target.
+    setTimeout(() => iframe.remove(), 330_000)
   }
 
   /**

--- a/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
+++ b/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
@@ -261,17 +261,12 @@ export default function ExportSelectModal({
       .map(msg => msg.messageId)
       .filter((id): id is number => typeof id === 'number')
 
-    const blob = await taskApis.exportTaskDocx(taskId, messageIds)
+    const url = await taskApis.getTaskDocxExportUrl(taskId, messageIds)
 
-    // Trigger download
-    const url = window.URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.download = `${taskName || 'Chat_Export'}_${new Date().toISOString().split('T')[0]}.docx`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    window.URL.revokeObjectURL(url)
+    // Navigate to the real download URL so the browser (including Safari, which
+    // ignores client-side blob download filenames) applies the server-provided
+    // Content-Disposition filename.
+    window.location.assign(url)
   }
 
   /**


### PR DESCRIPTION
## Background

User report: after clicking "Export DOCX" in the web UI, the downloaded file has **no `.docx` extension** (the filename looks like the site origin instead) and cannot be opened by double-clicking. PDF export works fine. The downloaded file itself was verified to be a valid OOXML document.

## Root cause

The frontend exports DOCX via `fetch` → blob → `<a download>` click. Our flow clicks the anchor **after** `await fetch` + `setTimeout`, i.e. asynchronously, outside the original user gesture. Whether Safari honors the `download` attribute for such programmatic blob downloads depends on transient-activation heuristics, which vary across Safari releases and response latency:

- Observed broken on **Safari 18.6**: the blob download falls back to a file named after the page origin with no extension.
- Observed working on **Safari 17.6** with the same code.
- Chrome/Edge are unaffected.

So this is not a simple version boundary, and the same browser can flip behavior with export latency — the reliable fix is to stop relying on `a[download]` for blob URLs entirely.

## Solution

Switch to a real download URL so the browser applies the server-provided `Content-Disposition` filename (the most native download path, unaffected by user-gesture rules on any Safari version, and also works in in-app webviews):

- New backend endpoint `POST /api/tasks/{task_id}/export/docx/download-url`: requires login + task membership, returns `{download_url, expires_in: 300}` carrying a short-lived token.
- Export endpoint `GET /api/tasks/{task_id}/export/docx` accepts `?download_token=` for header-less authentication.
- Frontend `ExportSelectModal` fetches the download URL first, then downloads through a hidden iframe (kept alive beyond the token lifetime), so an error response never replaces the SPA page.

The token is export-specific (`docx_export_download_token`), bound to `task_id + user_id + message_ids` (SHA-256), valid for 5 minutes, and reusable within the window to survive flaky networks and download retries.

## Changed files

- `backend/app/api/endpoints/adapter/tasks.py`: export endpoint accepts download_token; new download-url endpoint
- `backend/app/services/auth/docx_export_download_token.py`: export-specific short-lived token issue/verify
- `backend/app/services/auth/__init__.py`: expose the token helpers
- `frontend/src/apis/tasks.ts`: `exportTaskDocx` (Blob) → `getTaskDocxExportUrl` (POST for download_url)
- `frontend/src/features/tasks/components/share/ExportSelectModal.tsx`: download via hidden iframe
- `backend/tests/api/endpoints/adapter/test_task_export_docx_download_token.py`: regression coverage

## Tests

6 new cases: non-member rejection, download URL carries a bound token, export with token returns 200 with a `.docx` filename, task mismatch → 401, message_ids mismatch → 401, unauthenticated without token → 401. All 8 export-related tests pass. Frontend ESLint / TypeScript / unit tests and backend black / isort / syntax checks all pass.

Note: this branch is based on merged #3273 (RFC 5987 filename encoding), so Chinese task titles export with correct filenames as well.
