### PR TITLE
fix(wework): hash signed components in update e2e

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -90,6 +90,11 @@ application itself continues to update through `electron-updater`; the other
 seven components use independent
 `components-<channel>-<platform>-<arch>.json` manifests.
 
+The content SHA-256 values in a published component manifest must be computed
+from the final application resources after Electron Builder finishes signing.
+macOS code signing can rewrite nested executables, so publication must not
+reuse the pre-package content hashes from `components.json`.
+
 Component archives are named by their archive SHA-256 and stored as immutable
 assets. Repository-built Wework core plugin/UI, application static asset,
 bundled plugin, and Executor archives live in their corresponding version

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -79,6 +79,10 @@ SHA-512 校验。
 SHA-256。Electron 应用本身仍通过 `electron-updater` 升级；其余七个组件使用
 `components-<channel>-<platform>-<arch>.json` 独立升级。
 
+发布组件清单中的内容 SHA-256 必须从 Electron Builder 完成签名后的最终应用资源
+计算。macOS 代码签名可能重写嵌套可执行文件，因此不得直接复用打包前
+`components.json` 中的内容哈希。
+
 组件压缩包以压缩包 SHA-256 命名并作为不可变资产保存。本项目源码构建的 Wework
 核心插件及 UI、应用静态资源、内置插件和 Executor 压缩包存放在对应的版本
 Release；外部 Core DSH、Codex 和 DWS 压缩包集中存放在 `wework-updater`，供

