### PR TITLE
fix(wework): preserve native tray identity from creation

### DIFF
--- a/docs/en/wework/developer-guide/wework-debug-instance-context.md
+++ b/docs/en/wework/developer-guide/wework-debug-instance-context.md
@@ -59,6 +59,12 @@ instances from the release app and other worktrees. Do not change the UUID
 namespace or replace it with a random GUID because doing so resets users' menu
 bar visibility rules again.
 
+Electron creates the macOS `NSStatusItem` before assigning its `autosaveName`.
+The tray must therefore be constructed with an empty image and receive its real
+icon afterward. This prevents iBar from observing the temporary `Item-0`
+identity and applying an unrelated hidden rule. Do not move the real image back
+into the `Tray` constructor.
+
 The script also exports these values as `VITE_WEWORK_*` so the frontend can display them at runtime.
 
 ## Frontend Display

--- a/docs/zh/wework/developer-guide/wework-debug-instance-context.md
+++ b/docs/zh/wework/developer-guide/wework-debug-instance-context.md
@@ -53,6 +53,10 @@ macOS 托盘会根据 `WEWORK_APP_IDENTIFIER` 派生稳定的 UUID v5，并作�
 `WEWORK_APP_IDENTIFIER` 与正式版和其他 worktree 隔离。不要修改 UUID
 namespace 或改用随机 GUID，否则会再次重置用户的菜单栏显示规则。
 
+Electron 在 macOS 上创建 `NSStatusItem` 后才写入 `autosaveName`。托盘必须先用
+空图片完成构造，再设置真实图标，避免 iBar 在这段窗口期把正式版识别成临时的
+`Item-0` 并套用错误的隐藏规则。不要把真实图片重新放回 `Tray` 构造函数。
+
 脚本也会把这些值导出为 `VITE_WEWORK_*`，供前端在运行时显示。
 
 ## 前端显示

--- a/wework/electron/src/host/tray-icon.test.ts
+++ b/wework/electron/src/host/tray-icon.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test, vi } from 'vitest'
 import type { NativeImage } from 'electron'
