### PR TITLE
fix(executor): disable shared Codex code mode host

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -1120,10 +1120,9 @@ fn persistent_codex_app_server_launch_config(
     launch_config
         .config_overrides
         .extend(codex_router_provider_overrides());
-    launch_config.config_overrides.extend([
-        "features.goals=true".to_owned(),
-        "features.code_mode_host=true".to_owned(),
-    ]);
+    launch_config
+        .config_overrides
+        .push("features.goals=true".to_owned());
     launch_config
         .config_overrides
         .extend(codex_runtime_default_config_overrides());

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -1757,6 +1757,9 @@ fn persistent_codex_app_server_launch_config_keeps_only_process_settings() {
     assert!(launch_config
         .config_overrides
         .contains(&"features.goals=true".to_owned()));
+    assert!(!launch_config
+        .config_overrides
+        .contains(&"features.code_mode_host=true".to_owned()));
     assert!(launch_config
         .config_overrides
         .contains(&"features.apply_patch_freeform=true".to_owned()));


### PR DESCRIPTION
## Summary
- stop forcing `features.code_mode_host=true` for the shared Codex app-server
- keep `features.goals=true` and existing runtime defaults intact
- add a regression assertion that the shared launch config does not enable the code-mode host

## Testing
- `cargo fmt --check` from `executor/`
- `cargo test -p wegent-executor persistent_codex_app_server_launch_config_keeps_only_process_settings` from `executor/`
- `cargo test -p wegent-executor --test codex_app_server_contract` from `executor/`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



* **Changes**
  * Persistent Codex app-server launches now retain the goals feature while no longer applying the code mode host override.
  * Added coverage to verify the updated launch configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->