### PR TITLE
fix(wework): handle closed main process output pipes

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -203,6 +203,15 @@ The guard handles only `EPIPE`; other stream errors still fail and expose their
 root cause. A configured external Node executable keeps native Node error
 handling and does not load this Electron-specific guard.
 
+The Electron main process may also be launched through pipes by a terminal,
+development script, or automation runner and remain resident after that parent
+exits. Before loading other Electron modules, the main process must install the
+same strict `EPIPE` guard on its own `stdout` and `stderr`, preventing later
+Node warnings or diagnostic logs from becoming uncaught-exception dialogs
+after the consumer closes. This path must neither exit the main process nor
+ignore errors other than `EPIPE`; the desktop window and local runtime do not
+share the log consumer's lifecycle.
+
 ## Bundled sidecars and resources
 
 Prepare Codex and DWS before packaging:

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -157,6 +157,12 @@ Electron，并设置 `ELECTRON_RUN_AS_NODE=1`。因此 Core DSH 以及 Codex ski
 其他标准流错误仍保持失败并暴露根因。自定义 Node 可执行文件使用原生 Node
 错误处理，不加载这段 Electron 专用逻辑。
 
+Electron 主进程也可能由终端、开发脚本或自动化 runner 通过管道启动，并在这些
+父进程结束后继续驻留。主进程必须在加载其他 Electron 模块前为自身的 `stdout`
+和 `stderr` 安装同样严格的 `EPIPE` 保护，避免后续 Node warning 或诊断日志因
+接收端已经关闭而触发未捕获异常弹窗。这里不能退出主进程，也不能吞掉 `EPIPE`
+以外的错误；桌面窗口和本地运行时的生命周期不属于日志消费者。
+
 ## Bundled sidecars 与资源
 
 构建前必须准备 Codex 和 DWS：

--- a/wework/electron/src/host/process-output-bootstrap.ts
+++ b/wework/electron/src/host/process-output-bootstrap.ts
@@ -1,0 +1,3 @@
+import { installProcessOutputErrorHandlers } from './process-output.js'
+
+installProcessOutputErrorHandlers()

--- a/wework/electron/src/host/process-output.test.ts
+++ b/wework/electron/src/host/process-output.test.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, test } from 'vitest'
+
+import { installProcessOutputErrorHandlers } from './process-output.js'
+
+describe('installProcessOutputErrorHandlers', () => {
+  test('ignores broken stdout and stderr pipes', () => {
+    const stdout = new EventEmitter()
+    const stderr = new EventEmitter()
+    installProcessOutputErrorHandlers(stdout, stderr)
+    const brokenPipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+
+    expect(() => stdout.emit('error', brokenPipe)).not.toThrow()
+    expect(() => stderr.emit('error', brokenPipe)).not.toThrow()
+  })
+
+  test('preserves unexpected output stream errors', () => {
+    const stdout = new EventEmitter()
+    const stderr = new EventEmitter()
+    installProcessOutputErrorHandlers(stdout, stderr)
+    const failure = Object.assign(new Error('stream failed'), { code: 'EIO' })
+
+    expect(() => stdout.emit('error', failure)).toThrow(failure)
+    expect(() => stderr.emit('error', failure)).toThrow(failure)
+  })
+})

--- a/wework/electron/src/host/process-output.ts
+++ b/wework/electron/src/host/process-output.ts
@@ -1,0 +1,16 @@
+import type { EventEmitter } from 'node:events'
+
+type ErrorEventSource = Pick<EventEmitter, 'on'>
+
+export function installProcessOutputErrorHandlers(
+  stdout: ErrorEventSource = process.stdout,
+  stderr: ErrorEventSource = process.stderr
+): void {
+  stdout.on('error', preserveOutputStreamErrors)
+  stderr.on('error', preserveOutputStreamErrors)
+}
+
+function preserveOutputStreamErrors(error: unknown): void {
+  if ((error as NodeJS.ErrnoException | undefined)?.code === 'EPIPE') return
+  throw error
+}

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -1,3 +1,5 @@
+import './host/process-output-bootstrap.js'
+
 import {
   app,
   BrowserWindow,


### PR DESCRIPTION
## Summary

- install an early Electron main-process stdout/stderr error guard
- ignore only `EPIPE` after a terminal, development launcher, or automation runner closes its output pipes
- preserve failures for every other stream error and document the lifecycle invariant in Chinese and English

## Root cause

A long-lived Electron main process can outlive the parent process consuming its stdout/stderr pipes. A later Node warning or console diagnostic then writes to a closed socket, emits an unhandled `EPIPE`, and surfaces Electron’s main-process JavaScript error dialog.

## Verification

- `pnpm --dir wework/electron test src/host/process-output.test.ts`
- `pnpm --dir wework/electron typecheck`
- `pnpm --dir wework/electron build`
- compiled bootstrap survived a closed stderr pipe followed by `process.emitWarning`
- isolated real Electron session started successfully with `pnpm --filter wework ai:verify start` and rendered the workbench
- pre-push Wework static checks, Electron typecheck, unit tests, and ESLint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Electron app stability when launched through terminal pipes, development scripts, or automation tools.
  - The desktop app and local runtime now remain active when log consumers disconnect unexpectedly.
  - Unexpected output-stream errors continue to be reported instead of being silently ignored.

- **Documentation**
  - Added English and Chinese guidance for configuring reliable Electron process output handling during macOS releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->