### PR TITLE
fix(wework): preserve released tray identity

### DIFF
--- a/wework/electron/src/host/tray-guid.test.ts
+++ b/wework/electron/src/host/tray-guid.test.ts
@@ -4,13 +4,17 @@ import { trayGuidForApplicationId } from './tray-guid.js'
 describe('trayGuidForApplicationId', () => {
   test('preserves the released Wework tray identity', () => {
     expect(trayGuidForApplicationId('io.wecode.wework')).toBe(
-      'b3dce801-ead2-5b83-bc0a-7be0b543c833'
+      '8fda9369-51a7-5cd6-9625-cb1b65f440db'
     )
   })
 
-  test('isolates tray identities for branded and debug applications', () => {
-    expect(trayGuidForApplicationId('io.wecode.wework')).not.toBe(
-      trayGuidForApplicationId('com.example.workbench')
+  test('generates stable isolated tray identities for branded and debug applications', () => {
+    const brandedGuid = trayGuidForApplicationId('com.example.workbench')
+
+    expect(brandedGuid).toBe(trayGuidForApplicationId('com.example.workbench'))
+    expect(brandedGuid).not.toBe(trayGuidForApplicationId('io.wecode.wework'))
+    expect(brandedGuid).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
     )
   })
 })

--- a/wework/electron/src/host/tray-guid.ts
+++ b/wework/electron/src/host/tray-guid.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto'
 
 const WEWORK_TRAY_NAMESPACE = '69ef5f47-9421-53b7-8c12-5a09a4450863'
+const RELEASED_WEWORK_APPLICATION_ID = 'io.wecode.wework'
+const RELEASED_WEWORK_TRAY_GUID = '8fda9369-51a7-5cd6-9625-cb1b65f440db'
 
 function uuidBytes(uuid: string): Buffer {
   return Buffer.from(uuid.replaceAll('-', ''), 'hex')
@@ -18,6 +20,10 @@ function formatUuid(bytes: Buffer): string {
 }
 
 export function trayGuidForApplicationId(applicationId: string): string {
+  if (applicationId === RELEASED_WEWORK_APPLICATION_ID) {
+    return RELEASED_WEWORK_TRAY_GUID
+  }
+
   const bytes = createHash('sha1')
     .update(uuidBytes(WEWORK_TRAY_NAMESPACE))
     .update(applicationId)


### PR DESCRIPTION
## Summary

- restore the released macOS tray GUID for the production `io.wecode.wework` bundle
- keep deterministic isolated GUID generation for branded and debug bundles
- add regression coverage for the released identity and generated UUID stability

## Root cause

Wework changed its tray GUID from the identity already persisted by macOS/iBar (`8fda9369-51a7-5cd6-9625-cb1b65f440db`) to a newly generated identity. After every Wework restart, iBar therefore applied its hidden state for the new item instead of the user-visible state saved for the released item.

## Verification

- reproduced on the current macOS machine using iBar Pro 2.1.0
- confirmed iBar persists the visible state across its own restart
- confirmed the compiled production bundle mapping returns the released GUID
- confirmed a real Electron verification instance creates the native tray
- `pnpm --filter @wegent/wework-electron test src/host/tray-guid.test.ts src/host/tray-manager.test.ts`
- `pnpm --filter @wegent/wework-electron typecheck`
- `pnpm --filter wework exec prettier --check electron/src/host/tray-guid.ts electron/src/host/tray-guid.test.ts`
- pre-push Wework static checks and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the WeWork desktop application maintains a consistent system tray identity across launches.
  * Preserved stable, distinct tray identities for branded application variants.
  * Improved compatibility with operating-system tray behavior by using valid, stable identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->