### PR TITLE
fix(wework): preserve task route when leaving settings

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1809,6 +1809,52 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('cloud-todo-workspace')).toBeVisible()
   })
 
+  test('keeps the active task return route when an inactive project space is retained', () => {
+    const taskTab = {
+      id: 'task-existing',
+      kind: 'task' as const,
+      title: '当前任务',
+      contentRoute: '/runtime-tasks?deviceId=local-device&taskId=runtime-1',
+    }
+    const boardTab = {
+      id: 'board-existing',
+      kind: 'board' as const,
+      title: '项目空间',
+      contentRoute: '/todo?projectId=project-1',
+    }
+    const workspaceTabs = (activeTab: typeof taskTab | typeof boardTab) =>
+      ({
+        tabs: [taskTab, boardTab],
+        activeTabId: activeTab.id,
+        activeTab,
+        openTab: vi.fn(),
+        selectTab: vi.fn(),
+        closeTab: vi.fn(),
+        closeOtherTabs: vi.fn(),
+        restoreClosedTab: vi.fn(),
+        moveTab: vi.fn(),
+        updateActiveTab: vi.fn(),
+      }) as unknown as WorkspaceTabsContextValue
+
+    window.sessionStorage.clear()
+    window.history.pushState({}, '', taskTab.contentRoute)
+
+    render(
+      <>
+        <WorkspaceTabsContext.Provider value={workspaceTabs(taskTab)}>
+          <DesktopWorkbenchLayout {...baseProps} routeActive />
+        </WorkspaceTabsContext.Provider>
+        <WorkspaceTabsContext.Provider value={workspaceTabs(boardTab)}>
+          <DesktopWorkbenchLayout {...baseProps} routeActive={false} surfaceKind="board" />
+        </WorkspaceTabsContext.Provider>
+      </>
+    )
+
+    act(() => navigateTo('/settings'))
+
+    expect(window.sessionStorage.getItem('wework.settingsReturnPath')).toBe(taskTab.contentRoute)
+  })
+
   test('returns to the active workspace tab when the URL is out of sync', async () => {
     deliveryApiMock.available = true
     const boardTab = {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -537,6 +537,8 @@ export function DesktopWorkbenchLayout({
   const [sidebarResizing, setSidebarResizing] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(() => isSettingsRoute(initialPath))
   const settingsReturnPathRef = useRef(initialPath === '/todo' ? '/todo' : '/')
+  const routeActiveRef = useRef(routeActive)
+  routeActiveRef.current = routeActive
   const activeTabRouteRef = useRef(
     ownedWorkspaceTab?.contentRoute ??
       `${stripAppBasePath(window.location.pathname)}${window.location.search}`
@@ -582,7 +584,7 @@ export function DesktopWorkbenchLayout({
     const handlePopState = () => {
       const path = stripAppBasePath(window.location.pathname)
       const enteringSettings = isSettingsRoute(path) && !isSettingsRoute(previousPath)
-      if (enteringSettings) {
+      if (enteringSettings && routeActiveRef.current) {
         settingsReturnPathRef.current = activeTabRouteRef.current
         writeSettingsReturnPath(activeTabRouteRef.current)
       }


### PR DESCRIPTION
## Summary

- prevent retained inactive project-space layouts from overwriting the settings return route
- preserve the active runtime task URL when opening and leaving settings
- add regression coverage for an active task tab with an inactive retained project-space tab

## Verification

- `pnpm --filter wework test src/components/layout/DesktopWorkbenchLayout.test.tsx -t "settings|keeps the active task return route when an inactive project space is retained"`
- `pnpm --filter wework exec prettier --check src/components/layout/DesktopWorkbenchLayout.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --filter wework exec eslint src/components/layout/DesktopWorkbenchLayout.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- pre-push Wework checks: ESLint, TypeScript, unit tests
- isolated real Electron verification: task workspace -> settings -> back returned to the task workspace while the fixed project-space tab remained retained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now preserves the return path for the active task route when inactive project-space surfaces remain open.
  * Navigating back from Settings returns users to the correct active task view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->