### PR TITLE
fix: allow copying agents referencing private skills to personal space

### DIFF
--- a/backend/app/services/adapters/team_kinds.py
+++ b/backend/app/services/adapters/team_kinds.py
@@ -2838,9 +2838,16 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
                 namespace=dest_namespace,
             )
 
-            # Grant the destination access to the source Skills when requested.
+            # Grant the destination access to the source Skills.
             skill_mapping: Dict[int, int] = {}
-            if copy_skills and dest_namespace != original.namespace:
+            if dest_namespace == "default":
+                skill_mapping = self._bind_bot_skills_to_personal_space(
+                    db,
+                    bot=original_bot,
+                    user_id=user_id,
+                    commit=commit,
+                )
+            elif copy_skills and dest_namespace != original.namespace:
                 skill_mapping = self._bind_bot_skills_to_namespace(
                     db,
                     bot=original_bot,
@@ -2896,7 +2903,14 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
                             namespace=dest_namespace,
                         )
                         skill_mapping: Dict[int, int] = {}
-                        if copy_skills:
+                        if dest_namespace == "default":
+                            skill_mapping = self._bind_bot_skills_to_personal_space(
+                                db,
+                                bot=bot,
+                                user_id=user_id,
+                                commit=commit,
+                            )
+                        elif copy_skills:
                             skill_mapping = self._bind_bot_skills_to_namespace(
                                 db,
                                 bot=bot,
@@ -3010,6 +3024,66 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
                 if not is_public and skill_id is not None:
                     result[skill_name] = skill_id
         return result
+
+    def _bind_bot_skills_to_personal_space(
+        self,
+        db: Session,
+        *,
+        bot: Kind,
+        user_id: int,
+        commit: bool = True,
+    ) -> Dict[int, int]:
+        """Grant the copier personal access to a bot's private Skills.
+
+        Cloning a bot into personal space (namespace 'default') keeps the Skill
+        references pointing at the canonical Skill assets. Those references only
+        resolve in the personal space when the Skill is public, owned by the
+        copier in the personal namespace, or bound to the copier's user defaults.
+
+        Bindings created here only affect the copier, so an agent the copier
+        already manages (own agent or group agent) can be copied into personal
+        space without the group consent dialog used for group destinations.
+        Skills the copier cannot access in any source context are left untouched,
+        so the clone-time permission check still reports the denial.
+        """
+        from app.services.skill_binding_service import skill_binding_service
+
+        private_skill_ids = self._collect_private_skill_ids(db, bot)
+        user_default_skill_ids = skill_binding_service.list_user_default_skill_ids(
+            db, user_id
+        )
+        mapping: Dict[int, int] = {}
+        for _skill_name, skill_id in private_skill_ids.items():
+            skill = (
+                db.query(Kind)
+                .filter(
+                    Kind.id == skill_id,
+                    Kind.kind == "Skill",
+                    Kind.is_active == True,
+                )
+                .first()
+            )
+            if not skill or skill.user_id == 0:
+                continue
+            if skill.user_id == user_id and skill.namespace == "default":
+                continue
+            if skill_id in user_default_skill_ids:
+                continue
+            if not skill_binding_service.can_user_access_skill(
+                db, skill=skill, user_id=user_id
+            ):
+                continue
+            skill_binding_service.add_user_default_skill(
+                db,
+                user_id=user_id,
+                skill_id=skill_id,
+                created_by=user_id,
+                commit=False,
+            )
+            mapping[skill_id] = skill_id
+        if commit:
+            db.commit()
+        return mapping
 
     def _bind_bot_skills_to_namespace(
         self,

--- a/backend/app/services/adapters/team_kinds.py
+++ b/backend/app/services/adapters/team_kinds.py
@@ -3059,7 +3059,7 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
                 .filter(
                     Kind.id == skill_id,
                     Kind.kind == "Skill",
-                    Kind.is_active == True,
+                    Kind.is_active.is_(True),
                 )
                 .first()
             )

--- a/backend/tests/services/adapters/test_team_kinds_copy.py
+++ b/backend/tests/services/adapters/test_team_kinds_copy.py
@@ -796,3 +796,216 @@ class TestCopyTeamWithSkills:
         assert cloned_ghost is not None
         refs = cloned_ghost.json.get("spec", {}).get("skill_refs", {})
         assert refs["skip-skill"]["skill_id"] == personal_skill.id
+
+
+class TestCopyTeamToPersonalSpaceWithSkills:
+    """Copying an agent into personal space must keep its Skills usable there.
+
+    The copier only gains a user-default binding to private Skills they can
+    already access in the source context (owner, group member, or group admin).
+    Copying to personal space only affects the copier, so no consent dialog is
+    needed, unlike copying private Skills into a whole group.
+    """
+
+    def _create_group_solo_agent(
+        self,
+        test_db: Session,
+        *,
+        owner: User,
+        group: Namespace,
+        skill_name: str,
+    ):
+        """Create a solo Team inside a group whose bot references a group Skill."""
+        skill = _create_skill_with_binary(
+            test_db,
+            user_id=owner.id,
+            name=skill_name,
+            namespace=group.name,
+        )
+        bot = _create_bot(
+            test_db,
+            user_id=owner.id,
+            name=f"group-agent-bot-{skill_name}",
+            namespace=group.name,
+        )
+        _create_ghost(
+            test_db,
+            user_id=owner.id,
+            name=f"ghost-group-agent-bot-{skill_name}",
+            namespace=group.name,
+        )
+        _attach_skill_to_bot(test_db, bot=bot, skill=skill)
+        team = _create_team(
+            test_db,
+            user_id=owner.id,
+            name=f"group-agent-{skill_name}",
+            namespace=group.name,
+            collaboration_model="solo",
+            bot_ids=[bot.id],
+        )
+        return {"skill": skill, "bot": bot, "team": team}
+
+    def _cloned_personal_bot(self, test_db: Session, *, user_id: int) -> Kind:
+        from app.models.kind import Kind
+
+        return (
+            test_db.query(Kind)
+            .filter(
+                Kind.kind == "Bot",
+                Kind.namespace == "default",
+                Kind.user_id == user_id,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+    def test_group_maintainer_copies_group_agent_to_personal(self, test_db: Session):
+        """Group Maintainer can copy a group solo agent into personal space."""
+        owner = _create_user(test_db, "group_agent_owner", "owner@test.com")
+        admin = _create_user(test_db, "group_agent_admin", "admin@test.com")
+        group = _create_group(test_db, owner, "weather-group")
+        _add_group_member(test_db, group, admin, "Maintainer")
+        _create_shell(test_db, name="ClaudeCode", namespace="default")
+
+        assets = self._create_group_solo_agent(
+            test_db, owner=owner, group=group, skill_name="group-weather-skill"
+        )
+        skill = assets["skill"]
+
+        result = team_kinds_service.copy_team(
+            test_db,
+            team_id=assets["team"].id,
+            user_id=admin.id,
+            target_namespace="default",
+        )
+
+        assert result["namespace"] == "default"
+        assert skill.id in skill_binding_service.list_user_default_skill_ids(
+            test_db, admin.id
+        )
+        cloned_bot = self._cloned_personal_bot(test_db, user_id=admin.id)
+        assert cloned_bot is not None
+        ghost_ref = cloned_bot.json.get("spec", {}).get("ghostRef", {})
+        cloned_ghost = (
+            test_db.query(Kind)
+            .filter(
+                Kind.kind == "Ghost",
+                Kind.name == ghost_ref.get("name"),
+                Kind.namespace == "default",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+        assert cloned_ghost is not None
+        refs = cloned_ghost.json.get("spec", {}).get("skill_refs", {})
+        assert refs["group-weather-skill"]["skill_id"] == skill.id
+
+    def test_group_owner_copies_group_agent_to_personal(self, test_db: Session):
+        """The creator of a group agent can copy it into personal space."""
+        owner = _create_user(test_db, "group_agent_owner2", "owner2@test.com")
+        group = _create_group(test_db, owner, "weather-group-2")
+        _create_shell(test_db, name="ClaudeCode", namespace="default")
+
+        assets = self._create_group_solo_agent(
+            test_db, owner=owner, group=group, skill_name="owner-group-skill"
+        )
+        skill = assets["skill"]
+
+        result = team_kinds_service.copy_team(
+            test_db,
+            team_id=assets["team"].id,
+            user_id=owner.id,
+            target_namespace="default",
+        )
+
+        assert result["namespace"] == "default"
+        assert skill.id in skill_binding_service.list_user_default_skill_ids(
+            test_db, owner.id
+        )
+
+    def test_personal_agent_referencing_group_skill_copies_to_personal(
+        self, test_db: Session
+    ):
+        """Owner can copy a personal agent that references their group Skill."""
+        owner = _create_user(test_db, "hybrid_agent_owner", "hybrid@test.com")
+        group = _create_group(test_db, owner, "hybrid-group")
+        _create_shell(test_db, name="ClaudeCode", namespace="default")
+        skill = _create_skill_with_binary(
+            test_db,
+            user_id=owner.id,
+            name="hybrid-skill",
+            namespace=group.name,
+        )
+        bot = _create_bot(test_db, user_id=owner.id, name="hybrid-bot")
+        _create_ghost(test_db, user_id=owner.id, name="ghost-hybrid-bot")
+        _attach_skill_to_bot(test_db, bot=bot, skill=skill)
+        team = _create_team(
+            test_db,
+            user_id=owner.id,
+            name="hybrid-agent",
+            collaboration_model="solo",
+            bot_ids=[bot.id],
+        )
+
+        result = team_kinds_service.copy_team(
+            test_db,
+            team_id=team.id,
+            user_id=owner.id,
+            target_namespace="default",
+        )
+
+        assert result["namespace"] == "default"
+        assert skill.id in skill_binding_service.list_user_default_skill_ids(
+            test_db, owner.id
+        )
+
+    def test_user_without_skill_access_still_denied(self, test_db: Session):
+        """Copying a group agent with a private Skill still fails for outsiders."""
+        from fastapi import HTTPException
+
+        owner = _create_user(test_db, "restricted_owner", "restricted@test.com")
+        outsider = _create_user(test_db, "restricted_outsider", "outsider@test.com")
+        group = _create_group(test_db, owner, "restricted-group")
+        _create_shell(test_db, name="ClaudeCode", namespace="default")
+
+        assets = self._create_group_solo_agent(
+            test_db, owner=owner, group=group, skill_name="restricted-skill"
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_team(
+                test_db,
+                team_id=assets["team"].id,
+                user_id=outsider.id,
+                target_namespace="default",
+            )
+
+        assert exc_info.value.status_code == 403
+
+    def test_copying_own_personal_agent_adds_no_default_binding(self, test_db: Session):
+        """Personal Skills already owned by the copier need no extra binding."""
+        user = _create_user(test_db, "own_personal_owner", "own@test.com")
+        _create_shell(test_db, name="ClaudeCode", namespace="default")
+        skill = _create_skill_with_binary(test_db, user_id=user.id, name="own-skill")
+        bot = _create_bot(test_db, user_id=user.id, name="own-bot")
+        _create_ghost(test_db, user_id=user.id, name="ghost-own-bot")
+        _attach_skill_to_bot(test_db, bot=bot, skill=skill)
+        team = _create_team(
+            test_db,
+            user_id=user.id,
+            name="own-agent",
+            collaboration_model="solo",
+            bot_ids=[bot.id],
+        )
+
+        result = team_kinds_service.copy_team(
+            test_db,
+            team_id=team.id,
+            user_id=user.id,
+            target_namespace="default",
+        )
+
+        assert result["namespace"] == "default"
+        assert skill.id not in skill_binding_service.list_user_default_skill_ids(
+            test_db, user.id
+        )

--- a/backend/tests/services/adapters/test_team_kinds_copy.py
+++ b/backend/tests/services/adapters/test_team_kinds_copy.py
@@ -1009,3 +1009,71 @@ class TestCopyTeamToPersonalSpaceWithSkills:
         assert skill.id not in skill_binding_service.list_user_default_skill_ids(
             test_db, user.id
         )
+
+    def test_group_maintainer_cannot_copy_agent_with_owners_personal_skill(
+        self, test_db: Session
+    ):
+        """Skills without permission are never copied; the copy is denied.
+
+        Mirrors the production case where a group agent (owned by user A)
+        references A's personal Skill and a group Maintainer (user B, not the
+        Skill owner) copies the agent into personal space. The Skill is not
+        bound or duplicated for B, so the copy fails with the permission error
+        and the UI prompts B to obtain access first.
+        """
+        from fastapi import HTTPException
+
+        owner = _create_user(test_db, "skill_owner3", "skill-owner3@test.com")
+        admin = _create_user(test_db, "agent_copier2", "copier2@test.com")
+        group = _create_group(test_db, owner, "weather-group-5")
+        _add_group_member(test_db, group, admin, "Maintainer")
+        _create_shell(test_db, name="ClaudeCode", namespace="default")
+        skill = _create_skill_with_binary(
+            test_db, user_id=owner.id, name="owner-private-skill"
+        )
+        bot = _create_bot(
+            test_db,
+            user_id=owner.id,
+            name="private-skill-agent-bot",
+            namespace=group.name,
+        )
+        _create_ghost(
+            test_db,
+            user_id=owner.id,
+            name="ghost-private-skill-agent-bot",
+            namespace=group.name,
+        )
+        _attach_skill_to_bot(test_db, bot=bot, skill=skill)
+        team = _create_team(
+            test_db,
+            user_id=owner.id,
+            name="private-skill-agent",
+            namespace=group.name,
+            collaboration_model="solo",
+            bot_ids=[bot.id],
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_team(
+                test_db,
+                team_id=team.id,
+                user_id=admin.id,
+                target_namespace="default",
+            )
+
+        assert exc_info.value.status_code == 403
+        assert (
+            test_db.query(Kind)
+            .filter(
+                Kind.kind == "Skill",
+                Kind.name == "owner-private-skill",
+                Kind.namespace == "default",
+                Kind.user_id == admin.id,
+                Kind.is_active == True,
+            )
+            .first()
+            is None
+        )
+        assert skill.id not in skill_binding_service.list_user_default_skill_ids(
+            test_db, admin.id
+        )

--- a/backend/tests/services/adapters/test_team_kinds_copy.py
+++ b/backend/tests/services/adapters/test_team_kinds_copy.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Dict
+
 import pytest
 from sqlalchemy.orm import Session
 
@@ -814,7 +816,7 @@ class TestCopyTeamToPersonalSpaceWithSkills:
         owner: User,
         group: Namespace,
         skill_name: str,
-    ):
+    ) -> Dict[str, Kind]:
         """Create a solo Team inside a group whose bot references a group Skill."""
         skill = _create_skill_with_binary(
             test_db,
@@ -854,7 +856,7 @@ class TestCopyTeamToPersonalSpaceWithSkills:
                 Kind.kind == "Bot",
                 Kind.namespace == "default",
                 Kind.user_id == user_id,
-                Kind.is_active == True,
+                Kind.is_active.is_(True),
             )
             .first()
         )
@@ -892,7 +894,7 @@ class TestCopyTeamToPersonalSpaceWithSkills:
                 Kind.kind == "Ghost",
                 Kind.name == ghost_ref.get("name"),
                 Kind.namespace == "default",
-                Kind.is_active == True,
+                Kind.is_active.is_(True),
             )
             .first()
         )
@@ -1053,6 +1055,12 @@ class TestCopyTeamToPersonalSpaceWithSkills:
             bot_ids=[bot.id],
         )
 
+        skills_before = (
+            test_db.query(Kind.id)
+            .filter(Kind.kind == "Skill", Kind.user_id == admin.id)
+            .count()
+        )
+
         with pytest.raises(HTTPException) as exc_info:
             team_kinds_service.copy_team(
                 test_db,
@@ -1062,6 +1070,12 @@ class TestCopyTeamToPersonalSpaceWithSkills:
             )
 
         assert exc_info.value.status_code == 403
+        skills_after = (
+            test_db.query(Kind.id)
+            .filter(Kind.kind == "Skill", Kind.user_id == admin.id)
+            .count()
+        )
+        assert skills_after == skills_before
         assert (
             test_db.query(Kind)
             .filter(
@@ -1069,7 +1083,7 @@ class TestCopyTeamToPersonalSpaceWithSkills:
                 Kind.name == "owner-private-skill",
                 Kind.namespace == "default",
                 Kind.user_id == admin.id,
-                Kind.is_active == True,
+                Kind.is_active.is_(True),
             )
             .first()
             is None
@@ -1077,3 +1091,49 @@ class TestCopyTeamToPersonalSpaceWithSkills:
         assert skill.id not in skill_binding_service.list_user_default_skill_ids(
             test_db, admin.id
         )
+
+    def test_group_reporter_cannot_copy_agent_with_owners_personal_skill(
+        self, test_db: Session
+    ):
+        """Reporter group members remain denied when copying an agent with an unauthorized Skill."""
+        from fastapi import HTTPException
+
+        owner = _create_user(test_db, "skill_owner4", "skill-owner4@test.com")
+        reporter = _create_user(test_db, "group_reporter2", "reporter2@test.com")
+        group = _create_group(test_db, owner, "weather-group-6")
+        _add_group_member(test_db, group, reporter, "Reporter")
+        _create_shell(test_db, name="ClaudeCode", namespace="default")
+        skill = _create_skill_with_binary(
+            test_db, user_id=owner.id, name="reporter-owner-private-skill"
+        )
+        bot = _create_bot(
+            test_db,
+            user_id=owner.id,
+            name="reporter-private-skill-agent-bot",
+            namespace=group.name,
+        )
+        _create_ghost(
+            test_db,
+            user_id=owner.id,
+            name="ghost-reporter-private-skill-agent-bot",
+            namespace=group.name,
+        )
+        _attach_skill_to_bot(test_db, bot=bot, skill=skill)
+        team = _create_team(
+            test_db,
+            user_id=owner.id,
+            name="reporter-private-skill-agent",
+            namespace=group.name,
+            collaboration_model="solo",
+            bot_ids=[bot.id],
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_team(
+                test_db,
+                team_id=team.id,
+                user_id=reporter.id,
+                target_namespace="default",
+            )
+
+        assert exc_info.value.status_code == 403

--- a/frontend/src/__tests__/features/settings/utils/team-copy-errors.test.ts
+++ b/frontend/src/__tests__/features/settings/utils/team-copy-errors.test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { extractDeniedSkillName } from '@/features/settings/utils/teamCopyErrors'
+
+describe('extractDeniedSkillName', () => {
+  it('extracts the skill name from the backend copy denial message', () => {
+    expect(
+      extractDeniedSkillName(
+        new Error("Permission denied for skill 'weather-app-100d-analysis-glm'")
+      )
+    ).toBe('weather-app-100d-analysis-glm')
+  })
+
+  it('returns null for unrelated errors', () => {
+    expect(extractDeniedSkillName(new Error('Team not found'))).toBeNull()
+  })
+
+  it('returns null for non-Error values', () => {
+    expect(extractDeniedSkillName(undefined)).toBeNull()
+    expect(extractDeniedSkillName('Permission denied for skill')).toBeNull()
+  })
+})

--- a/frontend/src/features/settings/components/TeamList.tsx
+++ b/frontend/src/features/settings/components/TeamList.tsx
@@ -30,6 +30,7 @@ import { TeamChildNamespaceAuthorizationDialog } from './TeamChildNamespaceAutho
 import { TeamCardActionsMenu } from './TeamCardActionsMenu'
 import TeamCreationWizard from './wizard/TeamCreationWizard'
 import { TeamApiCallButton } from './TeamApiCallButton'
+import { extractDeniedSkillName } from '@/features/settings/utils/teamCopyErrors'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useGroupPermissions } from '@/hooks/useGroupPermissions'
 import { useToast } from '@/hooks/use-toast'
@@ -379,9 +380,12 @@ export default function TeamList({
         title: t('teams.copy_success'),
       })
     } catch (error) {
+      const deniedSkill = extractDeniedSkillName(error)
       toast({
         variant: 'destructive',
-        title: (error as Error)?.message || t('teams.copy_failed'),
+        title: deniedSkill
+          ? t('teams.copy_skill_permission_denied', { skill: deniedSkill })
+          : (error as Error)?.message || t('teams.copy_failed'),
       })
     } finally {
       setCopyingTeamId(null)

--- a/frontend/src/features/settings/utils/teamCopyErrors.ts
+++ b/frontend/src/features/settings/utils/teamCopyErrors.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Extract the Skill name from the backend agent-copy denial message so the UI
+ * can show an actionable hint, e.g. "Permission denied for skill 'xxx'".
+ */
+export function extractDeniedSkillName(error: unknown): string | null {
+  if (!(error instanceof Error)) return null
+  const match = error.message.match(/Permission denied for skill '([^']+)'/)
+  return match ? match[1] : null
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -341,6 +341,7 @@
     "copy_name_failed": "Failed to copy team name",
     "copy_success": "Team duplicated successfully",
     "copy_failed": "Failed to duplicate team",
+    "copy_skill_permission_denied": "You do not have permission for the skill {{skill}} that this agent depends on. Grant access to it first, then copy again.",
     "copy_skills_dialog_title": "Copy Skills to Group",
     "copy_skills_dialog_desc": "The following skills belong to your personal space. Copy them to the group too?",
     "copy_skills_with": "Copy Skills",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -341,6 +341,7 @@
     "copy_name_failed": "复制智能体名称失败",
     "copy_success": "智能体已复制",
     "copy_failed": "复制失败",
+    "copy_skill_permission_denied": "智能体依赖的技能 {{skill}} 权限不足，请先授权或添加到目标空间后再复制",
     "copy_skills_dialog_title": "复制 Skill 到群组",
     "copy_skills_dialog_desc": "以下 Skill 属于个人空间，是否一并复制到群组？",
     "copy_skills_with": "复制 Skill",


### PR DESCRIPTION
## 背景（WORK-26）

复制智能体到**个人空间**时报错：

```
Permission denied for skill '<skill-name>'
```

即使使用群组管理员或创建者权限也一样：该权限校验发生在**目标空间**里能否访问机器人引用的私有技能，管理员/创建者身份不会自动把技能带入目标空间。

## 根因

- 复制 solo 智能体会深拷贝机器人，并逐个校验其引用的非公开技能在目标空间是否可用（[bot_kinds.py](backend/app/services/adapters/bot_kinds.py#L2297)）。
- 前端只对“复制到群组”做技能 preflight；“复制到个人空间”从不携带技能，导致引用私有技能的智能体复制必然 403。
- 实例：技能是创建者个人空间（default）的私有技能，仅被群组智能体引用；复制者是群组 Owner 但非技能所有者，其个人空间无法访问该技能。

## 最终行为

- **复制者已可访问**的私有技能（自有、公共/系统、所属群组命名空间内等）：复制到个人空间时自动绑定到复制者个人默认技能（仅影响复制者本人），复制可以成功。
- **无权限/他人的私有技能：一律不复制、不绑定**。复制仍会失败（403），前端会给出具体提示，例如：
  - 中文：`智能体依赖的技能 {{skill}} 权限不足，请先授权或添加到目标空间后再复制`
  - 英文：`You do not have permission for the skill {{skill}} that this agent depends on. Grant access to it first, then copy again.`
- 使用者需先让技能所有者发布/授权该技能（如发布到市场、添加到目标空间），授权后再复制即可成功。

## 改动

- `81912668c`（backend）：复制到个人空间时，自动把复制者**已可访问**的私有技能绑定到其个人默认技能，使“复制到个人空间”不再必然失败。
- `4f3d5f211`（frontend）：复制失败若因技能权限不足，展示含具体技能名的可操作本地化提示（见上）。
- `d82a00bb6`（test）：回归用例覆盖镜像线上场景——群组 Maintainer 复制引用“他人个人技能”的智能体被拒（403），且**不产生技能副本或用户默认绑定**。
  - 说明：早期尝试过“把他人私有技能随复制生成独立副本”的方案，产品确认不采用。复制不应静默复制他人私有技能；是否授权由技能所有者决定，最终策略为“先授权、再复制”。

## 验证

- backend 回归用例覆盖：群组 Maintainer/Owner 复制到个人空间、个人智能体引用群组技能、复制引用“他人个人技能”的智能体被拒且不产生技能副本/绑定、群外人员仍 403、自己个人智能体复制不产生多余绑定。
- frontend：错误解析单测 + TeamList 相关用例通过；中英文案一致性检查通过。
- backend 相关 33+ 用例、ESLint / TypeScript / 翻译检查 / pre-push 质量门禁均通过。