### PR TITLE
fix(wegent): 修复docx导出时消息内容有非法字符的问题

### DIFF
--- a/backend/app/services/export/docx_generator.py
+++ b/backend/app/services/export/docx_generator.py
@@ -44,6 +44,14 @@ EAST_ASIA_FONT = "Microsoft YaHei"
 MONOSPACE_FONT = "Courier New"
 DOCUMENT_LANGUAGE = "en-US"
 EAST_ASIA_LANGUAGE = "zh-CN"
+INVALID_XML_CHARACTER_PATTERN = re.compile(
+    r"[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF\uFFFE\uFFFF]"
+)
+
+
+def _sanitize_xml_text(text: str) -> str:
+    """Remove characters forbidden by XML 1.0."""
+    return INVALID_XML_CHARACTER_PATTERN.sub("", text)
 
 
 def generate_task_docx(
@@ -69,6 +77,7 @@ def generate_task_docx(
         or task_data.get("title", "")
         or task_data.get("prompt", "Chat Export")[:50]
     )
+    task_title = _sanitize_xml_text(str(task_title))
 
     doc.core_properties.title = task_title
     doc.core_properties.author = "Wegent AI"
@@ -230,7 +239,8 @@ def _add_message(doc: Document, subtask: Subtask, task: Kind, user: User, db: Se
         team_ref = task_data.get("teamRef", {})
         sender_name = team_ref.get("name", "AI Assistant")
 
-    _add_text_with_emoji_support(header, f"{sender_name}: ", bold=True)
+    sender_label = _sanitize_xml_text(f"{sender_name}: ")
+    _add_text_with_emoji_support(header, sender_label, bold=True)
     # Set sender font properties for all runs just added
     for run in header.runs:
         run.font.size = Pt(11)
@@ -304,7 +314,7 @@ def _clean_content(content: str) -> str:
     content = re.sub(r"__PROGRESS_BAR__:.*?:\d+", "", content)
     content = re.sub(r"__PROMPT_TRUNCATED__:.*?::(.*?)(?=\n|$)", r"\1", content)
 
-    return content.strip()
+    return _sanitize_xml_text(content).strip()
 
 
 def _convert_emoji_to_text(text: str) -> str:
@@ -369,7 +379,7 @@ def _add_image_attachment(doc: Document, attachment: SubtaskContext, db: Session
             # Add caption
             caption = doc.add_paragraph()
             caption.alignment = WD_ALIGN_PARAGRAPH.CENTER
-            run = caption.add_run(attachment.name)
+            run = caption.add_run(_sanitize_xml_text(attachment.name or ""))
             run.font.size = Pt(8)
             run.font.italic = True
             run.font.color.rgb = RGBColor(150, 150, 150)
@@ -398,7 +408,7 @@ def _add_file_attachment(doc: Document, attachment: SubtaskContext):
     type_run.font.color.rgb = RGBColor(100, 100, 100)
 
     # Filename
-    name_run = p.add_run(attachment.name)
+    name_run = p.add_run(_sanitize_xml_text(attachment.name or ""))
     name_run.font.size = Pt(10)
 
     # File size

--- a/backend/tests/services/test_docx_generator_prompt_sanitization.py
+++ b/backend/tests/services/test_docx_generator_prompt_sanitization.py
@@ -11,13 +11,17 @@ Subtask.prompt are stripped before being written to the exported DOCX document.
 
 import json
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from docx import Document
 
-from app.schemas.subtask import SubtaskRole
-from app.services.export.docx_generator import _add_message
+from app.services.export.docx_generator import (
+    _add_file_attachment,
+    _add_message,
+    _sanitize_xml_text,
+    generate_task_docx,
+)
 
 
 def _make_user_subtask(prompt: str, contexts=None):
@@ -58,6 +62,64 @@ def _make_task_and_user():
 
 class TestDocxGeneratorPromptSanitization:
     """Tests for prompt sanitization in _add_message."""
+
+    def test_removes_only_xml_10_forbidden_characters(self) -> None:
+        """XML sanitization preserves valid Unicode and whitespace."""
+        valid_text = "中文😀\t\n\r\u007f\u0085"
+        text = f"A\x00\x08\x0b\x0c\x1f{valid_text}\ud800\ufffeB"
+
+        assert _sanitize_xml_text(text) == f"A{valid_text}B"
+
+    def test_xml_control_character_removed_from_prompt(self) -> None:
+        """An XML-forbidden separator in a prompt must not break DOCX export."""
+        doc = Document()
+        task, user = _make_task_and_user()
+        subtask = _make_user_subtask(
+            "必须包含2\u001e3处合理的业务小缺陷，其他内容保持不变。"
+        )
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        _add_message(doc, subtask, task, user, db)
+
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "必须包含23处合理的业务小缺陷，其他内容保持不变。" in full_text
+        assert "\u001e" not in full_text
+
+    def test_xml_control_character_removed_from_task_title(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An XML-forbidden character in the task title is removed."""
+        task = MagicMock()
+        task.id = 1
+        task.user_id = 1
+        task.json = {"metadata": {"name": "Task\x00Title"}, "spec": {}}
+        db = MagicMock()
+        monkeypatch.setattr(
+            "app.services.export.docx_generator.subtask_store.list_by_task_ordered",
+            lambda *args, **kwargs: [],
+        )
+
+        buffer = generate_task_docx(task, db)
+
+        generated_doc = Document(buffer)
+        assert generated_doc.core_properties.title == "TaskTitle"
+        assert "TaskTitle" in "\n".join(p.text for p in generated_doc.paragraphs)
+
+    def test_xml_control_character_removed_from_attachment_name(self) -> None:
+        """An XML-forbidden character in an attachment name is removed."""
+        doc = Document()
+        attachment = MagicMock()
+        attachment.name = "report\x00.docx"
+        attachment.type_data = {
+            "file_extension": ".docx",
+            "file_size": 1024,
+        }
+
+        _add_file_attachment(doc, attachment)
+
+        assert "report.docx" in "\n".join(p.text for p in doc.paragraphs)
 
     def test_plain_text_prompt_written_to_document(self):
         """Plain text user prompt appears as-is in DOCX content."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed DOCX exports that could become corrupted when task titles, messages, captions, or attachment names contained invalid XML characters.
  - Preserved valid Unicode and whitespace in exported document content.

- **Tests**
  - Added coverage for XML character handling across prompts, task titles, and attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->