### PR TITLE
security: remove git credential ORM state mutation

### DIFF
--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -502,13 +502,17 @@ class UserService(BaseService[User, UserUpdate, UserUpdate]):
         return user_list
 
     def decrypt_user_git_info(self, user: User) -> User:
-        """Return a decrypted view of *user* without touching session state.
+        """Return a decrypted read view of *user* without touching session state.
 
-        Decrypted tokens must never land on the session-attached ORM object:
-        a getter that mutates tracked state leaves plaintext in the identity
-        map, one refactor away from being persisted by an unrelated commit.
-        The plaintext view is therefore built on a detached copy of the row;
-        the session-attached instance keeps ciphertext.
+        Decrypted tokens must never land on the session-attached ORM object: a
+        getter that mutates tracked state leaves plaintext in the identity map,
+        one refactor away from being persisted by an unrelated commit. The view
+        is therefore a transient copy of the row (never re-attach or commit
+        it); the session-attached instance keeps ciphertext and stays clean.
+
+        The copy is returned for every git_info shape (None, empty list,
+        encrypted, plaintext legacy, missing token key), so this read path can
+        never hand out the original session-attached instance.
 
         Callers only read attributes (user.id, user.git_info values), so the
         copy is transparent to them. Nobody may re-attach or commit the
@@ -517,23 +521,22 @@ class UserService(BaseService[User, UserUpdate, UserUpdate]):
         if user is None:
             return user
 
-        if user.git_info is None:
-            return user
-
-        decrypted_items = []
-        for git_item in user.git_info:
-            token = git_item.get("git_token")
-            if token and is_token_encrypted(token):
-                decrypted_items.append(
-                    {**git_item, "git_token": decrypt_git_token(token)}
-                )
-            else:
-                decrypted_items.append(dict(git_item))
-
         plain_view = User()
         for column in user.__table__.columns:
             setattr(plain_view, column.name, getattr(user, column.name))
-        plain_view.git_info = decrypted_items
+
+        if user.git_info is not None:
+            decrypted_items = []
+            for git_item in user.git_info:
+                token = git_item.get("git_token")
+                if token and is_token_encrypted(token):
+                    decrypted_items.append(
+                        {**git_item, "git_token": decrypt_git_token(token)}
+                    )
+                else:
+                    decrypted_items.append(dict(git_item))
+            plain_view.git_info = decrypted_items
+
         return plain_view
 
 

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -502,23 +502,39 @@ class UserService(BaseService[User, UserUpdate, UserUpdate]):
         return user_list
 
     def decrypt_user_git_info(self, user: User) -> User:
+        """Return a decrypted view of *user* without touching session state.
+
+        Decrypted tokens must never land on the session-attached ORM object:
+        a getter that mutates tracked state leaves plaintext in the identity
+        map, one refactor away from being persisted by an unrelated commit.
+        The plaintext view is therefore built on a detached copy of the row;
+        the session-attached instance keeps ciphertext.
+
+        Callers only read attributes (user.id, user.git_info values), so the
+        copy is transparent to them. Nobody may re-attach or commit the
+        returned object: it is a read view, not a persistent instance.
+        """
         if user is None:
             return user
 
-        # Check if git_info is None or empty
         if user.git_info is None:
             return user
 
-        decrypt_git_info = []
-
+        decrypted_items = []
         for git_item in user.git_info:
-            plain_token = git_item["git_token"]
-            if is_token_encrypted(plain_token):
-                git_item["git_token"] = decrypt_git_token(plain_token)
+            token = git_item.get("git_token")
+            if token and is_token_encrypted(token):
+                decrypted_items.append(
+                    {**git_item, "git_token": decrypt_git_token(token)}
+                )
+            else:
+                decrypted_items.append(dict(git_item))
 
-            decrypt_git_info.append(git_item)
-        user.git_info = decrypt_git_info
-        return user
+        plain_view = User()
+        for column in user.__table__.columns:
+            setattr(plain_view, column.name, getattr(user, column.name))
+        plain_view.git_info = decrypted_items
+        return plain_view
 
 
 user_service = UserService(User)

