### PR TITLE
fix(wework): prevent project hover card position jump

### DIFF
--- a/wework/src/components/ui/hover-card.test.tsx
+++ b/wework/src/components/ui/hover-card.test.tsx
@@ -352,8 +352,20 @@ describe('HoverCard', () => {
 
   test('measures the rendered card and moves it above the bottom viewport edge', async () => {
     vi.useFakeTimers()
+    let measuredStyle: {
+      left: string
+      top: string
+      visibility: string
+    } | null = null
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
       const isCard = this.dataset.testid === 'bottom-hover-card'
+      if (isCard) {
+        measuredStyle = {
+          left: this.style.left,
+          top: this.style.top,
+          visibility: this.style.visibility,
+        }
+      }
       return {
         x: isCard ? 530 : 900,
         y: isCard ? 700 : 680,
@@ -383,13 +395,19 @@ describe('HoverCard', () => {
     fireEvent.mouseEnter(screen.getByText('Current task'))
     await act(async () => vi.advanceTimersByTime(450))
 
+    expect(measuredStyle).toEqual({
+      left: '0px',
+      top: '0px',
+      visibility: 'hidden',
+    })
     expect(screen.getByTestId('bottom-hover-card')).toHaveStyle({
       left: '530px',
       top: '380px',
+      visibility: 'visible',
     })
   })
 
-  test('calibrates once when the rendered size changes with its position', async () => {
+  test('measures once when the rendered size changes with its position', async () => {
     vi.useFakeTimers()
     let cardMeasurements = 0
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
@@ -440,7 +458,7 @@ describe('HoverCard', () => {
     fireEvent.mouseEnter(screen.getByText('Current task'))
     await act(async () => vi.advanceTimersByTime(450))
 
-    expect(screen.getByTestId('stable-hover-card')).toHaveStyle({ left: '210px', top: '200px' })
+    expect(screen.getByTestId('stable-hover-card')).toHaveStyle({ left: '210px', top: '500px' })
     expect(cardMeasurements).toBe(1)
   })
 })

--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -89,9 +89,10 @@ export function HoverCard({
   const closeTimerRef = useRef<number | null>(null)
   const focusWithinRef = useRef(false)
   const pinnedRef = useRef(false)
+  const openRef = useRef(false)
+  const [open, setOpen] = useState(false)
   const [position, setPosition] = useState<HoverCardPosition | null>(null)
   const [pinned, setPinned] = useState(false)
-  const isOpen = position !== null
 
   const clearTimers = useCallback(() => {
     if (openTimerRef.current !== null) {
@@ -108,24 +109,26 @@ export function HoverCard({
     clearTimers()
     focusWithinRef.current = false
     pinnedRef.current = false
+    openRef.current = false
+    setOpen(false)
     setPinned(false)
     setPosition(null)
   }, [clearTimers])
 
-  const open = useCallback(() => {
+  const show = useCallback(() => {
     clearTimers()
-    const rect = anchorRef.current?.getBoundingClientRect()
-    if (!rect) return
-    setPosition(hoverCardPosition(rect, estimatedWidth, estimatedHeight))
-  }, [clearTimers, estimatedHeight, estimatedWidth])
+    if (openRef.current || !anchorRef.current) return
+    openRef.current = true
+    setOpen(true)
+  }, [clearTimers])
 
   const scheduleOpen = useCallback(() => {
     clearTimers()
     openTimerRef.current = window.setTimeout(() => {
       openTimerRef.current = null
-      open()
+      show()
     }, DEFAULT_OPEN_DELAY_MS)
-  }, [clearTimers, open])
+  }, [clearTimers, show])
 
   const scheduleClose = useCallback(() => {
     if (pinnedRef.current) return
@@ -178,12 +181,12 @@ export function HoverCard({
       if (focusIsInsideAnchor && !openOnFocus) return
       focusWithinRef.current = true
       if (openOnFocus) {
-        open()
+        show()
         return
       }
       keepOpen()
     },
-    [keepOpen, open, openOnFocus, pin, shouldPinInteraction]
+    [keepOpen, openOnFocus, pin, shouldPinInteraction, show]
   )
 
   const handleBlurCapture = useCallback(
@@ -207,26 +210,24 @@ export function HoverCard({
     []
   )
 
-  // Calibrate once per open transition. Re-running from the position update can
-  // make position-sensitive content alternate between two measured layouts.
+  // Measure while hidden, then reveal at the final position. Showing the
+  // estimated position first makes tall cards visibly jump after calibration.
+  // Calibrate only once because position-sensitive content can otherwise
+  // alternate between two measured layouts.
   useLayoutEffect(() => {
-    if (!isOpen) return
+    if (!open) return
     const anchorRect = anchorRef.current?.getBoundingClientRect()
     const cardRect = cardRef.current?.getBoundingClientRect()
     if (!anchorRect || !cardRect) return
 
-    const nextPosition = hoverCardPosition(
-      anchorRect,
-      cardRect.width || estimatedWidth,
-      cardRect.height || estimatedHeight
+    setPosition(
+      hoverCardPosition(
+        anchorRect,
+        cardRect.width || estimatedWidth,
+        cardRect.height || estimatedHeight
+      )
     )
-    setPosition(current => {
-      if (!current || (nextPosition.left === current.left && nextPosition.top === current.top)) {
-        return current
-      }
-      return nextPosition
-    })
-  }, [estimatedHeight, estimatedWidth, isOpen])
+  }, [estimatedHeight, estimatedWidth, open])
 
   useEffect(() => {
     if (!position) return
@@ -312,13 +313,13 @@ export function HoverCard({
       }}
     >
       {children}
-      {position &&
+      {open &&
         createPortal(
           <div
             ref={cardRef}
             data-testid={testId}
             role={interactive ? 'dialog' : 'tooltip'}
-            style={position}
+            style={position ?? { left: 0, top: 0, visibility: 'hidden' }}
             onMouseEnter={interactive ? keepOpen : undefined}
             onMouseLeave={interactive ? scheduleClose : undefined}
             className={cn(


### PR DESCRIPTION
Project-space task conversation hover cards were briefly rendered at an estimated position before DOM measurement moved them to their final coordinates. This change mounts the card hidden for one layout measurement and reveals it only at the final position, while preserving the single-measure guard against layout loops. Validation: focused HoverCard and CloudTodoBoardCard tests, TypeScript, Prettier, ESLint, and isolated Electron source build/start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HoverCard positioning to ensure cards appear in the correct location after opening.
  - Prevented visible misplacement while the card’s size and position are being calculated.
  - Improved behavior when the card’s rendered size changes, including near screen edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->