### PR TITLE
fix(chat): allow follow-up messages in subscription tasks

### DIFF
--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -277,12 +277,21 @@ def _resolve_existing_task_team(
     client-selected team cannot move a turn onto another agent. For legacy
     tasks without a usable teamRef the client team is used as-is; a missing
     client team is corrected to the bound team when available.
+
+    The task lookup must accept subscription tasks (``STATE_SUBSCRIPTION``)
+    as well as regular active ones: subscription-triggered conversations are
+    normal chats that users keep sending follow-up messages to. Using
+    ``get_regular_active_task`` here rejected every follow-up in such
+    conversations with "Task not found". ``TaskResource.is_active_query()``
+    mirrors the states accepted by the REST read path
+    (``get_active_non_deleted_task`` in the sharded store).
     """
-    existing_task = task_stores.task_store.get_regular_active_task(
+    existing_task = task_stores.task_store.get_task_by_states(
         db,
         task_id=task_id,
+        states=TaskResource.is_active_query(),
     )
-    if not existing_task:
+    if not existing_task or existing_task.namespace == "system":
         return None, None, {"error": "Task not found"}
 
     try:

--- a/backend/tests/api/ws/test_chat_namespace_team_binding.py
+++ b/backend/tests/api/ws/test_chat_namespace_team_binding.py
@@ -29,7 +29,9 @@ from app.api.ws.chat_namespace import _resolve_task_bound_team  # noqa: E402
 
 def _task(team_ref: dict | None) -> SimpleNamespace:
     spec = {"teamRef": team_ref} if team_ref else {}
-    return SimpleNamespace(id=390051750105148, user_id=2838, json={"spec": spec})
+    return SimpleNamespace(
+        id=390051750105148, user_id=2838, namespace="default", json={"spec": spec}
+    )
 
 
 def _db_returning_team(bound_team: object | None) -> Mock:
@@ -151,7 +153,7 @@ def test_missing_bound_team_raises() -> None:
 def test_existing_task_missing_returns_error(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(
         task_stores.task_store,
-        "get_regular_active_task",
+        "get_task_by_states",
         Mock(return_value=None),
     )
     client_team = SimpleNamespace(id=273960, name="qbird-direct-log")
@@ -174,7 +176,7 @@ def test_existing_task_uses_bound_team(monkeypatch: MonkeyPatch) -> None:
     bound_team = SimpleNamespace(id=267213, name="creator-php-workflow")
     monkeypatch.setattr(
         task_stores.task_store,
-        "get_regular_active_task",
+        "get_task_by_states",
         Mock(return_value=existing_task),
     )
     monkeypatch.setattr(
@@ -206,7 +208,7 @@ def test_existing_task_corrects_inactive_client_team(
     bound_team = SimpleNamespace(id=267213, name="creator-php-workflow")
     monkeypatch.setattr(
         task_stores.task_store,
-        "get_regular_active_task",
+        "get_task_by_states",
         Mock(return_value=existing_task),
     )
     monkeypatch.setattr(
@@ -228,7 +230,7 @@ def test_legacy_task_without_team_ref_and_client_team_errors(
     existing_task = _task(None)
     monkeypatch.setattr(
         task_stores.task_store,
-        "get_regular_active_task",
+        "get_task_by_states",
         Mock(return_value=existing_task),
     )
 
@@ -250,7 +252,7 @@ def test_bound_team_same_as_client_returns_team(monkeypatch: MonkeyPatch) -> Non
     bound_team = SimpleNamespace(id=267213, name="creator-php-workflow")
     monkeypatch.setattr(
         task_stores.task_store,
-        "get_regular_active_task",
+        "get_task_by_states",
         Mock(return_value=existing_task),
     )
     monkeypatch.setattr(
@@ -278,7 +280,7 @@ def test_bound_team_resolution_error_is_returned(monkeypatch: MonkeyPatch) -> No
     )
     monkeypatch.setattr(
         task_stores.task_store,
-        "get_regular_active_task",
+        "get_task_by_states",
         Mock(return_value=existing_task),
     )
     monkeypatch.setattr(
@@ -295,3 +297,63 @@ def test_bound_team_resolution_error_is_returned(monkeypatch: MonkeyPatch) -> No
     assert task is None
     assert result is None
     assert error == {"error": "Team missing"}
+
+
+def test_subscription_task_followup_is_accepted(monkeypatch: MonkeyPatch) -> None:
+    """Regression: subscription-triggered conversations (is_active=STATE_SUBSCRIPTION)
+    must accept follow-up messages instead of returning "Task not found"."""
+    from app.models.task import TaskResource
+
+    existing_task = _task(
+        {
+            "name": "creator-php-workflow",
+            "namespace": "default",
+            "user_id": 2838,
+        }
+    )
+    bound_team = SimpleNamespace(id=267213, name="creator-php-workflow")
+    store_lookup = Mock(return_value=existing_task)
+    monkeypatch.setattr(task_stores.task_store, "get_task_by_states", store_lookup)
+    monkeypatch.setattr(
+        chat_namespace,
+        "_resolve_task_bound_team",
+        Mock(return_value=bound_team),
+    )
+    client_team = SimpleNamespace(id=273960, name="qbird-direct-log")
+
+    task, result, error = _resolve_existing_task_team(
+        Mock(), existing_task.id, client_team
+    )
+
+    assert error is None
+    assert task is existing_task
+    assert result is bound_team
+    # The lookup must cover both regular active and subscription tasks.
+    states = store_lookup.call_args.kwargs["states"]
+    assert TaskResource.STATE_ACTIVE in states
+    assert TaskResource.STATE_SUBSCRIPTION in states
+
+
+def test_system_namespace_task_is_rejected(monkeypatch: MonkeyPatch) -> None:
+    existing_task = _task(
+        {
+            "name": "creator-php-workflow",
+            "namespace": "default",
+            "user_id": 2838,
+        }
+    )
+    existing_task.namespace = "system"
+    monkeypatch.setattr(
+        task_stores.task_store,
+        "get_task_by_states",
+        Mock(return_value=existing_task),
+    )
+    client_team = SimpleNamespace(id=273960, name="qbird-direct-log")
+
+    task, result, error = _resolve_existing_task_team(
+        Mock(), existing_task.id, client_team
+    )
+
+    assert task is None
+    assert result is None
+    assert error == {"error": "Task not found"}


### PR DESCRIPTION
## Problem

Conversations created by subscription triggers (scheduled pushes) have been unable to continue chatting since yesterday — every message fails with the generic "Request failed: Unknown error" toast.

## Root cause

`chat:send` has always looked up the task with `get_regular_active_task`, which only accepts `STATE_ACTIVE` (is_active=1). Subscription tasks are persisted with `STATE_SUBSCRIPTION` (is_active=2). **The regression is not in the lookup function itself, but in how #3249 changed the handling of a failed lookup:**

- Before : the same `get_regular_active_task` call was only used to fetch `task_json` for the group-chat @mention check. When it returned None, `task_json = {}` and the send flow continued — so daily follow-ups in subscription conversations kept working.
- After: the newly introduced `_resolve_existing_task_team` promoted this lookup to a hard gate for sending; a None result immediately returns `{"error": "Task not found"}` and the send is aborted.

Production evidence: three user retries all logged `chat:send error: Task not found` (chat_namespace.py:841), while the same user's other is_active=1 conversations worked normally that day; the database confirms both tasks have is_active=2.

## Changes

- `_resolve_existing_task_team` now uses `get_task_by_states(states=TaskResource.is_active_query())`, accepting ACTIVE + SUBSCRIPTION, matching the semantics of the REST read path (`get_active_non_deleted_task` in the sharded store). The `namespace != "system"` guard is preserved.
- The REST `create_task_or_append` path intentionally rejects subscription tasks (locked in by `test_append_existing_subscription_task_is_not_treated_as_regular_active_task`), so it is left unchanged.
- The original tests mocked `get_regular_active_task` and never covered the real "task exists but is in SUBSCRIPTION state" case; this PR adds regression tests for it.

## Testing

- Updated the mock targets of existing cases in `tests/api/ws/test_chat_namespace_team_binding.py`; added regression tests: subscription tasks accept follow-ups, and system-namespace tasks are still rejected.
- All 257 tests in `tests/api/ws/` pass; black/isort clean.