### PR TITLE
fix(wework): build macOS x64 releases natively

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -185,28 +185,24 @@ jobs:
             runner: macos-14
             platform: macos
             arch: arm64
-            node_arch: arm64
             cargo_target: aarch64-apple-darwin
             codex_target: aarch64-apple-darwin
           - name: macOS x64
-            runner: macos-14
+            runner: macos-15-intel
             platform: macos
             arch: x64
-            node_arch: x64
             cargo_target: x86_64-apple-darwin
             codex_target: x86_64-apple-darwin
           - name: Windows x64
             runner: windows-latest
             platform: windows
             arch: x64
-            node_arch: x64
             cargo_target: x86_64-pc-windows-msvc
             codex_target: x86_64-pc-windows-msvc
           - name: Linux x64
             runner: ubuntu-latest
             platform: linux
             arch: x64
-            node_arch: x64
             cargo_target: x86_64-unknown-linux-gnu
             codex_target: x86_64-unknown-linux-gnu
 
@@ -215,10 +211,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare-release.outputs.release_sha }}
-
-      - name: Install Rosetta 2
-        if: matrix.platform == 'macos' && matrix.arch == 'x64'
-        run: sudo softwareupdate --install-rosetta --agree-to-license || true
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -232,7 +224,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
-          architecture: ${{ matrix.node_arch }}
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -318,6 +318,9 @@ describe('bundled plugin resources', () => {
     )
 
     expect(workflow).toContain('macos-14')
+    expect(workflow).toContain('macos-15-intel')
+    expect(workflow).not.toContain('Install Rosetta 2')
+    expect(workflow).not.toContain('node_arch')
     expect(workflow).toContain('windows-latest')
     expect(workflow).toContain('ubuntu-latest')
     expect(workflow).toContain('macOS arm64')


### PR DESCRIPTION
## Summary

- run the macOS x64 release build on the native `macos-15-intel` GitHub-hosted runner
- remove the Rosetta installation step and redundant per-matrix Node architecture override
- assert the native Intel runner configuration in the existing release workflow test

## Root cause

The failed `Build macOS x64` job ran an x64 Node.js 24.20.0 process through Rosetta on an arm64 `macos-14` runner. During concurrent package asset preparation, Node aborted with `async hook stack has become corrupted` from a worker thread. This was a Node runtime crash rather than an application compile or signing failure. Using GitHub's native Intel runner removes the emulation layer from the x64 release path.

## Verification

- `pnpm --filter wework test src/test/bundled-plugin-resources.test.ts`
- `pnpm --filter wework exec prettier --check ../.github/workflows/wework-app.yml src/test/bundled-plugin-resources.test.ts`
- `git diff --check`
- `actionlint .github/workflows/wework-app.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release**
  * Updated macOS x64 builds to use the macOS 15 Intel runner.
  * Simplified macOS build setup by removing Rosetta 2 installation and explicit Node.js architecture configuration.
* **Tests**
  * Updated release workflow validation to reflect the revised macOS build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->