--- a/backend/tests/security/test_git_secret_hygiene.py
+++ b/backend/tests/security/test_git_secret_hygiene.py
@@ -83,7 +83,8 @@ def _raw_git_info(engine, user_id: int):
 
 def _assert_transient_read_view(view, attached, db) -> None:
     """Lock the ownership contract: the view is a transient copy, never the
-    session-attached instance, and not registered with the session."""
+    session-attached instance, and not registered with the session. The view
+    must also not share any mutable container with the attached instance."""
     assert view is not attached
     state = sa_inspect(view)
     assert state.transient
@@ -92,6 +93,11 @@ def _assert_transient_read_view(view, attached, db) -> None:
     assert view not in db.dirty
     assert view not in db.new
     assert view not in db.deleted
+    if view.git_info is not None:
+        assert view.git_info is not attached.git_info
+        for view_item, attached_item in zip(view.git_info, attached.git_info):
+            if isinstance(view_item, dict):
+                assert view_item is not attached_item
 
 
 def _assert_attached_clean(attached, db) -> None:
@@ -136,7 +142,13 @@ def test_getter_leaves_no_dirty_state(db_engine) -> None:
 
 
 def test_commit_after_getter_keeps_db_ciphertext(db_engine) -> None:
-    """The admin-path sequence (getter then an unrelated commit)."""
+    """A bare unrelated commit after the getter leaves the DB ciphertext.
+
+    Note this invariant also held on the vulnerable BASE code (value-equality
+    masked the in-place contamination); the persistence regression lock for
+    the real BASE exploit sequence (getter -> git_info rewrite -> commit) is
+    test_git_info_rewrite_after_getter_keeps_db_ciphertext.
+    """
     engine = db_engine
     with sessionmaker(bind=engine)() as db:
         user_id = _add_encrypted_user(db)
@@ -145,6 +157,46 @@ def test_commit_after_getter_keeps_db_ciphertext(db_engine) -> None:
         db.commit()
 
     assert is_token_encrypted(_raw_git_info(engine, user_id)[0]["git_token"])
+
+
+def test_git_info_rewrite_after_getter_keeps_db_ciphertext(db_engine) -> None:
+    """The proven BASE exploit sequence: decrypt getter, then a git_info
+    rewrite in the same session via the production write path, then commit.
+
+    On the vulnerable code the getter left plaintext on the session-attached
+    instance, so the rewrite (delete_git_token) persisted it to the database.
+    The stored ciphertext must survive this sequence.
+    """
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_user(
+            db,
+            "two-tokens",
+            [
+                {
+                    "type": "personal",
+                    "git_domain": "github.com",
+                    "git_token": encrypt_git_token(PLAIN_TOKEN),
+                },
+                {
+                    "type": "personal",
+                    "git_domain": "gitlab.com",
+                    "git_token": encrypt_git_token(PLAIN_LEGACY),
+                },
+            ],
+        )
+    with sessionmaker(bind=engine)() as db:
+        # Hold the attached instance BEFORE the getter runs: the vulnerable
+        # code contaminates it in place, and a reload after the getter would
+        # return a fresh (clean) instance via the weak identity map.
+        attached = db.query(User).filter(User.id == user_id).first()
+        user_service.get_user_by_id(db, user_id)  # decrypt read view
+        user_service.delete_git_token(db, user=attached, git_domain="gitlab.com")
+
+    remaining = _raw_git_info(engine, user_id)
+    assert len(remaining) == 1
+    assert is_token_encrypted(remaining[0]["git_token"])
+    assert remaining[0]["git_token"] != PLAIN_TOKEN
 
 
 def test_subsequent_same_session_reader_not_contaminated(db_engine) -> None:
@@ -252,11 +304,18 @@ def test_read_view_ownership_and_pass_through(db_engine, shape, stored) -> None:
 def test_git_auth_consumer_receives_plaintext_token(db_engine) -> None:
     """Production consumer regression: the git-skill auth resolver
     (git_skill.utils.get_auth_for_repo) receives the plaintext token while
-    the session-attached User keeps ciphertext and the DB is unchanged."""
+    the session-attached User keeps ciphertext and the DB is unchanged.
+
+    The attached instance is captured BEFORE the consumer runs, so a
+    regression that contaminates it in place cannot hide behind a reload.
+    """
     engine = db_engine
     with sessionmaker(bind=engine)() as db:
         user_id = _add_encrypted_user(db)
     with sessionmaker(bind=engine)() as db:
+        # Hold the instance the consumer will resolve from before it runs.
+        attached = db.query(User).filter(User.id == user_id).first()
+
         provider, owner, repo, auth_info = get_auth_for_repo(
             "https://github.com/wecode-ai/Wegent", user_id, db
         )
@@ -266,7 +325,8 @@ def test_git_auth_consumer_receives_plaintext_token(db_engine) -> None:
         assert owner == "wecode-ai"
         assert repo == "Wegent"
 
-        attached = db.query(User).filter(User.id == user_id).first()
+        # The very instance the consumer resolved from must still hold
+        # ciphertext and stay clean.
         assert is_token_encrypted(attached.git_info[0]["git_token"])
         _assert_attached_clean(attached, db)
 

