### PR TITLE
fix(backend): recover stuck task cancellations

### DIFF
--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -67,6 +67,10 @@ INJECTION_MODE_KB_HEAD = "kb_head"
 # so this sits just above it. Raise it if that page window grows.
 MAX_ATTACHMENT_TEXT_SLICE = 64_000
 
+CANCELLED_ASSISTANT_CONTEXT_NOTE = (
+    "[Previous assistant response was interrupted by the user.]"
+)
+
 
 def _is_restricted_kb_context(kb_ctx: SubtaskContext) -> bool:
     """Whether a KB history context should be suppressed for restricted mode."""
@@ -278,6 +282,28 @@ def subtask_to_messages(
         ]
 
     # Assistant messages ---------------------------------------------------
+    # A cancelled turn may contain a partial response and an incomplete
+    # messages_chain. Preserve the useful text, but close the turn explicitly
+    # so the next model request does not interpret it as an unfinished assistant
+    # message. Empty cancelled turns add no context and must be omitted.
+    if subtask.status == SubtaskStatus.CANCELLED:
+        if subtask.role != SubtaskRole.ASSISTANT:
+            return []
+        result = subtask.result if isinstance(subtask.result, dict) else {}
+        content = result.get("value", "")
+        if not isinstance(content, str) or not content.strip():
+            return []
+        return [
+            MessageResponse(
+                id=str(subtask.id),
+                role="assistant",
+                content=(f"{content.rstrip()}\n\n{CANCELLED_ASSISTANT_CONTEXT_NOTE}"),
+                created_at=(
+                    subtask.created_at.isoformat() if subtask.created_at else None
+                ),
+            )
+        ]
+
     # For FAILED assistant subtasks, only keep result.value when present.
     # Do not expand messages_chain for failed turns to avoid injecting
     # tool-call artifacts or partial chain state into model history.
@@ -320,10 +346,19 @@ def subtask_to_messages(
                 and msg_kwargs.get("summary_compacted") is True
                 else None
             )
