### PR TITLE
fix(executor): propagate Claude context window

### DIFF
--- a/executor/src/agents/claude_code.rs
+++ b/executor/src/agents/claude_code.rs
@@ -36,6 +36,7 @@ use crate::{
 
 const FILE_EDIT_HOOK_COMMAND_ENV: &str = "WEGENT_FILE_EDIT_HOOK_COMMAND";
 const CLAUDE_FILE_EDIT_HOOK_MATCHER: &str = "Write|Edit|MultiEdit|NotebookEdit";
+const CLAUDE_MAX_CONTEXT_TOKENS_ENV: &str = "CLAUDE_CODE_MAX_CONTEXT_TOKENS";
 const SKILL_MANIFEST_FILE: &str = ".wegent-skills.json";
 const DEFAULT_CLAUDE_MODEL_ENV: &[&str] = &[
     "ANTHROPIC_DEFAULT_HAIKU_MODEL",
@@ -474,7 +475,7 @@ pub(crate) fn model_id(request: &ExecutionRequest) -> Option<String> {
 fn apply_model_environment(mut spec: CommandSpec, request: &ExecutionRequest) -> CommandSpec {
     let env_values = model_env(request);
     for (key, value) in &env_values {
-        if is_process_env_key(key) {
+        if key != CLAUDE_MAX_CONTEXT_TOKENS_ENV && is_process_env_key(key) {
             spec = spec.env(key, value);
         }
     }
@@ -491,9 +492,59 @@ fn apply_model_environment(mut spec: CommandSpec, request: &ExecutionRequest) ->
         }
     }
 
+    spec = apply_model_context_window_environment(spec, request);
     spec = apply_default_model_environment(spec, request);
 
     spec
+}
+
+fn apply_model_context_window_environment(
+    spec: CommandSpec,
+    request: &ExecutionRequest,
+) -> CommandSpec {
+    let Some((context_window, source)) = resolved_claude_context_window(request) else {
+        return spec;
+    };
+
+    let mut fields = task_fields(&request.task_id, &request.subtask_id);
+    fields.push(("context_window_tokens", context_window.to_string()));
+    fields.push(("context_window_source", source.to_owned()));
+    log_executor_event("claude context window configured", &fields);
+
+    spec.env(CLAUDE_MAX_CONTEXT_TOKENS_ENV, context_window.to_string())
+}
+
+fn resolved_claude_context_window(request: &ExecutionRequest) -> Option<(i64, &'static str)> {
+    if let Some(context_window) = model_string(request, CLAUDE_MAX_CONTEXT_TOKENS_ENV)
+        .and_then(|value| positive_context_window(&Value::String(value)))
+    {
+        return Some((context_window, "explicit_env"));
+    }
+
+    if let Some(context_window) = claude_model_context_window(&request.model_config) {
+        return Some((context_window, "model_config"));
+    }
+
+    process_model_environment(CLAUDE_MAX_CONTEXT_TOKENS_ENV)
+        .and_then(|value| positive_context_window(&Value::String(value)))
+        .map(|context_window| (context_window, "process_env"))
+}
+
+fn claude_model_context_window(model_config: &Value) -> Option<i64> {
+    model_config
+        .get("model_context_window")
+        .or_else(|| model_config.get("context_window"))
+        .or_else(|| model_config.get("contextWindow"))
+        .and_then(positive_context_window)
+}
+
+fn positive_context_window(value: &Value) -> Option<i64> {
+    let context_window = match value {
+        Value::Number(value) => value.as_i64(),
+        Value::String(value) => value.trim().parse().ok(),
+        _ => None,
+    }?;
+    (context_window > 0).then_some(context_window)
 }
 
 fn apply_default_model_environment(

--- a/executor/tests/agent_command_contract.rs
+++ b/executor/tests/agent_command_contract.rs
@@ -175,6 +175,117 @@ fn claude_command_maps_nested_model_env_to_process_environment() {
 }
 
 #[test]
+fn claude_command_maps_supported_context_window_fields_to_process_environment() {
+    let _lock = env_lock();
+    let _process_context = EnvGuard::remove("CLAUDE_CODE_MAX_CONTEXT_TOKENS");
+    let cases = [
+        ("model_context_window", json!(1_000_000)),
+        ("context_window", json!(200_000)),
+        ("contextWindow", json!("128000")),
+    ];
+
+    for (key, value) in cases {
+        let request = ExecutionRequest {
+            prompt: json!("run locally"),
+            model_config: json!({key: value}),
+            ..ExecutionRequest::default()
+        };
+
+        let spec = build_claude_command(&request, "claude");
+
+        let expected = match key {
+            "model_context_window" => "1000000",
+            "context_window" => "200000",
+            "contextWindow" => "128000",
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            spec.envs().get("CLAUDE_CODE_MAX_CONTEXT_TOKENS").unwrap(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn claude_command_ignores_invalid_context_window_values() {
+    let _lock = env_lock();
+    let _process_context = EnvGuard::remove("CLAUDE_CODE_MAX_CONTEXT_TOKENS");
+
+    for value in [json!(0), json!(-1), json!(true), json!("invalid")] {
+        let request = ExecutionRequest {
+            prompt: json!("run locally"),
+            model_config: json!({"context_window": value}),
+            ..ExecutionRequest::default()
+        };
+
+        let spec = build_claude_command(&request, "claude");
+
+        assert!(!spec.envs().contains_key("CLAUDE_CODE_MAX_CONTEXT_TOKENS"));
+    }
+
+    let invalid_explicit_env = ExecutionRequest {
+        prompt: json!("run locally"),
+        model_config: json!({
+            "env": {"CLAUDE_CODE_MAX_CONTEXT_TOKENS": "invalid"}
+        }),
+        ..ExecutionRequest::default()
+    };
+
+    let spec = build_claude_command(&invalid_explicit_env, "claude");
+
+    assert!(!spec.envs().contains_key("CLAUDE_CODE_MAX_CONTEXT_TOKENS"));
+}
+
+#[test]
+fn claude_command_applies_context_window_precedence() {
+    let _lock = env_lock();
+    let _process_context = EnvGuard::set("CLAUDE_CODE_MAX_CONTEXT_TOKENS", "262144");
+    let request_context = ExecutionRequest {
+        prompt: json!("run locally"),
+        model_config: json!({"context_window": 1_000_000}),
+        ..ExecutionRequest::default()
+    };
+    let explicit_context = ExecutionRequest {
+        prompt: json!("run locally"),
+        model_config: json!({
+            "context_window": 1_000_000,
+            "env": {"CLAUDE_CODE_MAX_CONTEXT_TOKENS": "524288"}
+        }),
+        ..ExecutionRequest::default()
+    };
+    let process_context = ExecutionRequest {
+        prompt: json!("run locally"),
+        ..ExecutionRequest::default()
+    };
+
+    let request_spec = build_claude_command(&request_context, "claude");
+    let explicit_spec = build_claude_command(&explicit_context, "claude");
+    let process_spec = build_claude_command(&process_context, "claude");
+
+    assert_eq!(
+        request_spec
+            .envs()
+            .get("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
+            .unwrap(),
+        "1000000"
+    );
+    assert_eq!(
+        explicit_spec
+            .envs()
+            .get("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
+            .unwrap(),
+        "524288"
+    );
+    assert_eq!(
+        process_spec
+            .envs()
+            .get("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
+            .unwrap(),
+        "262144"
+    );
+}
+
+#[test]
 fn claude_command_uses_explicit_default_models_when_set() {
     let _lock = env_lock();
     let _default_haiku = EnvGuard::set("ANTHROPIC_DEFAULT_HAIKU_MODEL", "process-haiku");

--- a/executor/tests/agent_process_engine_contract.rs
+++ b/executor/tests/agent_process_engine_contract.rs
@@ -1056,6 +1056,7 @@ async fn agent_process_engine_writes_default_claude_settings_before_claude() {
 settings="$CLAUDE_CONFIG_DIR/settings.json"
 python3 - "$settings" <<'PY'
 import json
+import os
 import sys
 
 settings_path = sys.argv[1]
@@ -1065,6 +1066,7 @@ payload = {
     "includeCoAuthoredBy": settings.get("includeCoAuthoredBy"),
     "skipDangerousModePermissionPrompt": settings.get("skipDangerousModePermissionPrompt"),
     "env": settings.get("env", {}),
+    "maxContextTokens": os.environ.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS"),
 }
 print(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": json.dumps(payload, sort_keys=True)}]}}))
 PY
@@ -1078,7 +1080,11 @@ PY
         task_id: "86".to_owned(),
         prompt: json!("inspect default settings"),
         bot: json!([{"id": 326, "shell_type": "ClaudeCode"}]),
-        model_config: json!({"model": "anthropic", "model_id": "claude-sonnet-4"}),
+        model_config: json!({
+            "model": "anthropic",
+            "model_id": "claude-sonnet-4",
+            "context_window": 1_000_000
+        }),
         ..ExecutionRequest::default()
     };
 
@@ -1101,6 +1107,7 @@ PY
         "0"
     );
     assert_eq!(payload["env"]["ENABLE_TOOL_SEARCH"], "false");
+    assert_eq!(payload["maxContextTokens"], "1000000");
 }
 
 #[cfg(unix)]
@@ -1115,6 +1122,7 @@ async fn agent_process_engine_uses_process_env_for_claude_settings_env() {
 settings="$CLAUDE_CONFIG_DIR/settings.json"
 python3 - "$settings" <<'PY'
 import json
+import os
 import sys
 
 settings_path = sys.argv[1]


### PR DESCRIPTION
## Summary

- propagate supported model context-window fields to `CLAUDE_CODE_MAX_CONTEXT_TOKENS` for Claude Code
- preserve precedence: explicit model environment, request model config, then inherited process environment
- ignore invalid or non-positive context-window values and log the selected value/source without sensitive data
- keep existing Claude defaults, including `ENABLE_TOOL_SEARCH=false`

## Tests

- `cargo fmt --all -- --check`
- `cargo test --locked --test agent_command_contract claude_command` (27 passed)
- `cargo test --locked --test agent_process_engine_contract` (21 passed)
- `cargo check --locked`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code now supports configuring the maximum context window through model settings, request settings, or the process environment.
  * Supported context-window configuration formats are recognized and applied automatically.
  * Configuration precedence is now explicit: model environment settings override request settings, which override process environment values.

* **Bug Fixes**
  * Invalid or non-positive context-window values are ignored instead of being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->