### PR TITLE
feat(device): expose interactive session switches in Docker command

### DIFF
--- a/backend/app/services/device/remote_device_startup.py
+++ b/backend/app/services/device/remote_device_startup.py
@@ -263,6 +263,8 @@ class DefaultRemoteDeviceCommandProvider:
             "DEVICE_ID": context.device_id,
             "DEVICE_NAME": context.device_name,
             "EXECUTOR_MODE": "local",
+            "DEVICE_CODE_SERVER_ENABLED": "true",
+            "DEVICE_TERMINAL_ENABLED": "true",
             "WEGENT_EXECUTOR_HOME_ID": context.device_id,
             "WEGENT_WORKTREE_PERSISTENT_STORAGE_VERIFIED": "true",
             "WEGENT_BACKEND_URL": backend_url,

--- a/backend/tests/services/test_remote_device_startup.py
+++ b/backend/tests/services/test_remote_device_startup.py
@@ -36,12 +36,16 @@ def test_remote_docker_command_binds_device_identity_to_stable_home(monkeypatch)
 
     assert first.command == rebuilt.command
     assert first.env["DEVICE_ID"] == "device-stable-1"
+    assert first.env["DEVICE_CODE_SERVER_ENABLED"] == "true"
+    assert first.env["DEVICE_TERMINAL_ENABLED"] == "true"
     assert first.env["WEGENT_EXECUTOR_HOME_ID"] == "device-stable-1"
     assert first.env["WEGENT_WORKTREE_PERSISTENT_STORAGE_VERIFIED"] == "true"
     assert (
         "-v remote-device-1-home:/home/wegent/.wecode/wegent-executor" in first.command
     )
     assert "-e WEGENT_WORKTREE_PERSISTENT_STORAGE_VERIFIED=true" in first.command
+    assert "-e DEVICE_CODE_SERVER_ENABLED=true" in first.command
+    assert "-e DEVICE_TERMINAL_ENABLED=true" in first.command
     assert "WEGENT_EXECUTOR_HOME_ID" not in first.commands[1].command
     assert (
         "WEGENT_WORKTREE_PERSISTENT_STORAGE_VERIFIED" not in first.commands[1].command


### PR DESCRIPTION
## Summary

- expose `DEVICE_CODE_SERVER_ENABLED=true` in generated remote Docker commands
- expose `DEVICE_TERMINAL_ENABLED=true` so users can disable terminal access per container
- cover the generated environment and command flags with a focused provider contract test

## Testing

- `cd backend && uv run pytest tests/services/test_remote_device_startup.py -q`
- `cd backend && uv run black --check app/services/device/remote_device_startup.py tests/services/test_remote_device_startup.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote devices now automatically enable the code server and terminal when they start, providing access to browser-based development tools and terminal functionality.

- **Tests**
  - Added coverage to verify that both features are enabled consistently during remote device startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->