+            content = msg.get("content", "")
+            if (
+                role == "assistant"
+                and not content
+                and not msg.get("tool_calls")
+                and not msg.get("reasoning_content")
+                and resp_metadata is None
+            ):
+                continue
             resp = MessageResponse(
                 id=msg_id,
                 role=role,
-                content=msg.get("content", ""),
+                content=content,
                 name=msg.get("name"),
                 tool_call_id=msg.get("tool_call_id"),
                 tool_calls=msg.get("tool_calls"),
@@ -345,6 +380,8 @@ def subtask_to_messages(
 
     # Fallback for legacy data without messages_chain
     content = result.get("value", "")
+    if not content:
+        return []
     loaded_skills = result.get("loaded_skills")
     return [
         MessageResponse(

--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -1490,6 +1490,32 @@ class ChatNamespace(socketio.AsyncNamespace):
                 cancel_request, device_id
             )
 
+            # When the streaming runtime is already gone (e.g. backend restart
+            # killed the SSE consumer), no callback will ever arrive. Finalize
+            # the cancellation locally instead of leaving the task stuck in
+            # CANCELLING forever.
+            from app.services.chat.operations.cancel import (
+                is_stream_alive,
+                publish_task_cancelled_events,
+            )
+
+            if not await is_stream_alive(subtask_info["task_id"], payload.subtask_id):
+                finalized_subtask_ids = await run_sync_in_executor(
+                    _finalize_stuck_cancellation, payload.subtask_id
+                )
+                if finalized_subtask_ids is not None:
+                    await publish_task_cancelled_events(
+                        subtask_info["task_id"], finalized_subtask_ids, user_id
+                    )
+                    logger.info(
+                        "[WS] chat:cancel finalized locally (stream runtime gone): "
+                        "task_id=%s, subtask_id=%s, finalized_subtasks=%s",
+                        subtask_info["task_id"],
+                        payload.subtask_id,
+                        finalized_subtask_ids,
+                    )
+                    return {"success": True, "finalized": True}
+
             if not cancel_success:
                 logger.error(
                     "[WS] chat:cancel Runtime did not acknowledge cancellation "
@@ -2265,6 +2291,17 @@ def _mark_task_and_board_cancelling(subtask_id: int) -> None:
             subtask_id=subtask.id,
             user_id=task.user_id,
         )
+
+
+def _finalize_stuck_cancellation(subtask_id: int) -> Optional[list[int]]:
+    """Finalize cancellation locally when the streaming runtime is gone."""
+    from app.services.chat.operations.cancel import finalize_stuck_cancellation
+
+    with get_db_session() as db:
+        subtask = task_stores.subtask_store.get_by_id(db, subtask_id=subtask_id)
+        if not subtask:
+            return None
+        return finalize_stuck_cancellation(db, task_id=subtask.task_id)
 
 
 def _get_device_info_for_close_session(task_id: int, user_id: int) -> Optional[dict]:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -224,6 +224,12 @@ class Settings(BaseSettings):
     APPEND_CHAT_TASK_EXPIRE_HOURS: int = 2
     APPEND_CODE_TASK_EXPIRE_HOURS: int = 24
 
+    # Cancellation recovery configuration
+    # A task stuck in CANCELLING (or a streaming subtask whose runtime is gone) is
+    # finalized locally once no streaming activity has been observed for this long.
+    # Healthy streams touch Redis activity every ~1s, so 30min is conservative.
+    CANCELLING_STUCK_TIMEOUT_SECONDS: int = 1800
+
     # Subtask executor cleanup configuration
     # After a subtask is COMPLETED or FAILED, if executor_name/executor_namespace are set
     # and updated_at exceeds this threshold, the executor task will be deleted automatically.

--- a/backend/app/services/adapters/task_kinds/operations.py
+++ b/backend/app/services/adapters/task_kinds/operations.py
@@ -1154,6 +1154,29 @@ class TaskOperationsMixin:
         db.commit()
         return None
 
+    @staticmethod
+    def _is_cancellation_stuck(task_dict: Dict[str, Any]) -> bool:
+        """Return True when a task has sat in CANCELLING beyond the timeout.
+
+        The CANCELLING timestamp lives in status.updatedAt, which
+        _mark_task_and_board_cancelling refreshes when persisting the intent.
+        """
+        updated_at = task_dict.get("updated_at")
+        if isinstance(updated_at, str):
+            try:
+                updated_at = datetime.fromisoformat(updated_at)
+            except ValueError:
+                return False
+        if not isinstance(updated_at, datetime):
+            return False
+        if updated_at.tzinfo is not None:
+            idle_seconds = (
+                datetime.now(updated_at.tzinfo) - updated_at
+            ).total_seconds()
+        else:
+            idle_seconds = (datetime.now() - updated_at).total_seconds()
+        return idle_seconds > settings.CANCELLING_STUCK_TIMEOUT_SECONDS
+
     async def cancel_task(
         self,
         db: Session,
@@ -1184,6 +1207,24 @@ class TaskOperationsMixin:
             )
 
         if current_status == "CANCELLING":
+            if self._is_cancellation_stuck(task_dict):
+                logger.warning(
+                    f"Task {task_id} stuck in CANCELLING over "
+                    f"{settings.CANCELLING_STUCK_TIMEOUT_SECONDS}s, finalizing locally"
+                )
+                from app.services.chat.operations.cancel import (
+                    finalize_stuck_cancellation,
+                    publish_task_cancelled_events,
+                )
+
+                finalized_subtask_ids = finalize_stuck_cancellation(db, task_id=task_id)
+                await publish_task_cancelled_events(
+                    task_id, finalized_subtask_ids, user_id
+                )
+                return {
+                    "message": "Task cancellation finalized",
+                    "status": "CANCELLED",
+                }
             logger.info(f"Task {task_id} is already being cancelled")
             return {
                 "message": "Task is already being cancelled",

--- a/backend/app/services/chat/operations/cancel.py
+++ b/backend/app/services/chat/operations/cancel.py
@@ -9,13 +9,14 @@ subtask status on cancellation.
 """
 
 import logging
-from datetime import datetime
-from typing import Any, Optional
+from datetime import datetime, timezone
+from typing import Any, List, Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.db.session import SessionLocal
-from app.models.subtask import Subtask, SubtaskStatus
+from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
 from app.models.task import TaskResource
 from app.schemas.kind import Task
 from app.stores.tasks import subtask_store, task_store
@@ -115,3 +116,118 @@ def update_task_on_cancel(db: Session, task: TaskResource) -> None:
         task_crd.status.completedAt = datetime.now()
 
     task_store.update_json(db, task=task, payload=task_crd.model_dump(mode="json"))
+
+
+_TASK_FINAL_STATES = ("COMPLETED", "FAILED", "CANCELLED", "DELETE")
+
+
+async def is_stream_alive(task_id: int, subtask_id: Optional[int] = None) -> bool:
+    """
+    Return True when a runtime consumer is still streaming for this task.
+
+    Healthy streams refresh the task streaming key roughly every second via
+    StatusUpdatingEmitter, so a missing key, a different subtask owning the
+    key, or a stale last_activity_at means the consumer is gone and no
+    terminal callback will ever arrive.
+
+    Args:
+        task_id: Task ID to check
+        subtask_id: When given, the key must belong to this subtask
+
+    Returns:
+        True if streaming activity is fresh, False otherwise
+    """
+    from app.services.chat.storage import session_manager
+
+    status = await session_manager.get_task_streaming_status(task_id)
+    if not status:
+        return False
+    if subtask_id is not None and status.get("subtask_id") != subtask_id:
+        return False
+    last_activity_raw = status.get("last_activity_at")
+    if not last_activity_raw:
+        return False
+    try:
+        last_activity = datetime.fromisoformat(str(last_activity_raw))
+    except ValueError:
+        return False
+    if last_activity.tzinfo is None:
+        last_activity = last_activity.replace(tzinfo=timezone.utc)
+    idle_seconds = (datetime.now(timezone.utc) - last_activity).total_seconds()
+    return idle_seconds <= settings.CANCELLING_STUCK_TIMEOUT_SECONDS
+
+
+def finalize_stuck_cancellation(db: Session, *, task_id: int) -> List[int]:
+    """
+    Finalize cancellation locally when no runtime callback will arrive.
+
+    Marks non-final assistant subtasks CANCELLED and the task CANCELLED.
+    Used when the streaming runtime is dead (e.g. backend restart) and the
+    task would otherwise remain in CANCELLING forever.
+
+    Args:
+        db: Database session
+        task_id: Task ID to finalize
+
+    Returns:
+        IDs of subtasks marked CANCELLED. Empty when the task was already in
+        a final state.
+    """
+    task = task_store.get_regular_active_task(db, task_id=task_id)
+    if not task or not task.json:
+        return []
+
+    task_crd = Task.model_validate(task.json)
+    if task_crd.status and task_crd.status.status in _TASK_FINAL_STATES:
+        return []
+
+    finalized: List[int] = []
+    stuck_subtasks = subtask_store.list_by_task_statuses(
+        db,
+        task_id=task_id,
+        statuses=[SubtaskStatus.PENDING, SubtaskStatus.RUNNING],
+    )
+    for subtask in stuck_subtasks:
+        if subtask.role != SubtaskRole.ASSISTANT:
+            continue
+        update_subtask_on_cancel(db, subtask)
+        finalized.append(subtask.id)
+
+    update_task_on_cancel(db, task)
+    db.commit()
+
+    logger.warning(
+        "Finalized stuck cancellation locally: task_id=%s, subtask_ids=%s",
+        task_id,
+        finalized,
+    )
+    return finalized
+
+
+async def publish_task_cancelled_events(
+    task_id: int, subtask_ids: List[int], user_id: int
+) -> None:
+    """
+    Publish TaskCompletedEvent(CANCELLED) for locally finalized cancellations.
+
+    Lets downstream projections (board team, subscriptions) react exactly as
+    if the runtime had delivered the cancellation callback itself.
+    """
+    from app.core.events import TaskCompletedEvent, get_event_bus
+
+    event_bus = get_event_bus()
+    for subtask_id in subtask_ids:
+        try:
+            await event_bus.publish(
+                TaskCompletedEvent(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    user_id=user_id,
+                    status="CANCELLED",
+                )
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to publish TaskCompletedEvent for finalized cancel: "
+                f"task_id={task_id}, subtask_id={subtask_id}, error={e}"
+            )

--- a/backend/tests/api/endpoints/test_internal_chat_storage_history.py
+++ b/backend/tests/api/endpoints/test_internal_chat_storage_history.py
@@ -86,7 +86,7 @@ def _create_subtask(
     return subtask
 
 
-def test_internal_chat_history_includes_cancelled_subtasks(
+def test_internal_chat_history_marks_cancelled_partial_as_interrupted(
     test_client: TestClient,
     test_db: Session,
     test_user: User,
@@ -108,12 +108,26 @@ def test_internal_chat_history_includes_cancelled_subtasks(
         message_id=2,
         status=SubtaskStatus.CANCELLED,
         content="cancelled-message",
+        result_override={
+            "value": "cancelled-message",
+            "messages_chain": [
+                {"role": "assistant", "content": "incomplete chain content"}
+            ],
+        },
     )
     _create_subtask(
         test_db,
         user_id=test_user.id,
         task_id=task_id,
         message_id=3,
+        status=SubtaskStatus.CANCELLED,
+        content=None,
+    )
+    _create_subtask(
+        test_db,
+        user_id=test_user.id,
+        task_id=task_id,
+        message_id=4,
         status=SubtaskStatus.FAILED,
         content=None,
     )
@@ -128,8 +142,35 @@ def test_internal_chat_history_includes_cancelled_subtasks(
     assert [item["id"] for item in messages] == [str(completed.id), str(cancelled.id)]
     assert [item["content"] for item in messages] == [
         "completed-message",
-        "cancelled-message",
+        "cancelled-message\n\n"
+        "[Previous assistant response was interrupted by the user.]",
     ]
+
+
+def test_internal_chat_history_omits_empty_completed_assistant(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+):
+    task_id = 9528
+    _create_task_resource(test_db, user_id=test_user.id, task_id=task_id)
+    _create_subtask(
+        test_db,
+        user_id=test_user.id,
+        task_id=task_id,
+        message_id=1,
+        status=SubtaskStatus.COMPLETED,
+        content="",
+        result_override={
+            "value": "",
+            "messages_chain": [{"role": "assistant", "content": ""}],
+        },
+    )
+
+    response = test_client.get(f"/api/internal/chat/history/task-{task_id}")
+
+    assert response.status_code == 200
+    assert response.json()["messages"] == []
 
 
 def test_internal_chat_history_includes_failed_only_when_value_exists(

--- a/backend/tests/api/ws/test_chat_namespace_task_join.py
+++ b/backend/tests/api/ws/test_chat_namespace_task_join.py
@@ -144,6 +144,10 @@ async def test_chat_cancel_waits_for_runtime_ack_without_faking_terminal_state()
             "app.services.execution.dispatcher.execution_dispatcher.cancel",
             AsyncMock(return_value=True),
         ) as cancel_mock,
+        patch(
+            "app.services.chat.operations.cancel.is_stream_alive",
+            AsyncMock(return_value=True),
+        ),
     ):
         result = await namespace.on_chat_cancel(
             "sid-1",
@@ -189,6 +193,10 @@ async def test_chat_cancel_reports_runtime_rejection() -> None:
             "app.services.execution.dispatcher.execution_dispatcher.cancel",
             AsyncMock(return_value=False),
         ),
+        patch(
+            "app.services.chat.operations.cancel.is_stream_alive",
+            AsyncMock(return_value=True),
+        ),
     ):
         result = await namespace.on_chat_cancel(
             "sid-1",
@@ -196,6 +204,55 @@ async def test_chat_cancel_reports_runtime_rejection() -> None:
         )
 
     assert result == {"error": "Runtime did not acknowledge cancellation"}
+
+
+@pytest.mark.asyncio
+async def test_chat_cancel_finalizes_when_stream_runtime_is_gone() -> None:
+    """A dead stream has no consumer for the cancel flag and no terminal
+    callback, so the request path must finalize the cancellation itself."""
+
+    namespace = ChatNamespace()
+    namespace.get_session = AsyncMock(return_value={"user_id": 1})
+    namespace._check_token_expiry = AsyncMock(return_value=False)
+
+    async def run_sync_side_effect(func, *args):
+        if func.__name__ == "_get_subtask_for_cancel":
+            return {
+                "task_id": 101,
+                "status": SubtaskStatus.RUNNING,
+                "executor_name": None,
+            }
+        if func.__name__ == "_mark_task_and_board_cancelling":
+            return None
+        if func.__name__ == "_finalize_stuck_cancellation":
+            return [55]
+        raise AssertionError(f"Unexpected sync function: {func.__name__}")
+
+    with (
+        patch(
+            "app.api.ws.chat_namespace.run_sync_in_executor",
+            AsyncMock(side_effect=run_sync_side_effect),
+        ),
+        patch(
+            "app.services.execution.dispatcher.execution_dispatcher.cancel",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "app.services.chat.operations.cancel.is_stream_alive",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.chat.operations.cancel.publish_task_cancelled_events",
+            AsyncMock(),
+        ) as publish_mock,
+    ):
+        result = await namespace.on_chat_cancel(
+            "sid-1",
+            {"subtask_id": 55, "shell_type": "Chat"},
+        )
+
+    assert result == {"success": True, "finalized": True}
+    publish_mock.assert_awaited_once_with(101, [55], 1)
 
 
 def test_native_cancel_atomically_records_linked_board_intent(

--- a/backend/tests/services/chat/operations/test_cancel_stuck.py
+++ b/backend/tests/services/chat/operations/test_cancel_stuck.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for stuck-cancellation recovery in chat cancel operations."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.subtask import SubtaskRole, SubtaskStatus
+from app.services.chat.operations import cancel as cancel_ops
+from app.services.chat.operations.cancel import (
+    finalize_stuck_cancellation,
+    is_stream_alive,
+)
+
+
+def _task_json(status: str) -> dict:
+    return {
+        "apiVersion": "agent.wecode.io/v1",
+        "kind": "Task",
+        "metadata": {"name": "task-1", "namespace": "default"},
+        "spec": {
+            "title": "t",
+            "prompt": "p",
+            "teamRef": {"name": "team", "namespace": "default"},
+            "workspaceRef": {"name": "ws", "namespace": "default"},
+        },
+        "status": {"status": status, "progress": 0},
+    }
+
+
+def _streaming_status(subtask_id: int, last_activity_at: datetime) -> dict:
+    return {
+        "subtask_id": subtask_id,
+        "user_id": 7,
+        "username": "u",
+        "started_at": last_activity_at.isoformat(),
+        "last_activity_at": last_activity_at.isoformat(),
+    }
+
+
+class TestIsStreamAlive:
+    @pytest.mark.asyncio
+    async def test_dead_when_no_streaming_key(self):
+        fake_manager = SimpleNamespace(
+            get_task_streaming_status=AsyncMock(return_value=None)
+        )
+        with patch("app.services.chat.storage.session_manager", fake_manager):
+            assert await is_stream_alive(1, 100) is False
+
+    @pytest.mark.asyncio
+    async def test_dead_when_key_belongs_to_other_subtask(self):
+        fake_manager = SimpleNamespace(
+            get_task_streaming_status=AsyncMock(
+                return_value=_streaming_status(999, datetime.now(timezone.utc))
+            )
+        )
+        with patch("app.services.chat.storage.session_manager", fake_manager):
+            assert await is_stream_alive(1, 100) is False
+
+    @pytest.mark.asyncio
+    async def test_dead_when_activity_stale(self):
+        stale = datetime.now(timezone.utc) - timedelta(seconds=7200)
+        fake_manager = SimpleNamespace(
+            get_task_streaming_status=AsyncMock(
+                return_value=_streaming_status(100, stale)
+            )
+        )
+        with patch("app.services.chat.storage.session_manager", fake_manager):
+            assert await is_stream_alive(1, 100) is False
+
+    @pytest.mark.asyncio
+    async def test_alive_when_activity_fresh(self):
+        fresh = datetime.now(timezone.utc) - timedelta(seconds=5)
+        fake_manager = SimpleNamespace(
+            get_task_streaming_status=AsyncMock(
+                return_value=_streaming_status(100, fresh)
+            )
+        )
+        with patch("app.services.chat.storage.session_manager", fake_manager):
+            assert await is_stream_alive(1, 100) is True
+
+
+class TestFinalizeStuckCancellation:
+    def _patched_stores(self, task, subtasks):
+        task_store = SimpleNamespace(
+            get_regular_active_task=MagicMock(return_value=task),
+            update_json=MagicMock(),
+        )
+        subtask_store = SimpleNamespace(
+            list_by_task_statuses=MagicMock(return_value=subtasks),
+            update_fields=MagicMock(),
+        )
+        return task_store, subtask_store
+
+    def test_finalizes_running_assistant_and_task(self):
+        task = SimpleNamespace(id=1, user_id=7, json=_task_json("CANCELLING"))
+        assistant = SimpleNamespace(
+            id=100, role=SubtaskRole.ASSISTANT, status=SubtaskStatus.RUNNING
+        )
+        user_subtask = SimpleNamespace(
+            id=99, role=SubtaskRole.USER, status=SubtaskStatus.RUNNING
+        )
+        task_store, subtask_store = self._patched_stores(
+            task, [user_subtask, assistant]
+        )
+
+        with (
+            patch.object(cancel_ops, "task_store", task_store),
+            patch.object(cancel_ops, "subtask_store", subtask_store),
+        ):
+            db = MagicMock()
+            finalized = finalize_stuck_cancellation(db, task_id=1)
+
+        assert finalized == [100]
+        # Only the assistant subtask is cancelled
+        assert subtask_store.update_fields.call_count == 1
+        kwargs = subtask_store.update_fields.call_args.kwargs
+        assert kwargs["subtask"] is assistant
+        assert kwargs["status"] == SubtaskStatus.CANCELLED
+        # Task is written as CANCELLED
+        payload = task_store.update_json.call_args.kwargs["payload"]
+        assert payload["status"]["status"] == "CANCELLED"
+        db.commit.assert_called_once()
+
+    def test_noop_when_task_already_final(self):
+        task = SimpleNamespace(id=1, user_id=7, json=_task_json("CANCELLED"))
+        task_store, subtask_store = self._patched_stores(task, [])
+
+        with (
+            patch.object(cancel_ops, "task_store", task_store),
+            patch.object(cancel_ops, "subtask_store", subtask_store),
+        ):
+            db = MagicMock()
+            finalized = finalize_stuck_cancellation(db, task_id=1)
+
+        assert finalized == []
+        subtask_store.list_by_task_statuses.assert_not_called()
+        task_store.update_json.assert_not_called()
+        db.commit.assert_not_called()
+
+    def test_noop_when_task_missing(self):
+        task_store, subtask_store = self._patched_stores(None, [])
+
+        with (
+            patch.object(cancel_ops, "task_store", task_store),
+            patch.object(cancel_ops, "subtask_store", subtask_store),
+        ):
+            db = MagicMock()
+            finalized = finalize_stuck_cancellation(db, task_id=1)
+
+        assert finalized == []
+        task_store.update_json.assert_not_called()
+
+
+class TestRestCancelStuckRecovery:
+    """REST cancel_task must finalize tasks stuck in CANCELLING."""
+
+    def _make_service(self):
+        from app.services.adapters.task_kinds.operations import TaskOperationsMixin
+
+        return object.__new__(TaskOperationsMixin)
+
+    @pytest.mark.asyncio
+    async def test_stuck_cancelling_is_finalized(self):
+        svc = self._make_service()
+        old = datetime.now() - timedelta(seconds=3600)
+        svc.get_task_detail = MagicMock(
+            return_value={"status": "CANCELLING", "updated_at": old}
+        )
+
+        with (
+            patch.object(
+                cancel_ops, "finalize_stuck_cancellation", MagicMock(return_value=[100])
+            ) as mock_finalize,
+            patch.object(
+                cancel_ops, "publish_task_cancelled_events", AsyncMock()
+            ) as mock_publish,
+        ):
+            result = await svc.cancel_task(db=MagicMock(), task_id=1, user_id=7)
+
+        assert result["status"] == "CANCELLED"
+        mock_finalize.assert_called_once()
+        mock_publish.assert_awaited_once_with(1, [100], 7)
+
+    @pytest.mark.asyncio
+    async def test_fresh_cancelling_returns_early(self):
+        svc = self._make_service()
+        svc.get_task_detail = MagicMock(
+            return_value={"status": "CANCELLING", "updated_at": datetime.now()}
+        )
+
+        with patch.object(
+            cancel_ops, "finalize_stuck_cancellation", MagicMock()
+        ) as mock_finalize:
+            result = await svc.cancel_task(db=MagicMock(), task_id=1, user_id=7)
+
+        assert result["status"] == "CANCELLING"
+        mock_finalize.assert_not_called()

--- a/frontend/e2e/tests/tasks/task-runtime-consistency.spec.ts
+++ b/frontend/e2e/tests/tasks/task-runtime-consistency.spec.ts
@@ -15,6 +15,8 @@ const TEST_PREFIX = `e2e-runtime-${Date.now()}-${Math.random().toString(36).slic
 const TEST_MODEL_NAME = `${TEST_PREFIX}-model`
 const TEST_BOT_NAME = `${TEST_PREFIX}-bot`
 const TEST_TEAM_NAME = `${TEST_PREFIX}-team`
+const INTERRUPTED_ASSISTANT_CONTEXT_NOTE =
+  '[Previous assistant response was interrupted by the user.]'
 
 type RuntimeCheckResponse = {
   task_id: number
@@ -34,6 +36,19 @@ type RuntimeCheckTracker = {
 type SocketDropOptions = {
   chatEvents?: string[]
   terminalTaskStatuses?: string[]
+}
+
+type CapturedModelMessage = {
+  role?: string
+  content?: unknown
+  tool_calls?: unknown
+}
+
+type CapturedModelRequest = {
+  url: string
+  body?: {
+    messages?: CapturedModelMessage[]
+  } | null
 }
 
 test.describe.configure({ mode: 'serial' })
@@ -432,6 +447,60 @@ test.describe('Task runtime consistency', () => {
     await expectNoQueuedMessages(page)
   })
 
+  test('continues the same conversation after cancelling a partial response', async ({
+    page,
+    request,
+  }) => {
+    const messageText = `${TEST_PREFIX} cancel partial response request`
+    const responseMarker = `${TEST_PREFIX}-cancel-partial-response`
+    const followUpMessage = `${TEST_PREFIX} send a follow-up after the interrupted response`
+    const followUpMarker = `${TEST_PREFIX}-cancel-follow-up-response`
+
+    await configureStreamRule(request, messageText, {
+      responseContent: `${responseMarker} keeps streaming until the browser cancels this response`,
+      chunkDelayMs: 250,
+      doneDelayMs: 20000,
+    })
+    await configureStreamRule(request, followUpMessage, {
+      responseContent: `${followUpMarker} is non-empty after cancellation`,
+      chunkDelayMs: 40,
+    })
+
+    await gotoChatWithTestTeam(page)
+    await sendChatMessage(page, messageText)
+
+    const taskId = await waitForTaskId(page)
+    await expect(page.getByTestId('messages-container')).toContainText(responseMarker, {
+      timeout: 15000,
+    })
+
+    await stopActiveStream(page)
+    await waitForBackendStatus(request, taskId, ['CANCELLED'])
+
+    await sendChatMessage(page, followUpMessage)
+    expect(new URL(page.url()).searchParams.get('taskId')).toBe(String(taskId))
+    await expect(page.getByTestId('messages-container')).toContainText(followUpMarker, {
+      timeout: 30000,
+    })
+    await waitForBackendTerminal(request, taskId)
+
+    const followUpRequest = await waitForCapturedModelRequest(request, followUpMessage)
+    const requestText = extractText(followUpRequest.body)
+    expect(requestText).toContain(responseMarker)
+    expect(requestText).toContain(INTERRUPTED_ASSISTANT_CONTEXT_NOTE)
+
+    const assistantMessages = followUpRequest.body?.messages?.filter(
+      message => message.role === 'assistant'
+    )
+    expect(assistantMessages?.length).toBeGreaterThan(0)
+    expect(
+      assistantMessages?.every(
+        message => Boolean(message.tool_calls) || extractText(message.content).trim().length > 0
+      )
+    ).toBe(true)
+    await expectNoQueuedMessages(page)
+  })
+
   async function createTestResources(request: APIRequestContext): Promise<void> {
     const modelResponse = await request.post(`${API_BASE_URL}/api/v1/namespaces/default/models`, {
       headers: authHeaders(),
@@ -632,6 +701,54 @@ test.describe('Task runtime consistency', () => {
         return text ? text.split(marker).length - 1 : 0
       })
       .toBe(1)
+  }
+
+  async function waitForCapturedModelRequest(
+    request: APIRequestContext,
+    messageText: string
+  ): Promise<CapturedModelRequest> {
+    let matchedRequest: CapturedModelRequest | undefined
+
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get(`${MOCK_MODEL_SERVER_URL}/captured-requests`)
+          if (response.status() !== 200) {
+            return `HTTP_${response.status()}`
+          }
+
+          const captures = (await response.json()) as CapturedModelRequest[]
+          matchedRequest = captures.find(
+            capture =>
+              capture.url.includes('/chat/completions') &&
+              extractText(capture.body).includes(messageText)
+          )
+          return matchedRequest ? 'FOUND' : 'MISSING'
+        },
+        {
+          message: `Mock model should receive a request containing: ${messageText}`,
+          timeout: 30000,
+        }
+      )
+      .toBe('FOUND')
+
+    return matchedRequest!
+  }
+
+  function extractText(value: unknown): string {
+    if (typeof value === 'string') {
+      return value
+    }
+    if (Array.isArray(value)) {
+      return value.map(item => extractText(item)).join(' ')
+    }
+    if (value && typeof value === 'object') {
+      const objectValue = value as Record<string, unknown>
+      return ['messages', 'system', 'input', 'content', 'text', 'prompt']
+        .map(key => extractText(objectValue[key]))
+        .join(' ')
+    }
+    return ''
   }
 
   async function waitForTaskId(page: Page): Promise<number> {


### PR DESCRIPTION
## Summary

- detect when a task streaming runtime is missing or stale during cancellation
- finalize stuck task and assistant subtask cancellation locally, then publish cancellation events
- recover REST cancellations that remain in `CANCELLING` beyond the configured timeout
- mark cancelled partial assistant output as interrupted before reusing it as model history
- omit empty assistant completions so later messages are not poisoned by blank turns
- add focused WebSocket, service, and chat-history regression coverage
- add a CI-covered Playwright regression for cancelling a partial response and receiving a non-empty follow-up in the same conversation

## Testing

- `cd backend && uv run pytest -q tests/api/endpoints/test_internal_chat_storage_history.py tests/services/chat/operations/test_cancel_stuck.py tests/api/ws/test_chat_namespace_task_join.py` (20 passed)
- `uv run black --check app/api/endpoints/internal/chat_storage.py tests/api/endpoints/test_internal_chat_storage_history.py`
- `uv run isort --check-only app/api/endpoints/internal/chat_storage.py tests/api/endpoints/test_internal_chat_storage_history.py`
- `pnpm --dir frontend exec prettier --check e2e/tests/tasks/task-runtime-consistency.spec.ts`
- `pnpm --dir frontend exec eslint e2e/tests/tasks/task-runtime-consistency.spec.ts`
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- Playwright discovery lists the new scenario in Chromium shard 1/4
- GitHub Actions `Run E2E tests (Sharded)` completed successfully for shard 1/4, including the new cancellation follow-up scenario
- pre-push Frontend ESLint, TypeScript, and unit tests passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellations now complete successfully when the streaming runtime is no longer active.
  * Tasks stuck in cancellation are automatically finalized as cancelled after the configured timeout.
  * Cancellation events are published after stuck tasks are finalized.
  * Active cancellation requests continue to wait for the existing cancellation process.
  * Cancelled responses with partial output are clearly marked as interrupted in chat history.
  * Empty cancelled or completed assistant entries are omitted from chat history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->