--- a/backend/tests/security/test_git_secret_hygiene.py
+++ b/backend/tests/security/test_git_secret_hygiene.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Secret-state invariant: decrypting credentials for use must not mutate
+persistent ORM state into plaintext.
+
+Decrypting getters return a plaintext read view on a detached copy; the
+session-attached instance keeps ciphertext, the session never records a
+fake dirty state, and unrelated commits cannot persist plaintext.
+"""
+
+import json
+import os
+import tempfile
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import text
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("GIT_TOKEN_AES_KEY", "12345678901234567890123456789012")
+os.environ.setdefault("GIT_TOKEN_AES_IV", "1234567890abcdef")
+
+from app.db.base import Base
+from app.models.user import User
+from app.services.user import user_service
+from shared.utils.crypto import encrypt_git_token, is_token_encrypted
+
+PLAIN_TOKEN = "ghp_victimPlaintokenZz9"
+
+
+@pytest.fixture()
+def db_engine():
+    # Unique file per run: parallel xdist workers must not share one SQLite file.
+    db_path = os.path.join(tempfile.gettempdir(), f"sec_bug004_{uuid.uuid4().hex}.db")
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    with sessionmaker(bind=engine)() as db:
+        encrypted = encrypt_git_token(PLAIN_TOKEN)
+        assert is_token_encrypted(encrypted)
+        db.add(
+            User(
+                user_name="sec-hygiene",
+                password_hash="x",
+                email="sec-hygiene@example.com",
+                is_active=True,
+                git_info=[
+                    {
+                        "type": "personal",
+                        "git_domain": "github.com",
+                        "git_token": encrypted,
+                    }
+                ],
+            )
+        )
+        db.commit()
+        user_id = db.query(User).first().id
+    yield engine, user_id
+    engine.dispose()
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+
+def _raw_git_token(engine, user_id: int) -> str:
+    with engine.connect() as conn:
+        raw = conn.execute(
+            text("SELECT git_info FROM users WHERE id = :i"), {"i": user_id}
+        ).scalar()
+    items = json.loads(raw) if isinstance(raw, str) else raw
+    return items[0]["git_token"]
+
+
+def test_getter_returns_expected_plaintext(db_engine) -> None:
+    engine, user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        view = user_service.get_user_by_id(db, user_id)
+
+        assert view.git_info[0]["git_token"] == PLAIN_TOKEN
+
+
+def test_session_attached_object_keeps_ciphertext(db_engine) -> None:
+    engine, user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        view = user_service.get_user_by_id(db, user_id)
+
+        attached = db.query(User).filter(User.id == user_id).first()
+        assert attached is not view
+        assert attached.git_info[0]["git_token"] != PLAIN_TOKEN
+        assert is_token_encrypted(attached.git_info[0]["git_token"])
+
+
+def test_getter_leaves_no_dirty_state(db_engine) -> None:
+    engine, user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        view = user_service.get_user_by_id(db, user_id)
+        attached = db.query(User).filter(User.id == user_id).first()
+
+        assert view not in db.dirty
+        assert attached not in db.dirty
+        history = sa_inspect(attached).attrs.git_info.history
+        assert history.added == () and history.deleted == ()
+
+
+def test_commit_after_getter_keeps_db_ciphertext(db_engine) -> None:
+    """The admin-path sequence (getter then an unrelated commit)."""
+    engine, user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_service.get_user_by_id(db, user_id)
+        db.commit()
+
+    assert is_token_encrypted(_raw_git_token(engine, user_id))
+
+
+def test_subsequent_same_session_reader_not_contaminated(db_engine) -> None:
+    engine, user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_service.get_user_by_id(db, user_id)
+        # A later reader in the same session must not inherit plaintext.
+        again = user_service.get_user_by_id(db, user_id)
+        attached = db.query(User).filter(User.id == user_id).first()
+
+        assert is_token_encrypted(attached.git_info[0]["git_token"])
+        assert is_token_encrypted(_raw_git_token(engine, user_id))
+        assert again.git_info[0]["git_token"] == PLAIN_TOKEN
+
+
+def test_get_user_by_name_returns_plaintext_view(db_engine) -> None:
+    engine, user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        view = user_service.get_user_by_name(db, "sec-hygiene")
+
+        assert view.git_info[0]["git_token"] == PLAIN_TOKEN
+        assert view.id == user_id
+        assert view not in db.dirty
+
+
+def test_non_encrypted_and_missing_tokens_pass_through(db_engine) -> None:
+    """Users without stored tokens (or already-plaintext entries) are
+    returned unchanged and usable."""
+    engine, _user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        db.add(
+            User(
+                user_name="no-tokens",
+                password_hash="x",
+                email="no-tokens@example.com",
+                is_active=True,
+                git_info=None,
+            )
+        )
+        db.commit()
+        bare = db.query(User).filter(User.user_name == "no-tokens").first()
+
+        view = user_service.get_user_by_id(db, bare.id)
+
+        assert view.git_info is None
+
+
+def test_git_auth_flow_still_receives_plaintext_token(db_engine) -> None:
+    """The git-skill auth path consumes the plaintext token exactly as before."""
+    engine, user_id = db_engine
+    with sessionmaker(bind=engine)() as db:
+        view = user_service.get_user_by_id(db, user_id)
+        entry = view.git_info[0]
+
+        assert entry["git_domain"] == "github.com"
+        assert entry["git_token"] == PLAIN_TOKEN
+        assert is_token_encrypted(_raw_git_token(engine, user_id))

--- a/backend/tests/security/test_git_secret_hygiene.py
+++ b/backend/tests/security/test_git_secret_hygiene.py
@@ -5,9 +5,9 @@
 """Secret-state invariant: decrypting credentials for use must not mutate
 persistent ORM state into plaintext.
 
