### PR TITLE
fix(wework): enable board task follow-up

### DIFF
--- a/backend/app/models/delivery.py
+++ b/backend/app/models/delivery.py
@@ -296,6 +296,14 @@ class LoopItemTaskBinding(LoopNode):
     __mapper_args__ = {"polymorphic_identity": "execution"}
 
     @property
+    def model_selection(self) -> dict[str, object] | None:
+        metadata = self.metadata_json
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get("model_selection")
+        return value if isinstance(value, dict) else None
+
+    @property
     def workflow_node_id(self) -> str | None:
         metadata = self.metadata_json
         if not isinstance(metadata, dict):

--- a/backend/app/schemas/delivery.py
+++ b/backend/app/schemas/delivery.py
@@ -18,6 +18,7 @@ from pydantic import (
 
 from app.schemas.cloud_project import CloudProjectResponse, SnowflakeId
 from app.schemas.issue_workflow import IssueWorkflowInstance, WorkflowExecutionConfig
+from app.schemas.runtime_work import RuntimeModelSelection
 from app.schemas.tagging import MAX_TAGS_PER_ITEM
 from app.schemas.tagging import normalize_tags as _normalize_tags
 
@@ -359,6 +360,10 @@ class LoopItemTaskBind(BaseModel):
     task_id: str = Field(alias="taskId", min_length=1, max_length=255)
     task_title: str | None = Field(default=None, alias="taskTitle", max_length=255)
     backend_task_id: int | None = Field(default=None, alias="backendTaskId")
+    model_selection: RuntimeModelSelection | None = Field(
+        default=None,
+        alias="modelSelection",
+    )
     workflow_node_id: str | None = Field(
         default=None,
         alias="workflowNodeId",
@@ -369,7 +374,7 @@ class LoopItemTaskBind(BaseModel):
 
 
 class LoopItemTaskBindingResponse(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: SnowflakeId
     cloud_project_id: SnowflakeId
@@ -379,6 +384,10 @@ class LoopItemTaskBindingResponse(BaseModel):
     task_id: str
     task_title: str | None
     backend_task_id: int | None
+    model_selection: RuntimeModelSelection | None = Field(
+        default=None,
+        alias="modelSelection",
+    )
     workflow_node_id: str | None = None
     linked_by_user_id: int
     linked_at: datetime

--- a/backend/app/services/loop_item_executions/service.py
+++ b/backend/app/services/loop_item_executions/service.py
@@ -1737,6 +1737,16 @@ class LoopItemExecutionService:
                 taskId=execution.runtime_task_id,
                 taskTitle=item.title or "",
                 backendTaskId=execution.backend_task_id or None,
+                modelSelection=(
+                    {
+                        "modelName": execution.runtime_selection["model"],
+                        "modelType": execution.runtime_selection.get("model_type"),
+                        "options": execution.runtime_selection.get("model_options")
+                        or {},
+                    }
+                    if execution.runtime_selection.get("model")
+                    else None
+                ),
                 workflowNodeId=workflow_node_id,
             ),
             user_id=execution.executor_owner_user_id,

--- a/backend/app/services/loop_items/service.py
+++ b/backend/app/services/loop_items/service.py
@@ -89,6 +89,17 @@ ASSIGNMENT_HISTORY_KEY = "assignment_history"
 logger = logging.getLogger(__name__)
 
 
+def _task_binding_metadata(
+    values: LoopItemTaskBind, *, include_workflow_node: bool = True
+) -> dict[str, object]:
+    metadata: dict[str, object] = {}
+    if include_workflow_node and values.workflow_node_id:
+        metadata["workflow_node_id"] = values.workflow_node_id
+    if values.model_selection:
+        metadata["model_selection"] = values.model_selection.model_dump(by_alias=True)
+    return metadata
+
+
 class LoopItemService:
     @staticmethod
     def _project_status_ids(project: CloudProject) -> list[str]:
@@ -1592,15 +1603,17 @@ class LoopItemService:
             if active.loop_item_id == item_id:
                 if values.task_title and active.task_title != values.task_title:
                     active.task_title = values.task_title
-                if values.workflow_node_id:
+                metadata_updates = _task_binding_metadata(values)
+                if metadata_updates:
                     active.metadata_json = {
                         **(
                             active.metadata_json
                             if isinstance(active.metadata_json, dict)
                             else {}
                         ),
-                        "workflow_node_id": values.workflow_node_id,
+                        **metadata_updates,
                     }
+                if values.workflow_node_id:
                     from app.services.workflow_stage_context import (
                         workflow_stage_context_resolver,
                     )
@@ -1633,11 +1646,7 @@ class LoopItemService:
             backend_task_id=values.backend_task_id,
             linked_by_user_id=user_id,
             linked_at=self._now(),
-            metadata_json=(
-                {"workflow_node_id": values.workflow_node_id}
-                if values.workflow_node_id
-                else None
-            ),
+            metadata_json=_task_binding_metadata(values) or None,
         )
         if values.workflow_node_id:
             from app.services.workflow_stage_context import (
@@ -1722,6 +1731,18 @@ class LoopItemService:
             ):
                 if values.task_title and active.task_title != values.task_title:
                     active.task_title = values.task_title
+                metadata_updates = _task_binding_metadata(
+                    values, include_workflow_node=False
+                )
+                if metadata_updates:
+                    active.metadata_json = {
+                        **(
+                            active.metadata_json
+                            if isinstance(active.metadata_json, dict)
+                            else {}
+                        ),
+                        **metadata_updates,
+                    }
                 db.commit()
                 db.refresh(active)
                 return active
@@ -1736,6 +1757,8 @@ class LoopItemService:
             backend_task_id=values.backend_task_id,
             linked_by_user_id=user_id,
             linked_at=self._now(),
+            metadata_json=_task_binding_metadata(values, include_workflow_node=False)
+            or None,
         )
         db.add(binding)
         db.commit()

