### PR TITLE
fix(wework): restore project sidebar expansion

### DIFF
--- a/wework/DESIGN.md
+++ b/wework/DESIGN.md
@@ -870,6 +870,11 @@ implementation and WCAG conflict.
 
 - Preserve native title-bar drag regions and window controls; interactive
   elements are `no-drag` equivalents.
+- 原生标题栏拖拽区域不得与可交互控件的可见边界重叠；即使控件声明为
+  `no-drag`，也必须从拖拽区域的几何范围中明确排除。
+- Native title-bar drag regions must not geometrically overlap visible
+  interactive controls. Explicitly carve controls out of the drag region even
+  when they declare `no-drag`.
 - Respect macOS traffic-light safe areas, Windows controls, system scaling, and
   actual platform shortcuts.
 - Use the platform modifier in both behavior and visible shortcut labels.

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -2858,10 +2858,18 @@ describe('CloudTodoWorkspace', () => {
       />
     )
 
+    await userEvent.click(await screen.findByTestId('cloud-sidebar-project-11'))
     expect(screen.getByTestId('cloud-todo-sidebar-chrome-controls')).toHaveClass('gap-1')
     await userEvent.click(screen.getByTestId('cloud-todo-collapse-sidebar'))
     expect(screen.queryByTestId('cloud-todo-collapsed-app-current')).not.toBeInTheDocument()
-    expect(screen.getByTestId('cloud-todo-collapsed-chrome-controls')).toHaveClass('left-2')
+    expect(screen.getByTestId('cloud-todo-collapsed-chrome-controls')).toHaveClass(
+      'electron-titlebar-interactive-region',
+      'pointer-events-auto',
+      'left-2'
+    )
+    expect(
+      screen.getByTestId('cloud-project-header').querySelector('.electron-titlebar-drag-region')
+    ).toHaveClass('left-12')
 
     await userEvent.click(screen.getByTestId('cloud-todo-expand-sidebar'))
     expect(screen.queryByTestId('cloud-todo-collapsed-chrome-controls')).not.toBeInTheDocument()

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -4130,7 +4130,7 @@ export function CloudTodoWorkspace({
           {!embedded && sidebarCollapsed && (
             <div
               data-testid="cloud-todo-collapsed-chrome-controls"
-              className="absolute left-2 top-0 z-20 flex h-[38px] items-center gap-1"
+              className="electron-titlebar-interactive-region pointer-events-auto absolute left-2 top-0 z-20 flex h-[38px] items-center gap-1"
             >
               <DesktopWindowControls
                 sidebarCollapsed
@@ -4244,7 +4244,12 @@ export function CloudTodoWorkspace({
                 )}
               >
                 {!embedded && (
-                  <MacOSTitleBarDragRegion className="absolute inset-0 z-0 h-full w-full" />
+                  <MacOSTitleBarDragRegion
+                    className={cn(
+                      'absolute right-0 top-0 z-0 h-full',
+                      sidebarCollapsed ? 'left-12' : 'left-0'
+                    )}
+                  />
                 )}
                 <div
                   ref={projectHeaderContentRef}


### PR DESCRIPTION
## Summary

- keep the collapsed project-space sidebar control outside the native title-bar drag region
- mark the collapsed control container as an Electron interactive region
- cover collapse and restore after selecting a concrete project space
- document that native drag regions must not geometrically overlap visible controls

## Verification

- `pnpm --filter wework test src/features/todo/CloudTodoWorkspace.test.tsx` (97 passed)
- `pnpm --filter wework exec prettier --check DESIGN.md src/features/todo/CloudTodoWorkspace.tsx src/features/todo/CloudTodoWorkspace.test.tsx`
- `pnpm --filter wework exec eslint src/features/todo/CloudTodoWorkspace.tsx src/features/todo/CloudTodoWorkspace.test.tsx`
- pre-push Wework ESLint, TypeScript, and unit-test checks
- isolated real Electron verification: collapsed button bounds `x=8..40`, drag region starts at `x=48`, and clicking restores `data-sidebar-collapsed=false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsed-sidebar controls so they remain interactive and responsive.
  * Adjusted the project header’s window-drag area to avoid overlapping visible controls.
  * Preserved expected sidebar collapse and restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->