### PR TITLE
fix(wework): disable browser toolbar navigation actions without history or while loading

### DIFF
--- a/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-multi-tabs.scenario.mjs
@@ -321,6 +321,12 @@ export function createDesktopScenario({ captureScreenshot, executorHome, resultD
       await waitForFixtureAResponseCount(1)
       const expectedReloadRequestStartCount = fixtureARequestStartCount + 1
       const releaseReloadResponse = holdNextFixtureAResponse()
+      // Reload is disabled while the page is still loading; wait for the
+      // fixture to finish before triggering the reload under test.
+      await control.command('waitFor', BROWSER_RELOAD_SELECTOR, {
+        enabled: true,
+        timeoutMs: uiTimeoutMs,
+      })
       await control.command('click', BROWSER_RELOAD_SELECTOR)
       try {
         await waitForFixtureARequestStartCount(expectedReloadRequestStartCount)

--- a/wework/e2e/desktop/scenarios/embedded-browser-toolbar-actions.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/embedded-browser-toolbar-actions.scenario.mjs
@@ -13,6 +13,12 @@ const ACTIVE_BROWSER_PANEL_SELECTOR =
   ' [data-testid="right-workspace-panel"] div:not(.hidden) > [data-testid="workspace-browser-panel"]'
 const BROWSER_INPUT_SELECTOR =
   ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-url-input"]'
+const BROWSER_BACK_BUTTON_SELECTOR =
+  ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-back-button"]'
+const BROWSER_FORWARD_BUTTON_SELECTOR =
+  ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-forward-button"]'
+const BROWSER_RELOAD_BUTTON_SELECTOR =
+  ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-reload-button"]'
 const BROWSER_MORE_BUTTON_SELECTOR =
   ACTIVE_BROWSER_PANEL_SELECTOR + ' [data-testid="workspace-browser-more-button"]'
 const FIND_ITEM_SELECTOR = '[data-testid="workspace-browser-find-item"]'
@@ -41,20 +47,23 @@ const DEVICE_CLOSE_SELECTOR =
 const SETTINGS_ITEM_SELECTOR = '[data-testid="workspace-browser-settings-item"]'
 const BROWSER_SETTINGS_PAGE_SELECTOR = '[data-testid="browser-settings-page"]'
 const FIXTURE_PATH = '/embedded-browser-toolbar-actions-fixture'
+const SECOND_FIXTURE_PATH = '/embedded-browser-toolbar-actions-fixture-second'
+const HANGING_FIXTURE_PATH = '/embedded-browser-toolbar-actions-fixture-hanging'
+const HANGING_FIXTURE_RELEASE_PATH = '/embedded-browser-toolbar-actions-fixture-hanging-release'
 const BRIDGE_RUNTIME_FILE = 'embedded-browser-bridge.json'
 const BROWSER_LABEL = 'workspace-browser'
 const FIXTURE_WORD = 'Fixture'
 
-function fixtureHtml() {
+function fixtureHtml(title, heading) {
   return [
     '<!doctype html>',
     '<html>',
     '  <head>',
     '    <meta charset="utf-8" />',
-    '    <title>Embedded Browser Toolbar Fixture</title>',
+    `    <title>${title}</title>`,
     '  </head>',
     '  <body>',
-    '    <h1>Embedded Browser Toolbar Fixture</h1>',
+    `    <h1>${heading}</h1>`,
     '    <p>Fixture paragraph one.</p>',
     '    <p>Fixture paragraph two.</p>',
     '  </body>',
@@ -156,6 +165,27 @@ async function waitForElementGone(control, selector, timeoutMs, message) {
   throw new Error(message)
 }
 
+async function waitForElementCount(control, selector, expected, timeoutMs, message) {
+  const startedAt = Date.now()
+  let lastCount = null
+  while (Date.now() - startedAt < timeoutMs) {
+    lastCount = await control.command('getElementCount', selector)
+    if (lastCount === String(expected)) return
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error(`${message}; last count=${lastCount}`)
+}
+
+async function waitForButtonDisabled(control, selector, disabled, timeoutMs, message) {
+  await waitForElementCount(
+    control,
+    disabled ? `${selector}[disabled]` : `${selector}:not([disabled])`,
+    1,
+    timeoutMs,
+    message
+  )
+}
+
 function assertFramesEqual(before, after) {
   assert.equal(before.length, 4, 'Inspector verification returned an invalid before frame')
   assert.equal(after.length, 4, 'Inspector verification returned an invalid after frame')
@@ -168,17 +198,45 @@ function assertFramesEqual(before, after) {
 }
 
 export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
+  const hangingWaiters = []
   return {
     async handleHttp(request, response, url) {
-      if (request.method !== 'GET' || url.pathname !== FIXTURE_PATH) return false
+      if (request.method !== 'GET') return false
+      if (url.pathname === HANGING_FIXTURE_PATH) {
+        await new Promise(resolve => hangingWaiters.push(resolve))
+        response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+        response.end(fixtureHtml('Embedded Browser Hanging Fixture', 'Hanging fixture loaded'))
+        return true
+      }
+      if (url.pathname === HANGING_FIXTURE_RELEASE_PATH) {
+        while (hangingWaiters.length > 0) hangingWaiters.pop()()
+        response.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+        response.end('released')
+        return true
+      }
+      if (url.pathname === SECOND_FIXTURE_PATH) {
+        response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+        response.end(
+          fixtureHtml(
+            'Embedded Browser Toolbar Fixture Two',
+            'Embedded Browser Toolbar Fixture Two'
+          )
+        )
+        return true
+      }
+      if (url.pathname !== FIXTURE_PATH) return false
       response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-      response.end(fixtureHtml())
+      response.end(
+        fixtureHtml('Embedded Browser Toolbar Fixture', 'Embedded Browser Toolbar Fixture')
+      )
       return true
     },
 
     async verify(control) {
       const bridgeIdentity = await waitForBridgeIdentity(executorHome, uiTimeoutMs)
       const fixtureUrl = control.url + FIXTURE_PATH
+      const secondFixtureUrl = control.url + SECOND_FIXTURE_PATH
+      const hangingFixtureUrl = control.url + HANGING_FIXTURE_PATH
 
       await control.command('waitFor', RIGHT_PANEL_TOGGLE_SELECTOR, { timeoutMs: uiTimeoutMs })
       await control.command('click', RIGHT_PANEL_TOGGLE_SELECTOR)
@@ -192,6 +250,110 @@ export function createDesktopScenario({ executorHome, uiTimeoutMs }) {
         fixtureUrl,
         uiTimeoutMs,
         'The browser tab did not load the toolbar fixture'
+      )
+
+      // --- Toolbar navigation button state ---
+      // The first navigation has no history, so back and forward stay disabled.
+      await waitForButtonDisabled(
+        control,
+        BROWSER_BACK_BUTTON_SELECTOR,
+        true,
+        uiTimeoutMs,
+        'Back stayed enabled without navigation history'
+      )
+      await waitForButtonDisabled(
+        control,
+        BROWSER_FORWARD_BUTTON_SELECTOR,
+        true,
+        uiTimeoutMs,
+        'Forward stayed enabled without forward history'
+      )
+      await waitForButtonDisabled(
+        control,
+        BROWSER_RELOAD_BUTTON_SELECTOR,
+        false,
+        uiTimeoutMs,
+        'Reload did not become enabled after the page loaded'
+      )
+
+      // A same-tab navigation creates history and enables back.
+      await control.command('submit', BROWSER_INPUT_SELECTOR, { value: secondFixtureUrl })
+      // Back becoming enabled implies the navigation finished and created history.
+      await waitForButtonDisabled(
+        control,
+        BROWSER_BACK_BUTTON_SELECTOR,
+        false,
+        uiTimeoutMs,
+        'Back did not become enabled after a same-tab navigation'
+      )
+
+      // Going back restores the fixture and enables forward.
+      await control.command('click', BROWSER_BACK_BUTTON_SELECTOR)
+      await waitForValue(
+        control,
+        BROWSER_INPUT_SELECTOR,
+        fixtureUrl,
+        uiTimeoutMs,
+        'The back button did not return to the toolbar fixture'
+      )
+      await waitForButtonDisabled(
+        control,
+        BROWSER_FORWARD_BUTTON_SELECTOR,
+        false,
+        uiTimeoutMs,
+        'Forward did not become enabled after going back'
+      )
+
+      // While a page is loading, back, forward, and reload are all disabled.
+      // The hanging fixture only responds once the release endpoint is hit.
+      await control.command('submit', BROWSER_INPUT_SELECTOR, { value: hangingFixtureUrl })
+      // The reload button turning disabled signals that the panel observed the
+      // loading state; the address bar keeps the previous URL while loading.
+      await waitForButtonDisabled(
+        control,
+        BROWSER_RELOAD_BUTTON_SELECTOR,
+        true,
+        uiTimeoutMs,
+        'Reload stayed enabled while the page was loading'
+      )
+      await waitForButtonDisabled(
+        control,
+        BROWSER_BACK_BUTTON_SELECTOR,
+        true,
+        uiTimeoutMs,
+        'Back stayed enabled while the page was loading'
+      )
+      await waitForButtonDisabled(
+        control,
+        BROWSER_FORWARD_BUTTON_SELECTOR,
+        true,
+        uiTimeoutMs,
+        'Forward stayed enabled while the page was loading'
+      )
+      await fetch(control.url + HANGING_FIXTURE_RELEASE_PATH)
+      await waitForButtonDisabled(
+        control,
+        BROWSER_RELOAD_BUTTON_SELECTOR,
+        false,
+        uiTimeoutMs,
+        'Reload did not recover once the hanging fixture finished loading'
+      )
+
+      // Return to the original fixture for the remaining toolbar checks.
+      await control.command('submit', BROWSER_INPUT_SELECTOR, { value: fixtureUrl })
+      await waitForButtonDisabled(
+        control,
+        BROWSER_RELOAD_BUTTON_SELECTOR,
+        false,
+        uiTimeoutMs,
+        'The browser tab did not return to the toolbar fixture'
+      )
+      await waitForValue(
+        control,
+        BROWSER_INPUT_SELECTOR,
+        fixtureUrl,
+        uiTimeoutMs,
+        'The address bar did not settle back on the toolbar fixture'
       )
 
       if (process.platform === 'darwin') {

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -301,6 +301,53 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     await rm(directory, { recursive: true, force: true })
   })
 
+  test('ignores aborted load rejections instead of recording a navigation error', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockRejectedValue(
+      new Error('ERR_ABORTED (-3) loading "https://example.test/"')
+    )
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+
+    const state = await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    expect(state.navigationError).toBeNull()
+    expect(manager.state('workspace-browser').navigationError).toBeNull()
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  test('clears a stale navigation error when a main-frame navigation commits', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))
+    const manager = new EmbeddedBrowserManager(directory)
+    const contents = new FakeWebContents()
+    contents.loadURL.mockImplementation(async url => {
+      contents.commitUrl(url)
+    })
+    manager.attach('workspace-browser', contents as unknown as WebContents)
+    await manager.open({
+      label: 'workspace-browser',
+      url: 'https://example.test/',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+      navigateExisting: true,
+    })
+
+    contents.emit('did-fail-load', {}, -105, 'ERR_NAME_NOT_RESOLVED', 'https://example.test/', true)
+    expect(manager.state('workspace-browser').navigationError).toMatchObject({ code: -105 })
+
+    contents.commitUrl('https://example.test/')
+    contents.emit('did-navigate', {}, 'https://example.test/')
+    expect(manager.state('workspace-browser').navigationError).toBeNull()
+    await rm(directory, { recursive: true, force: true })
+  })
+
   test('keeps the host cursor visible briefly between adjacent agent actions', async () => {
     vi.useFakeTimers()
     const directory = await mkdtemp(join(tmpdir(), 'wework-browser-manager-'))

--- a/wework/electron/src/host/embedded-browser-manager.test.ts
+++ b/wework/electron/src/host/embedded-browser-manager.test.ts
@@ -415,6 +415,10 @@ describe('EmbeddedBrowserManager lifecycle', () => {
     expect(manager.state('workspace-browser').url).toBe('https://example.test/')
     expect(manager.state('workspace-browser').visible).toBe(true)
 
+    contents.navigationHistory.canGoBack.mockReturnValue(true)
+    expect(manager.state('workspace-browser').canGoBack).toBe(true)
+    expect(manager.state('workspace-browser').canGoForward).toBe(false)
+
     finishNavigation?.()
     await expect(opening).resolves.toMatchObject({
       label: 'workspace-browser',

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -131,6 +131,9 @@ export interface BrowserBackgroundPageState {
 }
 
 const AGENT_CURSOR_IDLE_HIDE_MS = 4_000
+// Chromium's ERR_ABORTED: the load was superseded by a newer navigation, which
+// is a normal race, not a user-facing failure.
+const NAVIGATION_ABORTED_ERROR_CODE = -3
 export const EMBEDDED_BROWSER_PARTITION = 'persist:wework-browser'
 export const EMBEDDED_BROWSER_ROUTE_PARTITION_PREFIX = 'persist:wework-browser-app-route:'
 export const EMBEDDED_BROWSER_ROUTE_HOST_SEPARATOR = ':host:'
@@ -452,6 +455,9 @@ export class EmbeddedBrowserManager {
       if (entry.historyId) void this.history.backfillTitle(entry.historyId, title)
     })
     contents.on('did-navigate', (_event, url) => {
+      // A committed main-frame navigation means a page is on screen again, so
+      // any failure recorded by a superseded load is now stale.
+      entry.navigationError = null
       if (url !== entry.previewDisplayUrl) {
         entry.requestedUrl = url
         entry.previewDisplayUrl = null
@@ -468,7 +474,7 @@ export class EmbeddedBrowserManager {
       emitPageState()
     })
     contents.on('did-fail-load', (_event, code, message, validatedURL, isMainFrame) => {
-      if (!isMainFrame || code === -3) return
+      if (!isMainFrame || code === NAVIGATION_ABORTED_ERROR_CODE) return
       this.recordNavigationFailure(entry, code, message, validatedURL || entry.requestedUrl)
     })
     contents.on('did-start-navigation', (_event, _url, _inPlace, isMainFrame) => {
@@ -1146,6 +1152,10 @@ export class EmbeddedBrowserManager {
       if (!entry.navigationError) {
         const message = error instanceof Error ? error.message : String(error)
         const code = Number(message.match(/\((-?\d+)\)/)?.[1] ?? -2)
+        // loadURL rejects with ERR_ABORTED when a newer navigation supersedes
+        // this one. The winning navigation reports its own outcome, so an
+        // aborted load must not leave a sticky failure on the entry.
+        if (code === NAVIGATION_ABORTED_ERROR_CODE) return
         this.recordNavigationFailure(entry, code, message, url)
       }
     }

--- a/wework/electron/src/host/embedded-browser-manager.ts
+++ b/wework/electron/src/host/embedded-browser-manager.ts
@@ -37,6 +37,8 @@ export interface BrowserPageState {
   title: string | null
   url: string | null
   isLoading: boolean
+  canGoBack: boolean
+  canGoForward: boolean
   visible: boolean
   navigationError: {
     code: number
@@ -618,6 +620,8 @@ export class EmbeddedBrowserManager {
       title: contents.getTitle() || null,
       url: pendingUrl || visibleCurrentUrl || entry.requestedUrl,
       isLoading: contents.isLoading(),
+      canGoBack: contents.navigationHistory.canGoBack(),
+      canGoForward: contents.navigationHistory.canGoForward(),
       visible: entry.visible,
       navigationError: entry.navigationError,
     }

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.test.tsx
@@ -218,6 +218,8 @@ describe('WorkspaceBrowserPanel', () => {
       title: 'Example Domain',
       url: 'https://example.com/',
       isLoading: false,
+      canGoBack: true,
+      canGoForward: true,
     })
     embeddedBrowserMocks.readEmbeddedBrowserAnnotationState.mockResolvedValue({
       label: 'workspace-browser',
@@ -869,6 +871,19 @@ describe('WorkspaceBrowserPanel', () => {
   })
 
   test('controls the embedded native browser from the toolbar and address bar', async () => {
+    let handlePageStateChange!: (pageState: {
+      label: string
+      nativeLabel: string
+      title: string | null
+      url: string | null
+      isLoading: boolean
+      canGoBack?: boolean
+      canGoForward?: boolean
+    }) => void
+    embeddedBrowserMocks.listenEmbeddedBrowserPageStateChanges.mockImplementation(handler => {
+      handlePageStateChange = handler
+      return Promise.resolve(() => undefined)
+    })
     mockBrowserHostRect()
     render(<WorkspaceBrowserPanel active />)
 
@@ -880,6 +895,18 @@ describe('WorkspaceBrowserPanel', () => {
 
     await waitFor(() => {
       expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalled()
+    })
+
+    act(() => {
+      handlePageStateChange({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        title: 'Example Domain',
+        url: 'https://example.com/',
+        isLoading: false,
+        canGoBack: true,
+        canGoForward: true,
+      })
     })
 
     fireEvent.click(screen.getByTestId('workspace-browser-back-button'))
@@ -898,6 +925,75 @@ describe('WorkspaceBrowserPanel', () => {
         'workspace-browser'
       )
     })
+  })
+
+  test('disables back, forward and reload while loading or without navigation history', async () => {
+    let handlePageStateChange!: (pageState: {
+      label: string
+      nativeLabel: string
+      title: string | null
+      url: string | null
+      isLoading: boolean
+      canGoBack?: boolean
+      canGoForward?: boolean
+    }) => void
+    embeddedBrowserMocks.listenEmbeddedBrowserPageStateChanges.mockImplementation(handler => {
+      handlePageStateChange = handler
+      return Promise.resolve(() => undefined)
+    })
+    embeddedBrowserMocks.readEmbeddedBrowserPageState.mockResolvedValue({
+      nativeLabel: 'workspace-browser-native-1',
+      title: 'Example Domain',
+      url: 'https://example.com/',
+      isLoading: false,
+      canGoBack: false,
+      canGoForward: false,
+    })
+    mockBrowserHostRect()
+    render(<WorkspaceBrowserPanel active />)
+
+    const input = screen.getByTestId('workspace-browser-url-input')
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.submit(input.closest('form')!)
+    await screen.findByTestId('workspace-browser-native-view')
+
+    // Without navigation history, back and forward stay disabled while reload works.
+    await waitFor(() => {
+      expect(screen.getByTestId('workspace-browser-back-button')).toBeDisabled()
+      expect(screen.getByTestId('workspace-browser-forward-button')).toBeDisabled()
+      expect(screen.getByTestId('workspace-browser-reload-button')).not.toBeDisabled()
+    })
+
+    // A navigation enables history-dependent actions.
+    act(() => {
+      handlePageStateChange({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        title: 'Example Domain',
+        url: 'https://example.com/next',
+        isLoading: false,
+        canGoBack: true,
+        canGoForward: false,
+      })
+    })
+    expect(screen.getByTestId('workspace-browser-back-button')).not.toBeDisabled()
+    expect(screen.getByTestId('workspace-browser-forward-button')).toBeDisabled()
+
+    // While a page is loading, all navigation actions are disabled.
+    act(() => {
+      handlePageStateChange({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        title: 'Example Domain',
+        url: 'https://example.com/next',
+        isLoading: true,
+        canGoBack: true,
+        canGoForward: true,
+      })
+    })
+    expect(screen.getByTestId('workspace-browser-back-button')).toBeDisabled()
+    expect(screen.getByTestId('workspace-browser-forward-button')).toBeDisabled()
+    expect(screen.getByTestId('workspace-browser-reload-button')).toBeDisabled()
   })
 
   test('opens the native browser again when the first open fails', async () => {
@@ -3065,6 +3161,19 @@ describe('WorkspaceBrowserPanel', () => {
   })
 
   test('discards a pending page read after the browser panel unmounts', async () => {
+    let handlePageStateChange!: (pageState: {
+      label: string
+      nativeLabel: string
+      title: string | null
+      url: string | null
+      isLoading: boolean
+      canGoBack?: boolean
+      canGoForward?: boolean
+    }) => void
+    embeddedBrowserMocks.listenEmbeddedBrowserPageStateChanges.mockImplementation(handler => {
+      handlePageStateChange = handler
+      return Promise.resolve(() => undefined)
+    })
     mockBrowserHostRect()
     const staleTitleChange = vi.fn()
     const firstView = render(<WorkspaceBrowserPanel active onTitleChange={staleTitleChange} />)
@@ -3073,6 +3182,18 @@ describe('WorkspaceBrowserPanel', () => {
     fireEvent.change(input, { target: { value: 'example.com' } })
     fireEvent.submit(input.closest('form')!)
     await waitFor(() => expect(embeddedBrowserMocks.openEmbeddedBrowser).toHaveBeenCalled())
+
+    act(() => {
+      handlePageStateChange({
+        label: 'workspace-browser',
+        nativeLabel: 'workspace-browser-native-1',
+        title: 'Example Domain',
+        url: 'https://example.com/',
+        isLoading: false,
+        canGoBack: true,
+        canGoForward: false,
+      })
+    })
 
     let resolvePageState!: (state: { nativeLabel: string; title: string; url: string }) => void
     const pendingPageState = new Promise<{

--- a/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx
@@ -415,6 +415,8 @@ export function WorkspaceBrowserTabPanel({
   const [browserOpenAttempt, setBrowserOpenAttempt] = useState(0)
   const [pageUrl, setPageUrl] = useState<string | null>(initialTransferredUrl)
   const [status, setStatus] = useState<BrowserStatus>(initialTransferredUrl ? 'ready' : 'idle')
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [navigationError, setNavigationError] = useState<EmbeddedBrowserNavigationError | null>(
     null
@@ -501,11 +503,15 @@ export function WorkspaceBrowserTabPanel({
   const applyNativePageStatus = useCallback(
     (pageState: {
       isLoading: boolean
+      canGoBack?: boolean
+      canGoForward?: boolean
       navigationError?: EmbeddedBrowserNavigationError | null
     }) => {
       const nextNavigationError = pageState.navigationError ?? null
       setNavigationError(nextNavigationError)
       setStatus(nextNavigationError ? 'error' : pageState.isLoading ? 'loading' : 'ready')
+      setCanGoBack(Boolean(pageState.canGoBack))
+      setCanGoForward(Boolean(pageState.canGoForward))
     },
     []
   )
@@ -2429,7 +2435,9 @@ export function WorkspaceBrowserTabPanel({
           <BrowserToolbarButton
             testId="workspace-browser-back-button"
             label={t('workbench.browser_back')}
-            disabled={!currentUrl || !embeddedBrowserAvailable}
+            disabled={
+              !currentUrl || !embeddedBrowserAvailable || !canGoBack || status === 'loading'
+            }
             onClick={() => void runBrowserCommand(() => goBackEmbeddedBrowser(label))}
           >
             <ArrowLeft className="h-4 w-4" />
@@ -2437,7 +2445,9 @@ export function WorkspaceBrowserTabPanel({
           <BrowserToolbarButton
             testId="workspace-browser-forward-button"
             label={t('workbench.browser_forward')}
-            disabled={!currentUrl || !embeddedBrowserAvailable}
+            disabled={
+              !currentUrl || !embeddedBrowserAvailable || !canGoForward || status === 'loading'
+            }
             onClick={() => void runBrowserCommand(() => goForwardEmbeddedBrowser(label))}
           >
             <ArrowRight className="h-4 w-4" />
@@ -2445,7 +2455,7 @@ export function WorkspaceBrowserTabPanel({
           <BrowserToolbarButton
             testId="workspace-browser-reload-button"
             label={t('workbench.browser_reload')}
-            disabled={!activePageUrl}
+            disabled={!activePageUrl || status === 'loading'}
             onClick={handleReload}
           >
             <RotateCw className="h-4 w-4" />

--- a/wework/src/lib/embedded-browser.ts
+++ b/wework/src/lib/embedded-browser.ts
@@ -53,6 +53,8 @@ export interface EmbeddedBrowserPageState {
   title: string | null
   url: string | null
   isLoading: boolean
+  canGoBack?: boolean
+  canGoForward?: boolean
   navigationError?: EmbeddedBrowserNavigationError | null
   invalidTlsCertificate?: EmbeddedBrowserInvalidTlsCertificateEvent | null
 }


### PR DESCRIPTION
## Problem

In the Wework built-in browser toolbar, the back, forward, and reload buttons were clickable at the wrong times:

- Back and forward were always enabled, even before any navigation history existed.
- Back, forward, and reload all stayed clickable while a page was still loading.

## Root cause

The toolbar buttons were only gated on "is there a URL", never on loading state or navigation history.

## Changes

- `wework/electron/src/host/embedded-browser-manager.ts`: include `canGoBack` / `canGoForward` (from `webContents.navigationHistory`) in the browser page state emitted to the renderer.
- `wework/src/lib/embedded-browser.ts`: expose the new optional fields on `EmbeddedBrowserPageState`.
- `wework/src/components/layout/workspace-panels/WorkspaceBrowserPanel.tsx`: track `canGoBack` / `canGoForward` from page-state events; back/forward are enabled only when matching history exists, and back/forward/reload are all disabled while a page is loading.

## Testing

- Unit: new case covering "disabled without history -> back enabled after navigation -> all disabled while loading"; 101 tests pass across `WorkspaceBrowserPanel` and `embedded-browser-manager`.
- Real Electron: extended the existing `browser-toolbar-actions` desktop E2E scenario (covered by GitHub CI) with assertions for the disabled states during a hanging page load and for back/forward enablement after same-tab navigation; the checkpoint passes against the packaged app.
- `prettier`, `eslint`, and `tsc --noEmit` pass for the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded browser toolbar controls now reflect available back and forward navigation history.
  * Navigation controls remain disabled while pages are loading or when navigation is unavailable.
  * Improved support for reloads, navigation history, blocked responses, and recovery from stalled page loads.

* **Bug Fixes**
  * Aborted navigations are no longer reported as failures.
  * Stale navigation errors are cleared after successful page navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->