### PR TITLE
fix(frontend): simplify mobile image generation controls

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
   packages: read
 
@@ -378,10 +379,12 @@ jobs:
           uv pip install -e ../shared
 
       - name: Download frontend E2E build
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: frontend-next-build
-          path: .ci-artifacts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          .github/scripts/download-actions-artifact.sh \
+            frontend-next-build \
+            .ci-artifacts
 
       - name: Install Knowledge Runtime dependencies
         run: uv sync --project knowledge_runtime --frozen
@@ -747,10 +750,12 @@ jobs:
           key: ${{ steps.claude-code-cli-cache.outputs.cache-primary-key }}
 
       - name: Download frontend E2E build
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: frontend-next-build
-          path: .ci-artifacts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          .github/scripts/download-actions-artifact.sh \
+            frontend-next-build \
+            .ci-artifacts
 
       - name: Restore frontend E2E build
         run: .github/scripts/restore-frontend-e2e-build.sh

--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -140,6 +140,17 @@ jest.mock('@/features/tasks/components/selector/VideoSettingsPopover', () => ({
   ),
 }))
 
+jest.mock('@/features/tasks/components/selector/ImageSizeSelector', () => ({
+  __esModule: true,
+  default: ({ inline, selectedSize }: { inline?: boolean; selectedSize?: string }) => (
+    <div
+      data-testid="image-size-selector-inline"
+      data-inline={inline ? 'true' : 'false'}
+      data-selected-size={selectedSize}
+    />
+  ),
+}))
+
 jest.mock('@/features/tasks/components/selector/MobileRepositorySelector', () => ({
   __esModule: true,
   default: () => <button type="button">Repository</button>,
@@ -604,7 +615,7 @@ describe('MobileChatInputControls layout', () => {
     expect(screen.getByTestId('send-button')).toBeInTheDocument()
   })
 
-  it('shows the image agent and model selectors in the primary row', () => {
+  it('moves image model and size controls out of the primary row', () => {
     render(
       <MobileChatInputControls
         {...buildProps()}
@@ -612,19 +623,53 @@ describe('MobileChatInputControls layout', () => {
         selectedImageModel={null}
         onImageModelChange={jest.fn()}
         isImageModelsLoading={false}
+        selectedImageSize="2048x2048"
+        onImageSizeChange={jest.fn()}
       />
     )
 
     expect(screen.getByTestId('mobile-team-selector-slot')).toContainElement(
       screen.getByTestId('mobile-team-selector')
     )
-    expect(screen.getByTestId('mobile-image-model-selector-slot')).toContainElement(
-      screen.getByTestId('mobile-image-model-selector')
-    )
+    expect(screen.queryByTestId('mobile-image-model-selector-slot')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-image-model-selector')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mobile-image-configuration-button')).toHaveClass('h-11', 'w-11')
+
+    fireEvent.click(screen.getByTestId('mobile-image-configuration-button'))
+
+    const imageConfiguration = screen.getByTestId('mobile-image-configuration')
+    expect(imageConfiguration).toContainElement(screen.getByTestId('mobile-image-model-selector'))
+    expect(imageConfiguration).toContainElement(screen.getByTestId('image-size-selector-inline'))
     expect(screen.getByTestId('mobile-image-model-selector')).toHaveAttribute(
       'data-trigger-variant',
-      'compact'
+      'settings-row'
+    )
+    expect(screen.getByTestId('image-size-selector-inline')).toHaveAttribute('data-inline', 'true')
+    expect(screen.getByTestId('image-size-selector-inline')).toHaveAttribute(
+      'data-selected-size',
+      '2048x2048'
     )
     expect(screen.queryByTestId('mobile-model-selector-slot')).not.toBeInTheDocument()
+  })
+
+  it('marks the mobile image configuration trigger when a model is required', () => {
+    render(
+      <MobileChatInputControls
+        {...buildProps()}
+        taskType="image"
+        selectedImageModel={null}
+        onImageModelChange={jest.fn()}
+        isModelSelectionRequired
+      />
+    )
+
+    expect(screen.getByTestId('mobile-image-configuration-button')).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    )
+    expect(screen.getByTestId('mobile-image-configuration-button')).toHaveClass(
+      'border-error',
+      'text-error'
+    )
   })
 })

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -470,6 +470,8 @@ export function ChatInputControls({
         selectedImageModel={selectedImageModel}
         onImageModelChange={onImageModelChange}
         isImageModelsLoading={isImageModelsLoading}
+        selectedImageSize={selectedImageSize}
+        onImageSizeChange={onImageSizeChange}
         showVideoControlsInChat={showVideoControlsInChat}
         selectedResolution={selectedResolution}
         onResolutionChange={onResolutionChange}

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -8,6 +8,7 @@ import React, { useMemo, useState, useCallback, type Dispatch, type SetStateActi
 import { ChevronRight, CircleStop, Hand, Plus, SlidersHorizontal, Zap } from 'lucide-react'
 import MobileModelSelector from '../selector/MobileModelSelector'
 import type { Model } from '../selector/ModelSelector'
+import ImageSizeSelector from '../selector/ImageSizeSelector'
 import VideoGenerationModeSelector from '../selector/VideoGenerationModeSelector'
 import VideoSettingsPopover from '../selector/VideoSettingsPopover'
 import MobileTeamSelector from '../selector/MobileTeamSelector'
@@ -100,6 +101,8 @@ export interface MobileChatInputControlsProps {
   selectedImageModel?: Model | null
   onImageModelChange?: (model: Model) => void
   isImageModelsLoading?: boolean
+  selectedImageSize?: string
+  onImageSizeChange?: (size: string) => void
   showVideoControlsInChat?: boolean
   selectedResolution?: string
   onResolutionChange?: (resolution: string) => void
@@ -194,6 +197,8 @@ export function MobileChatInputControls({
   selectedImageModel,
   onImageModelChange,
   isImageModelsLoading = false,
+  selectedImageSize = '1024x1024',
+  onImageSizeChange,
   showVideoControlsInChat = false,
   selectedResolution = '720p',
   onResolutionChange,
@@ -234,6 +239,7 @@ export function MobileChatInputControls({
   const { t } = useTranslation('chat')
   const [resourceDrawerOpen, setResourceDrawerOpen] = useState(false)
   const [videoConfigurationDrawerOpen, setVideoConfigurationDrawerOpen] = useState(false)
+  const [imageConfigurationDrawerOpen, setImageConfigurationDrawerOpen] = useState(false)
   const [nestedSelectorOpen, setNestedSelectorOpen] = useState(false)
   const [skillDrawerOpen, setSkillDrawerOpen] = useState(false)
   const showChatContexts = canUseChatContexts(taskType, selectedTeam)
@@ -277,6 +283,7 @@ export function MobileChatInputControls({
   )
   const showVideoConfiguration =
     showVideoGenerationModeAction || showVideoModelAction || showVideoSettings
+  const showImageConfiguration = Boolean(isImageMode && (onImageModelChange || onImageSizeChange))
   const hasMoreActions =
     showAttachmentAction ||
     showChatContexts ||
@@ -463,23 +470,29 @@ export function MobileChatInputControls({
           </div>
         )}
 
-        {isImageMode && onImageModelChange && (
-          <div
-            className="min-w-0 flex-1 overflow-hidden"
-            data-testid="mobile-image-model-selector-slot"
+        {showImageConfiguration && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-expanded={imageConfigurationDrawerOpen}
+            aria-invalid={isModelSelectionRequired || undefined}
+            aria-label={t('image.settings_title')}
+            data-testid="mobile-image-configuration-button"
+            title={t('image.settings_title')}
+            onClick={() => {
+              setResourceDrawerOpen(false)
+              setImageConfigurationDrawerOpen(true)
+            }}
+            disabled={isStreaming || Boolean(hideSelectors)}
+            className={`h-11 w-11 shrink-0 rounded-xl border hover:bg-hover hover:text-text-primary ${
+              isModelSelectionRequired
+                ? 'border-error bg-error/5 text-error'
+                : 'border-border bg-base text-text-muted'
+            }`}
           >
-            <MobileModelSelector
-              selectedModel={selectedImageModel ?? null}
-              setSelectedModel={model => model && onImageModelChange(model)}
-              forceOverride={false}
-              setForceOverride={() => {}}
-              selectedTeam={selectedTeam}
-              disabled={isStreaming}
-              isLoading={isImageModelsLoading}
-              modelCategoryType="image"
-              triggerVariant="compact"
-            />
-          </div>
+            <SlidersHorizontal className="h-5 w-5" />
+          </Button>
         )}
         {showVideoConfiguration && (
           <Button
@@ -617,6 +630,54 @@ export function MobileChatInputControls({
                   </Button>
                 </div>
               )}
+            </div>
+          </DrawerContent>
+        )}
+      </Drawer>
+
+      <Drawer open={imageConfigurationDrawerOpen} onOpenChange={setImageConfigurationDrawerOpen}>
+        {imageConfigurationDrawerOpen && (
+          <DrawerContent
+            className="max-h-[85vh] bg-[#f2f2f7] dark:bg-[#1c1c1e]"
+            showHandle={false}
+            data-testid="mobile-image-configuration-menu"
+          >
+            <div className="flex justify-center pb-3 pt-2">
+              <div className="h-1 w-9 rounded-full bg-[#3c3c43]/30 dark:bg-[#5c5c5e]" />
+            </div>
+            <div
+              className="max-h-[65vh] min-h-0 flex-1 overflow-y-auto px-4 pb-4"
+              style={{ paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}
+            >
+              <div className="px-1 pb-2 text-xs font-medium text-[#8e8e93]">
+                {t('image.settings_title')}
+              </div>
+              <div
+                className="divide-y divide-border overflow-hidden rounded-xl bg-white dark:bg-[#2c2c2e]"
+                data-testid="mobile-image-configuration"
+              >
+                {onImageModelChange && (
+                  <MobileModelSelector
+                    selectedModel={selectedImageModel ?? null}
+                    setSelectedModel={model => model && onImageModelChange(model)}
+                    forceOverride={false}
+                    setForceOverride={() => {}}
+                    selectedTeam={selectedTeam}
+                    disabled={isStreaming}
+                    isLoading={isImageModelsLoading}
+                    modelCategoryType="image"
+                    triggerVariant="settings-row"
+                  />
+                )}
+                {onImageSizeChange && (
+                  <ImageSizeSelector
+                    selectedSize={selectedImageSize}
+                    onSizeChange={onImageSizeChange}
+                    disabled={isStreaming}
+                    inline
+                  />
+                )}
+              </div>
             </div>
           </DrawerContent>
         )}

--- a/frontend/src/features/tasks/components/selector/ImageSizeSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/ImageSizeSelector.tsx
@@ -23,6 +23,7 @@ export interface ImageSizeSelectorProps {
   availableSizes?: ImageSizeOption[]
   disabled?: boolean
   compact?: boolean
+  inline?: boolean
 }
 
 const DEFAULT_IMAGE_SIZES: ImageSizeOption[] = [
@@ -81,6 +82,7 @@ export function ImageSizeSelector({
   availableSizes = DEFAULT_IMAGE_SIZES,
   disabled = false,
   compact = false,
+  inline = false,
 }: ImageSizeSelectorProps) {
   const { t } = useTranslation('chat')
   const [isOpen, setIsOpen] = useState(false)
@@ -109,6 +111,80 @@ export function ImageSizeSelector({
     .filter(Boolean)
     .join(' · ')
 
+  const settingsContent = (
+    <div className="space-y-4">
+      <section>
+        <h4 className="mb-2 text-sm font-medium text-text-primary">{t('image.ratio_section')}</h4>
+        <div className="flex flex-wrap gap-1 rounded bg-surface p-1">
+          {ratios.map(ratio => (
+            <button
+              key={ratio}
+              type="button"
+              data-testid={`image-ratio-${ratio.replace(':', '-')}`}
+              onClick={() => selectPreset(ratio, selectedResolution)}
+              disabled={disabled}
+              className={cn(
+                'flex min-w-[52px] flex-col items-center justify-center gap-1 rounded px-2 py-1.5',
+                'text-xs transition-colors',
+                selectedRatio === ratio
+                  ? 'bg-primary/10 text-text-primary'
+                  : 'text-text-secondary hover:bg-base',
+                'disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            >
+              <RatioIcon ratio={ratio} selected={selectedRatio === ratio} />
+              <span>{ratio}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h4 className="mb-2 text-sm font-medium text-text-primary">
+          {t('image.resolution_section')}
+        </h4>
+        <div className="flex gap-1 rounded bg-surface p-1">
+          {resolutions.map(resolution => (
+            <button
+              key={resolution}
+              type="button"
+              data-testid={`image-resolution-${resolution.toLowerCase()}`}
+              onClick={() => selectPreset(selectedRatio, resolution)}
+              disabled={disabled}
+              className={cn(
+                'flex-1 rounded py-1.5 text-sm transition-colors',
+                selectedResolution === resolution
+                  ? 'bg-primary/10 text-text-primary'
+                  : 'text-text-secondary hover:bg-base',
+                'disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            >
+              {resolution}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h4 className="mb-2 text-sm font-medium text-text-primary">{t('image.size_section')}</h4>
+        <div
+          className="rounded bg-surface px-3 py-2 text-sm text-text-secondary"
+          data-testid="image-size-value"
+        >
+          {selectedOption?.value ?? selectedSize}
+        </div>
+      </section>
+    </div>
+  )
+
+  if (inline) {
+    return (
+      <div className="p-4" data-testid="image-size-selector-inline">
+        {settingsContent}
+      </div>
+    )
+  }
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
@@ -133,69 +209,7 @@ export function ImageSizeSelector({
         align="start"
         sideOffset={4}
       >
-        <div className="space-y-4">
-          <section>
-            <h4 className="mb-2 text-sm font-medium text-text-primary">
-              {t('image.ratio_section')}
-            </h4>
-            <div className="flex flex-wrap gap-1 rounded bg-surface p-1">
-              {ratios.map(ratio => (
-                <button
-                  key={ratio}
-                  type="button"
-                  data-testid={`image-ratio-${ratio.replace(':', '-')}`}
-                  onClick={() => selectPreset(ratio, selectedResolution)}
-                  className={cn(
-                    'flex min-w-[52px] flex-col items-center justify-center gap-1 rounded px-2 py-1.5',
-                    'text-xs transition-colors',
-                    selectedRatio === ratio
-                      ? 'bg-primary/10 text-text-primary'
-                      : 'text-text-secondary hover:bg-base'
-                  )}
-                >
-                  <RatioIcon ratio={ratio} selected={selectedRatio === ratio} />
-                  <span>{ratio}</span>
-                </button>
-              ))}
-            </div>
-          </section>
-
-          <section>
-            <h4 className="mb-2 text-sm font-medium text-text-primary">
-              {t('image.resolution_section')}
-            </h4>
-            <div className="flex gap-1 rounded bg-surface p-1">
-              {resolutions.map(resolution => (
-                <button
-                  key={resolution}
-                  type="button"
-                  data-testid={`image-resolution-${resolution.toLowerCase()}`}
-                  onClick={() => selectPreset(selectedRatio, resolution)}
-                  className={cn(
-                    'flex-1 rounded py-1.5 text-sm transition-colors',
-                    selectedResolution === resolution
-                      ? 'bg-primary/10 text-text-primary'
-                      : 'text-text-secondary hover:bg-base'
-                  )}
-                >
-                  {resolution}
-                </button>
-              ))}
-            </div>
-          </section>
-
-          <section>
-            <h4 className="mb-2 text-sm font-medium text-text-primary">
-              {t('image.size_section')}
-            </h4>
-            <div
-              className="rounded bg-surface px-3 py-2 text-sm text-text-secondary"
-              data-testid="image-size-value"
-            >
-              {selectedOption?.value ?? selectedSize}
-            </div>
-          </section>
-        </div>
+        {settingsContent}
       </PopoverContent>
     </Popover>
   )

--- a/frontend/src/features/tasks/components/selector/ImageSizeSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/ImageSizeSelector.tsx
@@ -152,7 +152,7 @@ export function ImageSizeSelector({
               onClick={() => selectPreset(selectedRatio, resolution)}
               disabled={disabled}
               className={cn(
-                'flex-1 rounded py-1.5 text-sm transition-colors',
+                'min-h-11 flex-1 rounded py-1.5 text-sm transition-colors',
                 selectedResolution === resolution
                   ? 'bg-primary/10 text-text-primary'
                   : 'text-text-secondary hover:bg-base',

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -773,6 +773,7 @@
   },
   "image": {
     "title": "Image Generation",
+    "settings_title": "Image settings",
     "model_selector": "Select Image Model",
     "search_model": "Search image models...",
     "size_selector": "Select Size",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -773,6 +773,7 @@
   },
   "image": {
     "title": "图片生成",
+    "settings_title": "图片设置",
     "model_selector": "选择图片模型",
     "search_model": "搜索图片模型...",
     "size_selector": "选择尺寸",


### PR DESCRIPTION
## Summary
- Move mobile image model selection into a compact image settings drawer
- Surface image size selection in the same mobile drawer
- Keep required-model feedback on the settings trigger

## Tests
- pnpm --dir frontend exec jest src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx src/__tests__/features/tasks/components/selector/ImageSizeSelector.test.tsx
- pnpm --dir frontend exec prettier --check src/features/tasks/components/input/MobileChatInputControls.tsx src/features/tasks/components/input/ChatInputControls.tsx src/features/tasks/components/selector/ImageSizeSelector.tsx src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx src/i18n/locales/zh-CN/chat.json src/i18n/locales/en/chat.json
- pnpm --dir frontend exec eslint src/features/tasks/components/input/MobileChatInputControls.tsx src/features/tasks/components/input/ChatInputControls.tsx src/features/tasks/components/selector/ImageSizeSelector.tsx src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
- pnpm --dir frontend exec tsc --noEmit --pretty false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a mobile image-generation settings drawer for selecting the image model and size.
  - Added inline image-size controls within the settings drawer.
  - Added error styling when an image model is required but not selected.
  - Added English and Chinese translations for the image-generation settings title.

- **Tests**
  - Added coverage for the mobile image-configuration drawer, inline size controls, and validation styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->