-Decrypting getters return a plaintext read view on a detached copy; the
-session-attached instance keeps ciphertext, the session never records a
-fake dirty state, and unrelated commits cannot persist plaintext.
+Decrypting getters return a plaintext read view built on a *transient* copy
+of the row; the session-attached instance keeps ciphertext, the session never
+records dirty state, and unrelated commits cannot persist plaintext.
 """
 
 import json
@@ -26,10 +26,12 @@ os.environ.setdefault("GIT_TOKEN_AES_IV", "1234567890abcdef")
 
 from app.db.base import Base
 from app.models.user import User
+from app.services.git_skill.utils import get_auth_for_repo
 from app.services.user import user_service
 from shared.utils.crypto import encrypt_git_token, is_token_encrypted
 
 PLAIN_TOKEN = "ghp_victimPlaintokenZz9"
+PLAIN_LEGACY = "ghp_legacyPlaintokenToken"
 
 
 @pytest.fixture()
@@ -41,43 +43,68 @@ def db_engine():
         connect_args={"check_same_thread": False},
     )
     Base.metadata.create_all(bind=engine)
-    with sessionmaker(bind=engine)() as db:
-        encrypted = encrypt_git_token(PLAIN_TOKEN)
-        assert is_token_encrypted(encrypted)
-        db.add(
-            User(
-                user_name="sec-hygiene",
-                password_hash="x",
-                email="sec-hygiene@example.com",
-                is_active=True,
-                git_info=[
-                    {
-                        "type": "personal",
-                        "git_domain": "github.com",
-                        "git_token": encrypted,
-                    }
-                ],
-            )
-        )
-        db.commit()
-        user_id = db.query(User).first().id
-    yield engine, user_id
+    yield engine
     engine.dispose()
     if os.path.exists(db_path):
         os.remove(db_path)
 
 
-def _raw_git_token(engine, user_id: int) -> str:
+def _add_user(db, user_name: str, git_info) -> int:
+    db.add(
+        User(
+            user_name=user_name,
+            password_hash="x",
+            email=f"{user_name}@example.com",
+            is_active=True,
+            git_info=git_info,
+        )
+    )
+    db.commit()
+    return db.query(User).filter(User.user_name == user_name).first().id
+
+
+def _add_encrypted_user(db) -> int:
+    encrypted = encrypt_git_token(PLAIN_TOKEN)
+    assert is_token_encrypted(encrypted)
+    return _add_user(
+        db,
+        "sec-hygiene",
+        [{"type": "personal", "git_domain": "github.com", "git_token": encrypted}],
+    )
+
+
+def _raw_git_info(engine, user_id: int):
     with engine.connect() as conn:
         raw = conn.execute(
             text("SELECT git_info FROM users WHERE id = :i"), {"i": user_id}
         ).scalar()
-    items = json.loads(raw) if isinstance(raw, str) else raw
-    return items[0]["git_token"]
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+def _assert_transient_read_view(view, attached, db) -> None:
+    """Lock the ownership contract: the view is a transient copy, never the
+    session-attached instance, and not registered with the session."""
+    assert view is not attached
+    state = sa_inspect(view)
+    assert state.transient
+    assert not state.persistent
+    assert not state.detached
+    assert view not in db.dirty
+    assert view not in db.new
+    assert view not in db.deleted
+
+
+def _assert_attached_clean(attached, db) -> None:
+    """The session-attached instance keeps its stored value and no history."""
+    assert attached not in db.dirty
+    history = sa_inspect(attached).attrs.git_info.history
+    assert history.added == () and history.deleted == ()
 
 
 def test_getter_returns_expected_plaintext(db_engine) -> None:
-    engine, user_id = db_engine
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_encrypted_user(db)
     with sessionmaker(bind=engine)() as db:
         view = user_service.get_user_by_id(db, user_id)
 
@@ -85,40 +112,45 @@ def test_getter_returns_expected_plaintext(db_engine) -> None:
 
 
 def test_session_attached_object_keeps_ciphertext(db_engine) -> None:
-    engine, user_id = db_engine
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_encrypted_user(db)
     with sessionmaker(bind=engine)() as db:
         view = user_service.get_user_by_id(db, user_id)
 
         attached = db.query(User).filter(User.id == user_id).first()
-        assert attached is not view
-        assert attached.git_info[0]["git_token"] != PLAIN_TOKEN
+        _assert_transient_read_view(view, attached, db)
         assert is_token_encrypted(attached.git_info[0]["git_token"])
 
 
 def test_getter_leaves_no_dirty_state(db_engine) -> None:
-    engine, user_id = db_engine
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_encrypted_user(db)
     with sessionmaker(bind=engine)() as db:
         view = user_service.get_user_by_id(db, user_id)
         attached = db.query(User).filter(User.id == user_id).first()
 
-        assert view not in db.dirty
-        assert attached not in db.dirty
-        history = sa_inspect(attached).attrs.git_info.history
-        assert history.added == () and history.deleted == ()
+        _assert_transient_read_view(view, attached, db)
+        _assert_attached_clean(attached, db)
 
 
 def test_commit_after_getter_keeps_db_ciphertext(db_engine) -> None:
     """The admin-path sequence (getter then an unrelated commit)."""
-    engine, user_id = db_engine
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_encrypted_user(db)
     with sessionmaker(bind=engine)() as db:
         user_service.get_user_by_id(db, user_id)
         db.commit()
 
-    assert is_token_encrypted(_raw_git_token(engine, user_id))
+    assert is_token_encrypted(_raw_git_info(engine, user_id)[0]["git_token"])
 
 
 def test_subsequent_same_session_reader_not_contaminated(db_engine) -> None:
-    engine, user_id = db_engine
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_encrypted_user(db)
     with sessionmaker(bind=engine)() as db:
         user_service.get_user_by_id(db, user_id)
         # A later reader in the same session must not inherit plaintext.
@@ -126,49 +158,118 @@ def test_subsequent_same_session_reader_not_contaminated(db_engine) -> None:
         attached = db.query(User).filter(User.id == user_id).first()
 
         assert is_token_encrypted(attached.git_info[0]["git_token"])
-        assert is_token_encrypted(_raw_git_token(engine, user_id))
+        assert is_token_encrypted(_raw_git_info(engine, user_id)[0]["git_token"])
         assert again.git_info[0]["git_token"] == PLAIN_TOKEN
 
 
 def test_get_user_by_name_returns_plaintext_view(db_engine) -> None:
-    engine, user_id = db_engine
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_encrypted_user(db)
     with sessionmaker(bind=engine)() as db:
         view = user_service.get_user_by_name(db, "sec-hygiene")
+        attached = db.query(User).filter(User.id == user_id).first()
 
         assert view.git_info[0]["git_token"] == PLAIN_TOKEN
         assert view.id == user_id
-        assert view not in db.dirty
+        _assert_transient_read_view(view, attached, db)
+        _assert_attached_clean(attached, db)
 
 
-def test_non_encrypted_and_missing_tokens_pass_through(db_engine) -> None:
-    """Users without stored tokens (or already-plaintext entries) are
-    returned unchanged and usable."""
-    engine, _user_id = db_engine
+def test_get_all_users_returns_plaintext_views(db_engine) -> None:
+    engine = db_engine
     with sessionmaker(bind=engine)() as db:
-        db.add(
-            User(
-                user_name="no-tokens",
-                password_hash="x",
-                email="no-tokens@example.com",
-                is_active=True,
-                git_info=None,
-            )
-        )
+        _add_encrypted_user(db)
+        _add_user(db, "no-tokens", None)
+    with sessionmaker(bind=engine)() as db:
+        views = user_service.get_all_users(db)
+        by_name = {view.user_name: view for view in views}
+
+        assert by_name["sec-hygiene"].git_info[0]["git_token"] == PLAIN_TOKEN
+        assert by_name["no-tokens"].git_info is None
+
+        for name in ("sec-hygiene", "no-tokens"):
+            attached = db.query(User).filter(User.user_name == name).first()
+            _assert_transient_read_view(by_name[name], attached, db)
+            _assert_attached_clean(attached, db)
         db.commit()
-        bare = db.query(User).filter(User.user_name == "no-tokens").first()
 
-        view = user_service.get_user_by_id(db, bare.id)
+    rows = {
+        row[0]: row[1]
+        for row in (
+            ("sec-hygiene", _raw_git_info(engine, by_name["sec-hygiene"].id)),
+            ("no-tokens", _raw_git_info(engine, by_name["no-tokens"].id)),
+        )
+    }
+    assert is_token_encrypted(rows["sec-hygiene"][0]["git_token"])
+    assert rows["no-tokens"] is None
 
-        assert view.git_info is None
 
-
-def test_git_auth_flow_still_receives_plaintext_token(db_engine) -> None:
-    """The git-skill auth path consumes the plaintext token exactly as before."""
-    engine, user_id = db_engine
+@pytest.mark.parametrize(
+    ("shape", "stored"),
+    [
+        pytest.param("null", None, id="null"),
+        pytest.param("empty-list", [], id="empty-list"),
+        pytest.param(
+            "plaintext-legacy",
+            [{"type": "personal", "git_domain": "github.com", "git_token": PLAIN_LEGACY}],
+            id="plaintext-legacy",
+        ),
+        pytest.param(
+            "empty-token",
+            [{"type": "personal", "git_domain": "github.com", "git_token": ""}],
+            id="empty-token",
+        ),
+        pytest.param(
+            "missing-token-key",
+            [{"type": "personal", "git_domain": "github.com"}],
+            id="missing-token-key",
+        ),
+    ],
+)
+def test_read_view_ownership_and_pass_through(db_engine, shape, stored) -> None:
+    """Every stored git_info shape gets a transient read copy; the getter
+    never hands out the session-attached instance, not even for None."""
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_user(db, f"shape-{shape}", stored)
     with sessionmaker(bind=engine)() as db:
         view = user_service.get_user_by_id(db, user_id)
-        entry = view.git_info[0]
+        attached = db.query(User).filter(User.id == user_id).first()
 
-        assert entry["git_domain"] == "github.com"
-        assert entry["git_token"] == PLAIN_TOKEN
-        assert is_token_encrypted(_raw_git_token(engine, user_id))
+        # Returned semantics match what was stored (nothing to decrypt), and
+        # legacy/corrupt shapes (plaintext, empty or missing token) pass
+        # through instead of raising.
+        assert view.git_info == stored
+
+        _assert_transient_read_view(view, attached, db)
+        _assert_attached_clean(attached, db)
+        db.commit()
+
+    assert _raw_git_info(engine, user_id) == stored
+
+
+def test_git_auth_consumer_receives_plaintext_token(db_engine) -> None:
+    """Production consumer regression: the git-skill auth resolver
+    (git_skill.utils.get_auth_for_repo) receives the plaintext token while
+    the session-attached User keeps ciphertext and the DB is unchanged."""
+    engine = db_engine
+    with sessionmaker(bind=engine)() as db:
+        user_id = _add_encrypted_user(db)
+    with sessionmaker(bind=engine)() as db:
+        provider, owner, repo, auth_info = get_auth_for_repo(
+            "https://github.com/wecode-ai/Wegent", user_id, db
+        )
+
+        assert auth_info.auth_source == "platform_integration"
+        assert auth_info.password == PLAIN_TOKEN
+        assert owner == "wecode-ai"
+        assert repo == "Wegent"
+
+        attached = db.query(User).filter(User.id == user_id).first()
+        assert is_token_encrypted(attached.git_info[0]["git_token"])
+        _assert_attached_clean(attached, db)
+
+        db.commit()
+
+    assert is_token_encrypted(_raw_git_info(engine, user_id)[0]["git_token"])


### PR DESCRIPTION
# security: remove git credential ORM state mutation

## Summary(概述)

本 PR 修复 BUG-004:Git token 解密 getter 在 **session-attached ORM 实例**上就地改写凭据状态,导致:

```text
decrypt_user_git_info(user)
→ 就地解密 session-attached User.git_info
→ SQLAlchemy identity map 留存明文
→ 实例进入 session.dirty
→ 同 session 后续 git_info 重写 + commit
→ 明文写回数据库,静默替换加密存储列
```

修复刻意保持狭窄:getter 重写为纯转换,返回 **transient read copy**;调用方零改动。本 PR **不**涉及 Wegent 更广的信任边界、executor 生命周期、校验协议或出站网络策略的重新设计。

Out of scope(范围外):BUG-001 / BUG-002 / BUG-003 / BUG-005;executor_manager inbound authentication;shared-token identity redesign。

---

## 1. BUG-004 — Proven root cause(可执行证据)

在 BASE `8fbf06d4f` 上用真实调用路径(SQLite, SQLAlchemy 2.0.44,`user_service.get_user_by_id`)复现:

```text
view is attached object       : True        ← getter 返回的就是 session-attached 实例
git_info before getter        : ciphertext
git_info after getter         : plaintext   ← 就地解密,identity map 留存明文(PROVEN)
attached in db.dirty          : True        ← 实例进入 dirty(PROVEN)
db.is_modified(attached)      : False       ← 值相等掩盖;dirty 集合与 is_modified 不一致
attribute history             : () / ()     ← 就地改写同时污染了 committed 引用,无 net change
unrelated commit SQL          : 无 git_info UPDATE(仅 SELECT)
raw DB after unrelated commit : ciphertext  ← "任意不相关 commit 落库" 在当前 BASE 上不成立
```

**真实持久化 exploit 序列(BASE 上 PROVEN,裸 SQL witness):**

```text
getter(就地解密污染 attached)
→ delete_git_token(git_domain="gitlab.com")  ← 生产写路径,同 session
→ commit
→ raw DB git_info[0]["git_token"] == PLAIN_TOKEN,encrypted=False   ← 明文已落库
```

机制:getter 把明文留在 attached 实例上;同一 session 内任何 git_info 重写(增/删/改/排序)都会把这份明文写进 UPDATE。另两个变体(fresh dicts 不解密共享引用、`flag_modified`)同样可执行地证明明文落库。

### 被纠正的表述

原 PR 声称“后续任何同 session 的 commit()/autoflush 会把明文写回数据库”——**不成立**。当前 BASE 上,bare unrelated commit 不会持久化明文(值相等掩盖);明文落库需要 getter 之后的 git_info 重写。该机制差异已在本节以上述 witness 为准。

---

## 2. Fixed invariant(修复后的不变量)

```text
credential read/decryption NEVER mutates persistence-tracked User state;
the read path NEVER returns the original session-attached instance,
for ANY git_info shape (None / [] / encrypted / plaintext legacy /
empty token / missing token key).
```

实现:先构造 transient copy(`User()` + 逐列 `setattr`,再挂解密列表),所有分支一致返回该 copy。`git_info=None` 不再返回 attached 实例(修复了原 patch 的 representation split)。

---

## 3. Persistence severity(定性)

```text
PROVEN on BASE:
  - identity-map plaintext contamination(getter 后 attached.git_info 为明文)
  - dirty state(getter 后 attached in session.dirty)
  - plaintext persistence via getter → git_info rewrite → commit
    (delete_git_token 真实写路径,裸 SQL + raw DB witness)

NOT PROVEN / CORRECTED:
  - “任意不相关 commit/autoflush 立即落库”——当前 BASE 上无此 witness,
    bare commit 被值相等掩盖;该表述已删除,替换为上面可复现的机制。
```

---

## 4. View ownership semantics(视图归属语义)

返回值是 **transient read copy**,**不是 detached**:

```text
sa_inspect(view): transient=True persistent=False detached=False
view not in db.identity_map / db.dirty / db.new / db.deleted
view.git_info 与 attached.git_info 无共享可变容器(逐条 fresh dict)
```

约束:`User()` + 手动赋列的对象没有 session、没有 database identity,调用方**不得** re-attach / `db.add` / `db.merge` / commit。全部 9 个调用点(6 个文件:admin/users、admin/tasks、kind_management×3、kind/common×2、git_skill、repository_job)已审计,均为只读消费 `user.id` / `user.git_info` 等属性,无 `db.add/merge/delete` 命中返回值。

长期 API typing cleanup(改为显式 credential view 类型)记录为 follow-up,不在本 PR 硬扩。

---

## 5. Tests(测试,与覆盖一一对应)

专项:`backend/tests/security/test_git_secret_hygiene.py` — **14 passed**

```text
cd backend && uv run pytest tests/security/test_git_secret_hygiene.py -q
```

| 测试 | 锁定的不变量 | 对 BASE 判别 |
| --- | --- | --- |
| test_getter_returns_expected_plaintext | 视图对合法消费者返回明文 | 通过(良性契约,base 也满足) |
| test_session_attached_object_keeps_ciphertext | attached 保持密文 + 视图为 transient copy | FAIL on BASE |
| test_getter_leaves_no_dirty_state | session 无 dirty / 无属性历史 | FAIL on BASE |
| test_commit_after_getter_keeps_db_ciphertext | bare unrelated commit 不触碰存储密文(注:base 亦满足,非 exploit 锁) | 通过(文档化) |
| **test_git_info_rewrite_after_getter_keeps_db_ciphertext** | **BASE 真实 exploit 序列:getter → delete_git_token → commit,raw DB 仍密文** | **FAIL on BASE(裸 SQL witness)** |
| test_subsequent_same_session_reader_not_contaminated | 同 session 二读者不被污染 | FAIL on BASE |
| test_get_user_by_name_returns_plaintext_view | 第二个 getter 同样返回视图 | FAIL on BASE |
| test_get_all_users_returns_plaintext_views | get_all_users 同样返回视图 + attached 干净 | FAIL on BASE |
| test_read_view_ownership_and_pass_through[null/empty-list/plaintext-legacy/empty-token/missing-token-key] | 5 种形状:返回数据一致、视图非 attached、attached 干净、raw DB 不变 | FAIL on BASE(5/5) |
| test_git_auth_consumer_receives_plaintext_token | **真实消费者链** `get_auth_for_repo → parse_repo_url → get_user_git_info → get_user_by_id`;attached 实例(consumer 运行前持有引用)保持密文;raw DB 密文 | FAIL on BASE |

消费者测试在调用 consumer **之前**持有 attached 引用,防止弱 identity map 重载掩盖就地污染。

### Backend 全量回归(本 HEAD 实跑)

```text
cd backend && uv run pytest -q
```

结果见 Regression gate 一节。

### 对 BASE 的判别力

同一测试文件在 BASE `8fbf06d4f` 上运行:**12 failed / 2 passed**(2 个通过项为文档化 benign invariants)。测试名与证据一一对应,不存在“名字说 E2E 实际只读一个字段”的测试。

---

## 6. Hosted CI(当前 HEAD)

`gh pr checks 3325`(本 HEAD):

```text
Test Backend      pass
Lint Backend      pass(Black & isort)
E2E Tests 1-4     pass
Executor E2E      pass
Platform E2E      pass
Wework E2E        pass
... 其余 check 均 pass 或 skipping(不受影响的域)
```

CI green 仅作为 regression evidence,不能替代上面的 security witness。

---

## 7. Regression gate(回归门,本 HEAD 实跑)

```text
BUG-004 focused tests        = PASS(14/14,test_git_secret_hygiene.py)
user service + security      = PASS(34 passed)
backend full regression      = PASS(6659 passed / 1 skipped,exit 0)
BASE discrimination          = 12/14 FAIL on BASE(2 benign 除外)
executor_manager regression  = N/A(diff 无该域文件)
working tree                 = 分支树仅含本 PR 提交
```

---

## 8. 最终结论

```text
BUG-004
= CLOSED:getter 不再污染 session-attached ORM 状态;
  BASE 上 getter→重写→commit 明文落库 exploit 已由裸 SQL witness 证明并被修复。

BROADER SECURITY BOUNDARIES
= OUT OF SCOPE / UNCHANGED
```

---

## 9. Follow-ups(后续项,均不在本 PR)

- F1 `team_kinds.py:1269` `get_team_detail` 非作者分支对 session-attached User 执行 `user.git_info = []`(net change,潜在凭据清空)→ **已建公开 issue:[#3329](https://github.com/wecode-ai/Wegent/issues/3329)**
- F2 `git_skill/utils.py:164` 及 repository providers / `resolve_plaintext_git_token` 对已解密 token 的冗余二次解密(pre-existing,靠 crypto fallback 兜底 + 噪音日志)
- F3 `is_token_encrypted` 启发式会把 64 字符 base64 字母表的 legacy 明文 token 误判为密文;`resolve_plaintext_git_token` 会丢弃这类 token(pre-existing,device sync 功能性问题,非泄露)
- F4 `admin/users.py` 描述修复前行为的过时注释
- F5 长期:getter 返回类型 cleanup 为显式 credential view(dataclass/Pydantic),替换 transient User copy
- F6 `kind/common.py:118` `get_user_by_id(None, ...)` 死分支会在 `userReader` 中 AttributeError(pre-existing,无调用方传 None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git credentials are now decrypted only in temporary read-only views, preventing plaintext secrets from being persisted or contaminating session data.
  * Missing or unencrypted Git tokens are handled safely without errors.
  * Git authentication continues to receive usable plaintext credentials when needed.

* **Tests**
  * Added coverage to verify secret handling, session cleanliness, persistence safety, and token pass-through behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->