### PR TITLE
fix(image): support attachment references for image edits

### DIFF
--- a/backend/app/mcp_server/tools/image_generation.py
+++ b/backend/app/mcp_server/tools/image_generation.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
         "size": "Optional exact output size, for example 1024x1024",
         "max_images": "Number of images to generate, from 1 to 15",
         "reference_images": (
-            "Optional image attachment IDs, HTTP/HTTPS URLs, or base64 data URLs"
+            "Optional image attachment IDs, public HTTP/HTTPS URLs, or base64 data URLs. "
+            "For uploaded or previously generated images, use attachment IDs, "
+            "not Wegent attachment download URLs."
         ),
     },
 )

--- a/backend/app/services/execution/agents/image/generation_service.py
+++ b/backend/app/services/execution/agents/image/generation_service.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 from sqlalchemy.orm import Session
 
 from app.mcp_server.auth import TaskTokenInfo
+from app.models.subtask_context import SubtaskContext
 from app.services.context import context_service
 from app.services.execution.agents.generation_context import (
     resolve_generation_context,
@@ -20,6 +21,7 @@ from app.services.execution.agents.generation_context import (
 from app.services.execution.agents.video.materials import (
     normalize_reference_materials,
 )
+from shared.telemetry.decorators import trace_async
 
 from .attachment_uploader import upload_image_attachment
 from .download_url import (
@@ -30,6 +32,7 @@ from .providers import get_image_provider
 
 
 class ImageGenerationService:
+    @trace_async(span_name="image.generate", tracer_name=__name__)
     async def generate(
         self,
         db: Session,
@@ -66,11 +69,12 @@ class ImageGenerationService:
             token_info.user_id,
         )
         self._validate_reference_images(image_config, descriptors)
+        references = self._resolve_reference_images(db, descriptors)
 
         protocol = model_config.get("protocol") or "seedream"
         result = await get_image_provider(protocol, model_config).generate(
             prompt=prompt_text,
-            reference_images=[item["url"] for item in descriptors],
+            reference_images=references,
         )
         if not result.images:
             raise ValueError("No images generated")
@@ -143,6 +147,33 @@ class ImageGenerationService:
             "persisted": True,
             "result_data": result_data,
         }
+
+    @staticmethod
+    def _resolve_reference_images(
+        db: Session, descriptors: list[dict[str, Any]]
+    ) -> list[str]:
+        """Inline authorized attachments using the same image data as chat inputs."""
+        references: list[str] = []
+        for descriptor in descriptors:
+            if descriptor.get("url"):
+                references.append(descriptor["url"])
+                continue
+            attachment_id = descriptor.get("attachment_id")
+            if attachment_id is None:
+                raise ValueError("Reference image has no readable image data")
+            # normalize_reference_materials has already checked ownership and MIME type.
+            context = db.get(SubtaskContext, attachment_id)
+            block = (
+                context_service.build_vision_content_block(context)
+                if context is not None
+                else None
+            )
+            if block is None:
+                raise ValueError(
+                    f"Reference attachment {attachment_id} has no readable image data"
+                )
+            references.append(block["image_url"]["url"])
+        return references
 
     @staticmethod
     def _validate_reference_images(

--- a/backend/init_data/skills/wegent-image-generation/SKILL.md
+++ b/backend/init_data/skills/wegent-image-generation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: "Use this skill when the user asks to generate, draw, create, or revise an image. Supports text-to-image and image-reference generation."
 displayName: "Image Generation"
-version: "1.0.0"
+version: "1.0.1"
 author: "Wegent Team"
 tags: ["image", "generation", "creative"]
 bindShells: ["Chat", "Agno", "ClaudeCode"]
@@ -20,7 +20,9 @@ Call `generate_image` when the user asks for an image.
 
 - Put the complete visual description in `prompt`.
 - Use `reference_images` only when the user supplied image attachments or URLs.
-- Pass attachment IDs, not local sandbox paths.
+- Pass attachment IDs or public HTTP/HTTPS URLs, not local sandbox paths.
+- For uploaded or previously generated images, pass attachment IDs. Do not pass Wegent
+  attachment download URLs or relative `/api/attachments/...` paths as remote references.
 - Default to one image unless the user explicitly asks for multiple images.
 - The tool saves generated images as task attachments and returns image blocks. Do not create a duplicate card.
 - If the tool returns `error`, explain it once and do not retry unchanged parameters.

--- a/backend/init_data/skills/wegent-image-generation/SKILL.md
+++ b/backend/init_data/skills/wegent-image-generation/SKILL.md
@@ -20,7 +20,8 @@ Call `generate_image` when the user asks for an image.
 
 - Put the complete visual description in `prompt`.
 - Use `reference_images` only when the user supplied image attachments or URLs.
-- Pass attachment IDs or public HTTP/HTTPS URLs, not local sandbox paths.
+- Pass attachment IDs, public HTTP/HTTPS URLs, or base64 data URLs, not local
+  sandbox paths.
 - For uploaded or previously generated images, pass attachment IDs. Do not pass Wegent
   attachment download URLs or relative `/api/attachments/...` paths as remote references.
 - Default to one image unless the user explicitly asks for multiple images.

--- a/backend/tests/services/execution/agents/image/test_generation_service.py
+++ b/backend/tests/services/execution/agents/image/test_generation_service.py
@@ -26,7 +26,9 @@ from app.services.execution.agents.image.providers.base import (
 @pytest.mark.parametrize(
     "reference_images", [None, ["42"], [42, "https://example.com/ref.png", "42"]]
 )
-async def test_generated_image_returns_one_hour_download_url(reference_images) -> None:
+async def test_generated_image_returns_one_hour_download_url(
+    reference_images: list[str | int] | None,
+) -> None:
     token_info = SimpleNamespace(user_id=7, task_id=8, subtask_id=9)
     db = MagicMock()
     attachment = SimpleNamespace(
@@ -123,7 +125,7 @@ async def test_generated_image_returns_one_hour_download_url(reference_images) -
     ],
 )
 def test_reference_attachment_without_image_data_has_actionable_error(
-    attachment,
+    attachment: SimpleNamespace | None,
 ) -> None:
     db = MagicMock()
     db.get.return_value = attachment

--- a/backend/tests/services/execution/agents/image/test_generation_service.py
+++ b/backend/tests/services/execution/agents/image/test_generation_service.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -22,8 +23,28 @@ from app.services.execution.agents.image.providers.base import (
 
 
 @pytest.mark.asyncio
-async def test_generated_image_returns_one_hour_download_url() -> None:
+@pytest.mark.parametrize(
+    "reference_images", [None, ["42"], [42, "https://example.com/ref.png", "42"]]
+)
+async def test_generated_image_returns_one_hour_download_url(reference_images) -> None:
     token_info = SimpleNamespace(user_id=7, task_id=8, subtask_id=9)
+    db = MagicMock()
+    attachment = SimpleNamespace(
+        id=42,
+        user_id=7,
+        context_type="attachment",
+        mime_type="image/png",
+        file_extension=".png",
+        image_base64="aW1hZ2U=",
+        storage_backend="mysql",
+        storage_key="attachments/42",
+        updated_at=datetime(2026, 1, 1),
+        original_filename="image.png",
+        file_size=5,
+        type_data={},
+    )
+    db.query.return_value.filter.return_value.first.return_value = attachment
+    db.get.return_value = attachment
     provider = MagicMock()
     provider.generate = AsyncMock(
         return_value=ImageGenerationResult(
@@ -45,11 +66,6 @@ async def test_generated_image_returns_one_hour_download_url() -> None:
         ),
         patch(
             "app.services.execution.agents.image.generation_service."
-            "normalize_reference_materials",
-            return_value=[],
-        ),
-        patch(
-            "app.services.execution.agents.image.generation_service."
             "get_image_provider",
             return_value=provider,
         ),
@@ -65,10 +81,19 @@ async def test_generated_image_returns_one_hour_download_url() -> None:
         ),
     ):
         result = await ImageGenerationService().generate(
-            db=MagicMock(),
+            db=db,
             token_info=token_info,
             prompt="draw a lighthouse",
+            reference_images=reference_images,
         )
+
+    expected_references = [
+        "data:image/png;base64,aW1hZ2U=" if str(value) == "42" else value
+        for value in reference_images or []
+    ]
+    provider.generate.assert_awaited_once_with(
+        prompt="draw a lighthouse", reference_images=expected_references
+    )
 
     image = result["images"][0]
     parsed_url = urlparse(image["url"])
@@ -86,6 +111,70 @@ async def test_generated_image_returns_one_hour_download_url() -> None:
         "/api/attachments/42/download"
     ]
     assert result["result_data"]["blocks"][0]["image_download_urls"] == [image["url"]]
+
+
+@pytest.mark.parametrize(
+    "attachment",
+    [
+        None,
+        SimpleNamespace(
+            context_type="attachment", file_extension=".png", image_base64=""
+        ),
+    ],
+)
+def test_reference_attachment_without_image_data_has_actionable_error(
+    attachment,
+) -> None:
+    db = MagicMock()
+    db.get.return_value = attachment
+    with pytest.raises(
+        ValueError, match="Reference attachment 42 has no readable image data"
+    ):
+        ImageGenerationService._resolve_reference_images(db, [{"attachment_id": 42}])
+
+
+@pytest.mark.asyncio
+async def test_inaccessible_reference_attachment_never_reaches_provider() -> None:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    with (
+        patch(
+            "app.services.execution.agents.image.generation_service.resolve_generation_context"
+        ),
+        patch(
+            "app.services.execution.agents.image.generation_service.resolve_generation_model",
+            return_value={},
+        ),
+        patch(
+            "app.services.execution.agents.image.generation_service.get_image_provider"
+        ) as provider,
+        pytest.raises(ValueError, match="Reference attachment not found: 42"),
+    ):
+        await ImageGenerationService().generate(
+            db=db,
+            token_info=SimpleNamespace(user_id=7, task_id=8, subtask_id=9),
+            prompt="edit",
+            reference_images=["42"],
+        )
+    provider.assert_not_called()
+    db.get.assert_not_called()
+
+
+def test_reference_data_url_is_preserved() -> None:
+    data_url = "data:image/png;base64,aW1hZ2U="
+    assert ImageGenerationService._resolve_reference_images(
+        MagicMock(), [{"url": data_url}]
+    ) == [data_url]
+
+
+def test_reference_descriptor_url_is_preserved_without_attachment_lookup() -> None:
+    db = MagicMock()
+    url = "https://cdn.example/ref.png"
+
+    assert ImageGenerationService._resolve_reference_images(
+        db, [{"attachment_id": 42, "url": url}]
+    ) == [url]
+    db.get.assert_not_called()
 
 
 def test_reference_image_format_uses_model_capabilities() -> None:


### PR DESCRIPTION
## Summary
- inline authorized image attachment references before sending them to image providers
- keep provider-ready reference URLs unchanged when an external descriptor already supplies one
- document that generated/uploaded image references should use attachment IDs instead of Wegent download URLs

## Tests
- `cd backend && uv run pytest tests/services/execution/agents/image/test_generation_service.py tests/mcp_server/test_generation_tools.py`
- `cd backend && uv run black --check app/services/execution/agents/image/generation_service.py tests/services/execution/agents/image/test_generation_service.py tests/mcp_server/test_generation_tools.py`

Note: `uv run ruff check ...` could not run locally because `ruff` is not installed in the backend environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image generation now supports reference images provided through attachment IDs, public HTTP/HTTPS URLs, or base64 data URLs.
  * Attachment-based references are resolved automatically before image generation.

* **Bug Fixes**
  * Added validation and clearer errors when referenced images are unavailable or lack readable image data.
  * Unsupported local paths, attachment download URLs, and relative attachment paths are no longer accepted as remote references.

* **Documentation**
  * Updated reference-image guidance to clarify supported and unsupported input formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->