-import { convertToTemplateBitmap, createTrayIcon, type NativeImageFactory } from './tray-icon.js'
+import {
+  convertToTemplateBitmap,
+  createTrayBootstrapIcon,
+  createTrayIcon,
+  type NativeImageFactory,
+  type TrayBootstrapImageFactory,
+} from './tray-icon.js'
 
 function image(overrides: Partial<NativeImage> = {}): NativeImage {
   return {
@@ -15,6 +21,31 @@ function image(overrides: Partial<NativeImage> = {}): NativeImage {
 }
 
 describe('tray icon', () => {
+  test('keeps the macOS tray invisible until Electron assigns its persistent identity', () => {
+    const empty = image({ isEmpty: vi.fn(() => true) })
+    const images: TrayBootstrapImageFactory = {
+      createEmpty: vi.fn(() => empty),
+      createFromPath: vi.fn(),
+      createFromBitmap: vi.fn(),
+    }
+
+    expect(createTrayBootstrapIcon(images, '/icons/128x128.png', 'darwin')).toBe(empty)
+    expect(images.createEmpty).toHaveBeenCalledOnce()
+    expect(images.createFromPath).not.toHaveBeenCalled()
+  })
+
+  test('uses the application icon immediately outside macOS', () => {
+    const source = image()
+    const images: TrayBootstrapImageFactory = {
+      createEmpty: vi.fn(),
+      createFromPath: vi.fn(() => source),
+      createFromBitmap: vi.fn(),
+    }
+
+    expect(createTrayBootstrapIcon(images, '/icons/128x128.png', 'linux')).toBe(source)
+    expect(images.createEmpty).not.toHaveBeenCalled()
+  })
+
   test('converts white pixels to transparency and colored pixels to a template mask', () => {
     const bitmap = Buffer.from([255, 255, 255, 255, 0, 120, 240, 255, 30, 20, 10, 128])
 

--- a/wework/electron/src/host/tray-icon.ts
+++ b/wework/electron/src/host/tray-icon.ts
@@ -66,6 +66,23 @@ export interface NativeImageFactory {
   createFromPath(path: string): NativeImage
 }
 
+export interface TrayBootstrapImageFactory extends NativeImageFactory {
+  createEmpty(): NativeImage
+}
+
+export function createTrayBootstrapIcon(
+  images: TrayBootstrapImageFactory,
+  iconPath: string,
+  platform: NodeJS.Platform = process.platform
+): NativeImage {
+  // Electron assigns the macOS NSStatusItem autosaveName after its constructor
+  // sets the initial image. Keep the item invisible until that identity exists
+  // so menu bar managers never observe the temporary Item-0 identity.
+  return platform === 'darwin'
+    ? images.createEmpty()
+    : createTrayIcon(images, iconPath, null, platform)
+}
+
 export function convertToTemplateBitmap(bitmap: Buffer): Buffer {
   const template = Buffer.from(bitmap)
   for (let offset = 0; offset + 3 < template.length; offset += 4) {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -67,7 +67,7 @@ import {
 } from './host/startup-splash.js'
 import { assertStartupRecoverySender, StartupRecoveryService } from './host/startup-recovery.js'
 import { ElectronTrayManager, type TrayAction } from './host/tray-manager.js'
-import { createTrayIcon } from './host/tray-icon.js'
+import { createTrayBootstrapIcon, createTrayIcon } from './host/tray-icon.js'
 import { trayGuidForApplicationId } from './host/tray-guid.js'
 import { TrayNativeStatusController } from './host/tray-native-status.js'
 import { WindowClosePolicy, type WindowCloseDecision } from './host/window-close-policy.js'
@@ -1059,7 +1059,7 @@ function createTrayManager(): ElectronTrayManager<Electron.Menu | null, Tray> {
   const iconPath = join(resourcesRoot, 'icons', '128x128.png')
   const trayGuid = trayGuidForApplicationId(applicationId)
   return new ElectronTrayManager({
-    createTray: () => new Tray(createTrayIcon(nativeImage, iconPath), trayGuid),
+    createTray: () => new Tray(createTrayBootstrapIcon(nativeImage, iconPath), trayGuid),
     buildMenu: template => Menu.buildFromTemplate(template as MenuItemConstructorOptions[]),
     dispatchAction: dispatchTrayAction,
     applyIcon: (tray, state) => {


### PR DESCRIPTION
## Summary

- construct the macOS Electron tray with an empty bootstrap image
- apply the real tray image only after Electron assigns `NSStatusItem.autosaveName`
- preserve the existing stable release GUID and non-macOS tray behavior
- document and unit-test the native creation-order contract

## Root cause

Electron 43.4.1 creates the native macOS `NSStatusItem`, sets the initial image, and only then assigns the `Tray` GUID as `NSStatusItem.autosaveName`. iBar can observe the visible status item before the GUID exists and records it as `Item-0`.

The affected machine's iBar preferences contain both of these rules for the production bundle:

- `8fda9369-51a7-5cd6-9625-cb1b65f440db >>> io.wecode.wework` — always display
- `Item-0 >>> io.wecode.wework` — hidden

The previous fixes only asserted `Tray.getGUID()`, which reports the constructor argument and does not prove that iBar never observed the earlier native `Item-0` state. Changing or restoring GUID values therefore could not close this race.

On macOS this change passes an empty image into the `Tray` constructor. Electron assigns the GUID before the existing tray manager synchronously applies the real image, so the status item becomes observable with its stable identity already attached.

## Verification

- `pnpm test src/host/tray-icon.test.ts src/host/tray-guid.test.ts src/host/tray-manager.test.ts` in `wework/electron` — 19 passed
- `pnpm run typecheck` in `wework/electron` — passed
- changed-file ESLint and Prettier checks — passed
- isolated real Electron startup through `pnpm --filter wework ai:verify start` — passed
- real Electron tray snapshot — `created: true` with stable UUID GUID
- pre-push checks — passed