--- a/backend/tests/api/test_deliveries_api.py
+++ b/backend/tests/api/test_deliveries_api.py
@@ -270,9 +270,19 @@ def test_board_snapshot_returns_first_screen_dependencies(
             "deviceId": "local-device",
             "taskId": "snapshot-runtime-task",
             "taskTitle": "Snapshot runtime task",
+            "modelSelection": {
+                "modelName": "gpt-5.6-codex",
+                "modelType": "public",
+                "options": {"reasoning": "high"},
+            },
         },
     )
     assert binding.status_code == 201
+    assert binding.json()["modelSelection"] == {
+        "modelName": "gpt-5.6-codex",
+        "modelType": "public",
+        "options": {"reasoning": "high"},
+    }
 
     response = test_client.get(
         f"/api/v1/cloud-projects/{delivery_project.id}/board-snapshot",

--- a/backend/tests/services/test_loop_item_executions.py
+++ b/backend/tests/services/test_loop_item_executions.py
@@ -3407,6 +3407,11 @@ def test_mark_start_requested_binds_issue_runtime_task_without_workflow_stage(
     assert binding.task_title == item.title
     assert binding.workflow_node_id is None
     assert binding.metadata_json["workspace_device_id"] == "cloud-device-1"
+    assert binding.model_selection == {
+        "modelName": "test-model",
+        "modelType": None,
+        "options": {},
+    }
 
 
 @pytest.mark.parametrize("executor_type", ["project_robot", "generic_robot"])

--- a/wework/src/api/deliveries.test.ts
+++ b/wework/src/api/deliveries.test.ts
@@ -72,6 +72,45 @@ describe('createDeliveryApi queue and assignment routes', () => {
     expect(client.get).toHaveBeenCalledWith('/v1/cloud-projects/123/board-snapshot')
   })
 
+  it('persists the runtime task model identity when binding a board task', async () => {
+    const post = vi.fn(async () => undefined)
+    const api = createDeliveryApi(clientWith({ post }))
+
+    await api.bindTask(
+      'WEG-1',
+      {
+        deviceId: 'local-device',
+        taskId: 'runtime-1',
+        runtimeHandle: {
+          modelSelection: {
+            modelName: 'gpt-5.6-codex',
+            modelType: 'public',
+            options: { reasoning: 'high' },
+          },
+        },
+      },
+      'Fix board follow-up'
+    )
+
+    expect(post).toHaveBeenCalledWith('/v1/loop-items/WEG-1/tasks', {
+      deviceId: 'local-device',
+      taskId: 'runtime-1',
+      runtimeHandle: {
+        modelSelection: {
+          modelName: 'gpt-5.6-codex',
+          modelType: 'public',
+          options: { reasoning: 'high' },
+        },
+      },
+      taskTitle: 'Fix board follow-up',
+      modelSelection: {
+        modelName: 'gpt-5.6-codex',
+        modelType: 'public',
+        options: { reasoning: 'high' },
+      },
+    })
+  })
+
   it('loads one external board column page without requesting issue details', async () => {
     const client = {
       get: vi.fn(async () => ({ items: [], task_bindings: [], next_cursor: null })),

--- a/wework/src/api/deliveries.ts
+++ b/wework/src/api/deliveries.ts
@@ -3,6 +3,7 @@ import type { ProjectChatAgent } from './projectChatAgents'
 import type { ProjectChatWorkspaceBindingInput } from './projectChatAgents'
 import type {
   Attachment,
+  ModelSelectionConfig,
   ModelType,
   RuntimeAdditionalContext,
   RuntimeGoalCreateInput,
@@ -590,6 +591,7 @@ export interface LoopItemTaskBinding {
   task_id: string
   task_title: string | null
   backend_task_id: number | null
+  modelSelection?: ModelSelectionConfig | null
   workflow_node_id?: string | null
   binding_type?: 'system' | 'user'
   linked_at: string
@@ -1112,10 +1114,13 @@ export function createDeliveryApi(client: HttpClient) {
       taskTitle?: string | null,
       workflowNodeId?: string | null
     ): Promise<void> {
+      const modelSelection =
+        task.runtimeHandle?.modelSelection ?? task.runtimeHandle?.model_selection
       return client.post(`/v1/loop-items/${encodeURIComponent(itemId)}/tasks`, {
         ...task,
         ...(taskTitle ? { taskTitle } : {}),
         ...(workflowNodeId ? { workflowNodeId } : {}),
+        ...(modelSelection ? { modelSelection } : {}),
       })
     },
     decideWorkflowNode(

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
@@ -41,6 +41,12 @@ const mocks = vi.hoisted(() => ({
     }
   } | null,
   activeModelSelection: null as ModelSelectionConfig | null,
+  isBootstrapping: false,
+  runtimeWork: null as {
+    projects: unknown[]
+    chats: unknown[]
+    totalTasks: number
+  } | null,
 }))
 
 vi.mock('@/components/chat/ScrollableMessageArea', () => ({
@@ -108,7 +114,11 @@ vi.mock('@/components/layout/BufferedChatInput', () => ({
 vi.mock('@/features/workbench/useWorkbench', () => ({
   useWorkbenchPaneContext: () => ({
     services: {},
-    state: { devices: [], runtimeWork: null },
+    state: {
+      devices: [],
+      isBootstrapping: mocks.isBootstrapping,
+      runtimeWork: mocks.runtimeWork,
+    },
     projectChat: {
       models: [],
       selectedModel: null,
@@ -215,6 +225,8 @@ describe('TemporaryChatPanel', () => {
     mocks.syncTranscript.mockReset()
     mocks.lifecycleSnapshot = null
     mocks.activeModelSelection = null
+    mocks.isBootstrapping = false
+    mocks.runtimeWork = null
   })
 
   it('passes the collapsed idle state through to the shared composer', () => {
@@ -427,6 +439,25 @@ describe('TemporaryChatPanel', () => {
 
     expect(screen.getByTestId('mock-send')).toBeDisabled()
     expect(mocks.sendRuntimePaneMessage).not.toHaveBeenCalled()
+  })
+
+  it('lets a legacy task select a model after runtime work finishes without an identity', () => {
+    mocks.runtimeWork = {
+      projects: [],
+      chats: [],
+      totalTasks: 0,
+    }
+
+    render(
+      <TemporaryChatPanel
+        currentProject={null}
+        source={address}
+        instanceId="legacy-task-without-model"
+        initialAddress={address}
+      />
+    )
+
+    expect(screen.getByTestId('mock-send')).toBeEnabled()
   })
 
   it('auto-submits the initial input once after the task model identity is available', async () => {

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -138,7 +138,11 @@ export function TemporaryChatPanel({
   const globalSelectedModel = projectChat.getSelectedModel?.() ?? projectChat.selectedModel
   const globalSelectedModelOptions =
     projectChat.getSelectedModelOptions?.() ?? projectChat.selectedModelOptions
-  const taskModelIdentityPending = Boolean(address && !taskModelSelection?.taskSelection)
+  const taskModelIdentityPending = Boolean(
+    address &&
+    !taskModelSelection?.taskSelection &&
+    (state.isBootstrapping || state.runtimeWork === null)
+  )
   const sideChatProjectChat = useMemo(
     () => ({
       ...projectChat,

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -114,13 +114,18 @@ vi.mock('@/components/layout/workspace-panels/TemporaryChatPanel', () => ({
     collapseComposerWhenIdle,
   }: {
     testId: string
-    initialAddress?: { deviceId: string; taskId: string } | null
+    initialAddress?: {
+      deviceId: string
+      taskId: string
+      runtimeHandle?: { modelSelection?: { modelName?: string } }
+    } | null
     collapseComposerWhenIdle?: boolean
   }) => (
     <div
       data-testid={testId}
       data-device-id={initialAddress?.deviceId}
       data-task-id={initialAddress?.taskId}
+      data-model-name={initialAddress?.runtimeHandle?.modelSelection?.modelName}
       data-collapse-composer={String(collapseComposerWhenIdle)}
     >
       <div
@@ -999,6 +1004,11 @@ describe('CloudTodoWorkspace', () => {
         task_id: 'runtime-2',
         task_title: '验证完整工作流',
         backend_task_id: null,
+        modelSelection: {
+          modelName: 'gpt-5.6-codex',
+          modelType: 'public',
+          options: { reasoning: 'high' },
+        },
         linked_at: '2026-08-16T00:01:00Z',
       },
     ])
@@ -1129,6 +1139,10 @@ describe('CloudTodoWorkspace', () => {
     expect(screen.getByTestId('cloud-todo-card-popup-conversation-WEG-1')).toHaveAttribute(
       'data-collapse-composer',
       'true'
+    )
+    expect(screen.getByTestId('cloud-todo-card-popup-conversation-WEG-1')).toHaveAttribute(
+      'data-model-name',
+      'gpt-5.6-codex'
     )
     expect(screen.getByTestId('cloud-todo-card-popup-scroll-WEG-1')).toHaveClass(
       'max-h-[min(68vh,42rem)]',

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -553,6 +553,8 @@ function boardTaskModelSelection(
   binding: CloudTodoBoardTaskBinding,
   runtimeWork: RuntimeWorkListResponse | null | undefined
 ): ModelSelectionConfig | null {
+  if (binding.modelSelection) return binding.modelSelection
+
   const runtimeSelection = findRuntimeTask(runtimeWork, {
     deviceId: binding.device_id,
     taskId: binding.task_id,
@@ -1790,6 +1792,7 @@ export function CloudTodoWorkspace({
               task_id: binding.task_id,
               task_title: binding.task_title,
               workflow_node_id: binding.workflow_node_id,
+              modelSelection: binding.modelSelection,
               running: runtimeTaskRunningByAddress.get(addressKey) ?? false,
               changeRequestTarget: runtimeTask
                 ? runtimeTaskChangeRequestTarget(runtimeTask.workspace, runtimeTask.task)


### PR DESCRIPTION
## Summary

- persist the runtime model selection with board task bindings
- restore the bound model when opening task follow-up from the board
- let legacy bindings select a model after runtime identity loading completes instead of remaining disabled forever

## Root cause

Board task bindings only persisted the runtime address. Once the task disappeared from the local runtime-work snapshot, the follow-up panel could no longer resolve its immutable model identity and disabled the entire composer indefinitely.

## Verification

- Wework focused Vitest suites: 138 tests passed
- backend delivery API focused test passed
- backend loop-item execution binding focused test passed
- Prettier passed
- ESLint passed
- Black and isort checks passed
- git diff --check passed
- isolated Electron build and launch passed

Full Wework typecheck currently reports existing duplicate React/csstype dependency errors in untouched files under `src/components/chat` and workspace file panels.