### PR TITLE
fix(wework): sync bound work item status

### DIFF
--- a/wework/src/api/deliveries.test.ts
+++ b/wework/src/api/deliveries.test.ts
@@ -36,6 +36,7 @@ describe('createDeliveryApi queue and assignment routes', () => {
     expect(nextTaskTrackingStatus('in_progress', 'cancelled')).toBe('in_review')
     expect(nextTaskTrackingStatus('pending', 'failed')).toBe('in_review')
     expect(nextTaskTrackingStatus('pending', 'succeeded')).toBe('in_review')
+    expect(nextTaskTrackingStatus('in_review', 'succeeded')).toBeNull()
   })
 
   it('lists loop items with queue filters', async () => {

--- a/wework/src/api/deliveries.ts
+++ b/wework/src/api/deliveries.ts
@@ -662,7 +662,7 @@ export function nextTaskTrackingStatus(
   if (executionStatus === 'running' && itemStatus !== 'in_progress') {
     return 'in_progress'
   }
-  if (executionStatus === 'succeeded' && itemStatus !== 'completed') {
+  if (executionStatus === 'succeeded' && itemStatus !== 'completed' && itemStatus !== 'in_review') {
     return 'in_review'
   }
   if (

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -9,7 +9,6 @@ import {
   useState,
 } from 'react'
 import type { HTMLAttributes, OlHTMLAttributes, ReactNode } from 'react'
-import type { Element as HastElement } from 'hast'
 import { FileText, Folder, Link2 } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 import { ComposerLinkChip } from './ComposerLinkChip'
@@ -376,7 +375,9 @@ function estimateMarkdownChunkHeight(content: string): number {
 }
 
 type MarkdownCodeProps = {
-  node?: HastElement
+  node?: {
+    properties?: unknown
+  }
   compact?: boolean
 } & HTMLAttributes<HTMLElement>
 
@@ -384,9 +385,14 @@ function MarkdownCode({ className, children, node, compact = false, ...props }: 
   const isStreaming = useContext(MarkdownStreamingContext)
   const match = /language-(\w*)/.exec(className || '')
   const text = reactNodeToText(children)
+  const nodeDataBlock =
+    typeof node?.properties === 'object' &&
+    node.properties !== null &&
+    'dataBlock' in node.properties &&
+    node.properties.dataBlock === 'true'
   const isBlock =
     ('data-block' in props && Boolean(props['data-block'])) ||
-    node?.properties?.dataBlock === 'true' ||
+    nodeDataBlock ||
     Boolean(match) ||
     text.includes('\n')
   if (isBlock) {

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.test.tsx
@@ -282,6 +282,87 @@ describe('useWorkbenchCloudProjectContext', () => {
     expect(result.current.boundCloudItemStatusOverride).toBe('in_progress')
   })
 
+  test('persists settled execution status for an already-bound work item', async () => {
+    const cloudProject = project('space-cloud', 'local')
+    const runningItem = loopItem(cloudProject.id)
+    const reviewItem = {
+      ...runningItem,
+      status: 'in_review' as const,
+      version: 2,
+    }
+    const runtimeTask = {
+      deviceId: 'local-device',
+      taskId: 'runtime-1',
+    }
+    let currentItem = runningItem
+    const localApi = {
+      findCloudContextForTask: vi.fn().mockImplementation(async () => ({
+        project: cloudProject,
+        loop_item: currentItem,
+        loop_item_id: currentItem.id,
+      })),
+      listCloudFiles: vi.fn().mockResolvedValue({ items: [] }),
+      listCloudProjects: vi.fn().mockResolvedValue({ items: [cloudProject] }),
+      listDeliveries: vi.fn().mockResolvedValue({ items: [] }),
+      listLoopItems: vi.fn().mockImplementation(async () => ({ items: [currentItem] })),
+      updateTaskTrackingStatus: vi.fn().mockImplementation(async () => {
+        currentItem = reviewItem
+        return reviewItem
+      }),
+    }
+    const services = {
+      projectSpaceApis: {
+        local: localApi,
+        defaultLocation: 'local',
+      },
+    } as unknown as WorkbenchServices
+    const { result, rerender } = renderHook(
+      ({
+        runtimeTaskExecutionKnown,
+        runtimeTaskExecutionStatus,
+        runtimeTaskRunning,
+      }: {
+        runtimeTaskExecutionKnown: boolean
+        runtimeTaskExecutionStatus: string | null
+        runtimeTaskRunning: boolean
+      }) =>
+        useWorkbenchCloudProjectContext({
+          active: true,
+          currentRuntimeTask: runtimeTask,
+          currentProjectId: 42,
+          defaultProjectSpace: null,
+          paneKey: 'project:42',
+          runtimeTaskExecutionKnown,
+          runtimeTaskExecutionStatus,
+          runtimeTaskRunning,
+          runtimeTaskTitle: 'Lifecycle task',
+          services,
+          userId: 1,
+        }),
+      {
+        initialProps: {
+          runtimeTaskExecutionKnown: true,
+          runtimeTaskExecutionStatus: 'running',
+          runtimeTaskRunning: true,
+        },
+      }
+    )
+
+    await waitFor(() => expect(result.current.boundCloudItem?.status).toBe('in_progress'))
+
+    rerender({
+      runtimeTaskExecutionKnown: true,
+      runtimeTaskExecutionStatus: 'done',
+      runtimeTaskRunning: false,
+    })
+
+    await waitFor(() =>
+      expect(localApi.updateTaskTrackingStatus).toHaveBeenCalledWith(runtimeTask, 'succeeded')
+    )
+    await waitFor(() => expect(result.current.boundCloudItem?.status).toBe('in_review'))
+    expect(localApi.updateTaskTrackingStatus).toHaveBeenCalledOnce()
+  })
+
   test('automatically selects the configured default project space', async () => {
     const defaultProject = project('space-default')
     const deliveryApi = {

--- a/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
+++ b/wework/src/components/layout/useWorkbenchCloudProjectContext.ts
@@ -9,6 +9,7 @@ import {
 import {
   findProjectSpaceContextForTask,
   isDefaultWorkItemProject,
+  publishProjectSpaceTaskContextChanged,
   publishProjectSpaceTaskBindingChanged,
   projectSpaceKey,
   projectSpaceRef,
@@ -313,6 +314,7 @@ export function useWorkbenchCloudProjectContext({
     []
   )
   const pendingAutoJoinResolutionRef = useRef<PendingAutoJoinResolution | null>(null)
+  const taskStatusSyncKeyRef = useRef<string | null>(null)
   const runtimeTaskTitleRef = useRef(runtimeTaskTitle)
   useEffect(() => {
     runtimeTaskTitleRef.current = runtimeTaskTitle
@@ -446,6 +448,61 @@ export function useWorkbenchCloudProjectContext({
     [services?.deliveryApi, services?.projectSpaceApis?.cloud, services?.projectSpaceApis?.local]
   )
   const boundProjectSpaceApi = boundCloudProject ? projectSpaceApiFor(boundCloudProject) : undefined
+  const taskExecutionStatus = useMemo(
+    () =>
+      normalizeTaskExecutionStatus(
+        runtimeTaskExecutionStatus,
+        runtimeTaskRunning,
+        runtimeTaskExecutionKnown
+      ),
+    [runtimeTaskExecutionKnown, runtimeTaskExecutionStatus, runtimeTaskRunning]
+  )
+
+  useEffect(() => {
+    if (!contextRuntimeTask || !boundCloudProject || !boundCloudItem || !taskExecutionStatus) return
+    if (typeof boundProjectSpaceApi?.updateTaskTrackingStatus !== 'function') return
+    if (!nextTaskTrackingStatus(boundCloudItem.status, taskExecutionStatus)) return
+
+    const syncKey = [
+      contextRuntimeTask.deviceId,
+      contextRuntimeTask.taskId,
+      boundCloudProject.project_store,
+      boundCloudProject.id,
+      boundCloudItem.id,
+      boundCloudItem.status,
+      taskExecutionStatus,
+    ].join(':')
+    if (taskStatusSyncKeyRef.current === syncKey) return
+    taskStatusSyncKeyRef.current = syncKey
+
+    let active = true
+    void boundProjectSpaceApi
+      .updateTaskTrackingStatus(contextRuntimeTask, taskExecutionStatus)
+      .then(updatedItem => {
+        if (!active || !updatedItem) return
+        setBoundCloudItem(updatedItem)
+        setDeliveryItem(cloudItemAsLocalWorkItem(updatedItem, contextRuntimeTask))
+        publishProjectSpaceTaskContextChanged(contextRuntimeTask)
+      })
+      .catch(error => {
+        if (!active) return
+        taskStatusSyncKeyRef.current = null
+        console.warn('[Wework] Failed to sync project-space task status', {
+          task: contextRuntimeTask,
+          executionStatus: taskExecutionStatus,
+          error,
+        })
+      })
+    return () => {
+      active = false
+    }
+  }, [
+    boundCloudItem,
+    boundCloudProject,
+    boundProjectSpaceApi,
+    contextRuntimeTask,
+    taskExecutionStatus,
+  ])
 
   useEffect(() => {
     let active = true
@@ -889,14 +946,9 @@ export function useWorkbenchCloudProjectContext({
             runtimeTaskDescription
           )
           linkedItem = tracked.item
-          const executionStatus = normalizeTaskExecutionStatus(
-            runtimeTaskExecutionStatus,
-            runtimeTaskRunning,
-            runtimeTaskExecutionKnown
-          )
-          if (executionStatus) {
+          if (taskExecutionStatus) {
             linkedItem =
-              (await api.updateTaskTrackingStatus(contextRuntimeTask, executionStatus)) ??
+              (await api.updateTaskTrackingStatus(contextRuntimeTask, taskExecutionStatus)) ??
               linkedItem
           }
         }
@@ -923,9 +975,7 @@ export function useWorkbenchCloudProjectContext({
       contextRuntimeTask,
       projectSpaceApiFor,
       runtimeTaskDescription,
-      runtimeTaskExecutionKnown,
-      runtimeTaskExecutionStatus,
-      runtimeTaskRunning,
+      taskExecutionStatus,
       runtimeTaskTitle,
       t,
       taskBoardAssociation,


### PR DESCRIPTION
## Summary
- persist runtime execution status changes back to already-bound project-space work items
- keep succeeded work items in review without repeated status writes
- decouple AssistantMarkdown code-node typing from a concrete @types/hast version so Wework typecheck passes

## Verification
- pnpm --dir wework test src/api/deliveries.test.ts src/components/layout/useWorkbenchCloudProjectContext.test.tsx
- pnpm --dir wework exec eslint src/components/chat/AssistantMarkdown.tsx src/api/deliveries.ts src/components/layout/useWorkbenchCloudProjectContext.ts src/api/deliveries.test.ts src/components/layout/useWorkbenchCloudProjectContext.test.tsx
- pnpm --dir wework exec prettier --check src/components/chat/AssistantMarkdown.tsx src/api/deliveries.ts src/components/layout/useWorkbenchCloudProjectContext.ts src/api/deliveries.test.ts src/components/layout/useWorkbenchCloudProjectContext.test.tsx
- pnpm --dir wework typecheck
- AI_VERIFIED=1 git push -u upstream fix/wework-bound-task-status-sync


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization between task execution and project task statuses.
  - Completed tasks now correctly update associated work items to **In Review**.
  - Work items already marked **In Review** remain there until manually completed.
  - Status updates are more reliable and can retry after temporary synchronization failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->