--- a/wework/e2e/desktop/scenarios/app-update-differential.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/app-update-differential.scenario.mjs
@@ -5,6 +5,8 @@ import { createRequire } from 'node:module'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { hashComponentPath } from '../../../scripts/lib/component-content-hash.mjs'
+
 const TEST_TRAILER = Buffer.from('\nwework-e2e-differential-update\n')
 const UPDATE_CHANNEL = 'stable'
 const electronPackage = resolve(
@@ -68,6 +70,7 @@ export async function createDesktopScenario({
 
   let origin = ''
   let rejectManifest = true
+  let targetComponentManifest
   const requests = []
   const server = createServer((request, response) => {
     const url = new URL(request.url ?? '/', origin)
@@ -101,9 +104,7 @@ export async function createDesktopScenario({
     }
     if (path === `/components-${UPDATE_CHANNEL}-macos-arm64.json`) {
       response.setHeader('content-type', 'application/json')
-      response.end(
-        JSON.stringify(componentManifestForTarget(packagedComponents, targetVersion, origin))
-      )
+      response.end(JSON.stringify(targetComponentManifest))
       return
     }
     if (path === `/${targetZipName}.blockmap`) {
@@ -146,6 +147,12 @@ export async function createDesktopScenario({
   const address = server.address()
   assert.ok(address && typeof address !== 'string')
   origin = `http://127.0.0.1:${address.port}`
+  targetComponentManifest = await componentManifestForTarget(
+    packagedComponents,
+    resourcesRoot,
+    targetVersion,
+    origin
+  )
 
   return {
     usesReleasePackageRuntimeAssets: true,
@@ -217,6 +224,11 @@ export async function createDesktopScenario({
         componentManifestRequestIndex < firstZipRequestIndex,
         'The target app component manifest was not staged before the ZIP download'
       )
+      assert.equal(
+        requests.some(request => request.path.startsWith('/unused-')),
+        false,
+        'The updater downloaded an unchanged packaged component'
+      )
       const zipRequests = requests.filter(request => request.path === `/${targetZipName}`)
       assert.ok(
         zipRequests.some(request => request.range),
@@ -258,28 +270,32 @@ export async function createDesktopScenario({
   }
 }
 
-function componentManifestForTarget(packaged, targetVersion, origin) {
+async function componentManifestForTarget(packaged, resourcesRoot, targetVersion, origin) {
+  const components = await Promise.all(
+    Object.entries(packaged.components)
+      .filter(([id]) => id !== 'electron')
+      .map(async ([id, component]) => {
+        const contentSha256 = await hashComponentPath(join(resourcesRoot, component.path))
+        return [
+          id,
+          {
+            version: component.version,
+            contentSha256,
+            archiveSha256: contentSha256,
+            archiveBytes: 1,
+            downloadUrl: `${origin}/unused-${id}.tar.gz`,
+            entryPath: '.',
+          },
+        ]
+      })
+  )
   return {
     schemaVersion: 1,
     appVersion: targetVersion,
     channel: UPDATE_CHANNEL,
     platform: 'macos',
     arch: 'arm64',
-    components: Object.fromEntries(
-      Object.entries(packaged.components)
-        .filter(([id]) => id !== 'electron')
-        .map(([id, component]) => [
-          id,
-          {
-            version: component.version,
-            contentSha256: component.sha256,
-            archiveSha256: component.sha256,
-            archiveBytes: 1,
-            downloadUrl: `${origin}/unused-${id}.tar.gz`,
-            entryPath: '.',
-          },
-        ])
-    ),
+    components: Object.fromEntries(components),
   }
 }
 

--- a/wework/e2e/desktop/scenarios/component-update.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/component-update.scenario.mjs
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { createReadStream } from 'node:fs'
-import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { join, resolve } from 'node:path'
-import { pipeline } from 'node:stream/promises'
+
+import { hashComponentPath } from '../../../scripts/lib/component-content-hash.mjs'
 
 const MARKER_NAME = 'e2e-component-update.marker'
 
@@ -34,7 +34,7 @@ export async function createDesktopScenario({
   await createTarArchive(source, archive)
   const archiveBytes = await readFile(archive)
   const archiveSha256 = sha256(archiveBytes)
-  const contentSha256 = await hashTree(source)
+  const contentSha256 = await hashComponentPath(source)
   const target = componentTarget(process.platform, process.arch)
   const assetName = `WeworkComponent_weworkCorePlugins_${archiveSha256}_${target.platform}_${target.arch}.tar.gz`
   let origin = ''
@@ -190,28 +190,6 @@ async function waitFor(predicate, message, timeoutMs = 30_000) {
 
 async function readJson(path) {
   return JSON.parse(await readFile(path, 'utf8'))
-}
-
-async function hashTree(root, relative = '') {
-  const hash = createHash('sha256')
-  const entries = await readdir(join(root, relative), { withFileTypes: true })
-  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
-    const child = join(relative, entry.name)
-    if (entry.isDirectory()) {
-      hash.update(`directory:${child}\0${await hashTree(root, child)}\0`)
-    } else if (entry.isFile()) {
-      hash.update(`file:${child}\0${await fileSha256(join(root, child))}\0`)
-    } else {
-      throw new Error(`Unsupported component entry: ${child}`)
-    }
-  }
-  return hash.digest('hex')
-}
-
-async function fileSha256(path) {
-  const hash = createHash('sha256')
-  await pipeline(createReadStream(path), hash)
-  return hash.digest('hex')
 }
 
 function sha256(bytes) {

--- a/wework/scripts/lib/component-content-hash.mjs
+++ b/wework/scripts/lib/component-content-hash.mjs
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { lstat, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { pipeline } from 'node:stream/promises'
+
+export async function hashComponentPath(path) {
+  const metadata = await lstat(path)
+  if (metadata.isFile()) return fileSha256(path)
+  if (!metadata.isDirectory()) throw new Error(`Unsupported component entry: ${path}`)
+  return hashTree(path)
+}
+
+async function hashTree(root, relative = '') {
+  const hash = createHash('sha256')
+  const entries = await readdir(join(root, relative), { withFileTypes: true })
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const child = join(relative, entry.name)
+    if (entry.isDirectory()) {
+      hash.update(`directory:${child}\0${await hashTree(root, child)}\0`)
+    } else if (entry.isFile()) {
+      hash.update(`file:${child}\0${await fileSha256(join(root, child))}\0`)
+    } else {
+      throw new Error(`Unsupported component entry: ${child}`)
+    }
+  }
+  return hash.digest('hex')
+}
+
+async function fileSha256(path) {
+  const hash = createHash('sha256')
+  await pipeline(createReadStream(path), hash)
+  return hash.digest('hex')
+}

--- a/wework/scripts/lib/component-content-hash.test.mjs
+++ b/wework/scripts/lib/component-content-hash.test.mjs
@@ -1,0 +1,52 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { hashComponentPath } from './component-content-hash.mjs'
+
+const temporaryDirectories = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true }))
+  )
+})
+
+describe('hashComponentPath', () => {
+  test('hashes a file by its bytes', async () => {
+    const root = await temporaryDirectory()
+    const path = join(root, 'component.bin')
+    await writeFile(path, 'signed component')
+
+    await expect(hashComponentPath(path)).resolves.toBe(sha256('signed component'))
+  })
+
+  test('hashes directory entries in stable path order', async () => {
+    const root = await temporaryDirectory()
+    await mkdir(join(root, 'nested'))
+    await writeFile(join(root, 'z.txt'), 'last')
+    await writeFile(join(root, 'nested', 'a.txt'), 'first')
+
+    const nestedHash = createHash('sha256')
+      .update(`file:nested/a.txt\0${sha256('first')}\0`)
+      .digest('hex')
+    const expected = createHash('sha256')
+      .update(`directory:nested\0${nestedHash}\0`)
+      .update(`file:z.txt\0${sha256('last')}\0`)
+      .digest('hex')
+
+    await expect(hashComponentPath(root)).resolves.toBe(expected)
+  })
+})
+
+async function temporaryDirectory() {
+  const directory = await mkdtemp(join(tmpdir(), 'wework-component-hash-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function sha256(contents) {
+  return createHash('sha256').update(contents).digest('hex')
+}

--- a/wework/scripts/lib/component-content-hash.test.mjs
+++ b/wework/scripts/lib/component-content-hash.test.mjs
@@ -2,7 +2,15 @@ import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('node:fs/promises', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    readdir: async (...args) => (await actual.readdir(...args)).reverse(),
+  }
+})
 
 import { hashComponentPath } from './component-content-hash.mjs'
 

--- a/wework/scripts/prepare-desktop-release-assets.mjs
+++ b/wework/scripts/prepare-desktop-release-assets.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url'
 import { create } from 'tar'
 
 import { wrapWindowsScriptCommand } from './child-process-command.mjs'
+import { hashComponentPath } from './lib/component-content-hash.mjs'
 import { componentReleaseScope } from './desktop-component-release.mjs'
 import identityModule from '../electron/scripts/build-identity.cjs'
 
@@ -151,29 +152,6 @@ async function prepareComponentAssets() {
 async function sha256(path) {
   const hash = createHash('sha256')
   await pipeline(createReadStream(path), hash)
-  return hash.digest('hex')
-}
-
-async function hashComponentPath(path) {
-  const metadata = await stat(path)
-  if (metadata.isFile()) return sha256(path)
-  if (!metadata.isDirectory()) throw new Error(`Unsupported component entry: ${path}`)
-  return hashTree(path)
-}
-
-async function hashTree(root, relative = '') {
-  const hash = createHash('sha256')
-  const entries = await readdir(join(root, relative), { withFileTypes: true })
-  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
-    const child = join(relative, entry.name)
-    if (entry.isDirectory()) {
-      hash.update(`directory:${child}\0${await hashTree(root, child)}\0`)
-    } else if (entry.isFile()) {
-      hash.update(`file:${child}\0${await sha256(join(root, child))}\0`)
-    } else {
-      throw new Error(`Unsupported component entry: ${child}`)
-    }
-  }
   return hash.digest('hex')
 }
 


### PR DESCRIPTION
## Summary

- compute differential-update fixture component hashes from the final signed application resources
- share the production-compatible component content hashing helper across release packaging and desktop E2E scenarios
- assert that unchanged packaged components are reused instead of downloaded
- document that published component hashes must be generated after Electron Builder signing

## Root cause

The macOS arm64 release E2E used the pre-signing hashes stored in `components.json` as the target component manifest. Electron Builder signs nested executables after that manifest is created, changing component bytes. The updater correctly rejected those packaged components as non-matching and attempted the fixture's intentionally invalid `/unused-*.tar.gz` URLs, producing the observed executor HTTP 404.

## Verification

- `pnpm --filter wework test scripts/lib/component-content-hash.test.mjs`
- `pnpm --filter wework test scripts/desktop-resource-migration.test.mjs electron/src/runtime/component-update-manager.test.ts electron/src/runtime/desktop-components.test.ts src/test/bundled-plugin-resources.test.ts`
- package-owned Prettier and ESLint on changed Wework files
- Node syntax checks and `git diff --check`
- pre-push Wework static checks and unit tests

The release-package differential E2E requires a signed packaged macOS application and is intentionally left to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that macOS component manifest hashes must be calculated from final, signed application resources rather than pre-packaging values.

- **Bug Fixes**
  - Improved content-hash consistency for packaged files and directories.
  - Differential updates now avoid downloading unchanged components.

- **Tests**
  - Added coverage for deterministic file and directory content hashing.
  - Expanded update scenarios to verify packaged-resource hashes and prevent unnecessary component downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->