### PR TITLE
fix(wework): keep applications outside experiments

### DIFF
--- a/wework/dsh/ui-applications/client.js
+++ b/wework/dsh/ui-applications/client.js
@@ -20,7 +20,6 @@ window.__ModuleLoader__.load({
           ctx.wework.contributions.register(ctx, 'wework.sidebar.navigation', {
             id: 'applications.navigation',
             activeItem: 'sites',
-            experimental: true,
             icon: 'applications',
             labelKey: 'workbench.sites',
             label: '应用',

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -93,7 +93,6 @@ const TEST_DSH_NAVIGATION = [
   {
     id: 'applications.navigation',
     activeItem: 'sites',
-    experimental: true,
     icon: 'applications',
     label: '应用',
     order: 30,

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -2094,17 +2094,11 @@ describe('DesktopSidebar', () => {
     expect(screen.getByTestId('plugins-button')).toBeInTheDocument()
   })
 
-  test('shows Sites only while experimental features are enabled', async () => {
+  test('shows Applications while experimental features are disabled', () => {
     experimentalFeatures.enabled = false
-    const { unmount } = renderSidebar()
-
-    expect(screen.queryByTestId('sites-button')).not.toBeInTheDocument()
-
-    unmount()
-    experimentalFeatures.enabled = true
     renderSidebar()
 
-    expect(screen.getByTestId('sites-button')).toBeInTheDocument()
+    expect(screen.getByTestId('sites-button')).toHaveTextContent('应用')
   })
 
   test('shows Automations when experimental features are disabled', () => {

--- a/wework/src/test/setup.ts
+++ b/wework/src/test/setup.ts
@@ -93,7 +93,6 @@ const testSidebarNavigation = [
   {
     id: 'applications.navigation',
     activeItem: 'sites',
-    experimental: true,
     icon: 'applications',
     labelKey: 'workbench.sites',
     label: '应用',


### PR DESCRIPTION
## Summary
- remove the experimental flag from the Applications sidebar contribution
- keep test DSH navigation fixtures aligned with production registration
- cover Applications visibility when experimental features are disabled

## Verification
- `pnpm --filter wework test src/components/layout/DesktopSidebar.test.tsx` (115 passed)
- `pnpm --filter wework test src/App.plugins.test.tsx` (39 passed)
- `pnpm --filter wework exec prettier --check dsh/ui-applications/client.js src/test/setup.ts src/App.plugins.test.tsx src/components/layout/DesktopSidebar.test.tsx`
- `pnpm --filter wework exec eslint dsh/ui-applications/client.js src/test/setup.ts src/App.plugins.test.tsx src/components/layout/DesktopSidebar.test.tsx`
- isolated Electron verification: fresh/default preferences showed `sites-button`; clicking it rendered `sites-workspace`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications navigation is now available without enabling experimental features.
  * The Applications option remains visible in the sidebar when experimental features are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->