### PR TITLE
fix(wework): restore pre-push test concurrency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -147,6 +147,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run settings configuration check
         run: |
@@ -158,6 +160,9 @@ jobs:
 
       - name: Test CI cache policy
         run: .github/scripts/test-ci-cache-policy.sh
+
+      - name: Test AI push gate
+        run: scripts/hooks/test-ai-push-gate.sh
 
       - name: Test Wegent release policy
         run: scripts/test-publish-image-release-policy.sh

--- a/scripts/hooks/ai-push-gate.sh
+++ b/scripts/hooks/ai-push-gate.sh
@@ -197,7 +197,7 @@ run_wework_unit_tests() {
 
     if [ "$WEWORK_RENDERER_CHANGED" -eq 1 ]; then
         if [ "$WEWORK_RENDERER_FULL_TESTS" -eq 1 ]; then
-            test_workers="${WEWORK_PRE_PUSH_TEST_WORKERS:-1}"
+            test_workers="${WEWORK_PRE_PUSH_TEST_WORKERS:-2}"
             echo -e "   Running full renderer unit tests with $(format_worker_count "$test_workers")..."
             if ! pnpm --filter wework exec vitest run --dir src --pool=threads \
                 --maxWorkers "$test_workers" \

--- a/scripts/hooks/test-ai-push-gate.sh
+++ b/scripts/hooks/test-ai-push-gate.sh
@@ -53,6 +53,10 @@ for cmd in cargo uv black isort pytest npm npx pnpm; do
 done
 
 export CALL_LOG
+export GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-Wegent Push Gate Test}"
+export GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-push-gate-test@localhost}"
+export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-$GIT_AUTHOR_NAME}"
+export GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$GIT_AUTHOR_EMAIL}"
 
 # This historical range changes only backend Python files. It exercises the
 # Python module branch without pulling frontend or executor checks into the
@@ -241,15 +245,15 @@ bash "$PROJECT_ROOT/scripts/hooks/ai-push-gate.sh" <<EOF >"$WEWORK_FULL_TEST_OUT
 refs/heads/topic $WEWORK_FULL_LOCAL_SHA refs/heads/topic $WEWORK_FULL_BASE_SHA
 EOF
 
-if ! grep -qE '^pnpm --filter wework exec vitest run --dir src --pool=threads --maxWorkers 1$' "$CALL_LOG"; then
+if ! grep -qE '^pnpm --filter wework exec vitest run --dir src --pool=threads --maxWorkers 2$' "$CALL_LOG"; then
     echo "Expected full renderer tests to exclude Electron-owned test files."
     echo "Calls:"
     cat "$CALL_LOG"
     exit 1
 fi
 
-if ! grep -qE 'Running full renderer unit tests with 1 worker' "$WEWORK_FULL_TEST_OUT"; then
-    echo "Expected full Wework renderer tests to use one worker by default."
+if ! grep -qE 'Running full renderer unit tests with 2 workers' "$WEWORK_FULL_TEST_OUT"; then
+    echo "Expected full Wework renderer tests to use two workers by default."
     cat "$WEWORK_FULL_TEST_OUT"
     exit 1
 fi


### PR DESCRIPTION
## Summary

- restore full Wework renderer pre-push tests from 1 worker to the repository-safe default of 2 workers
- update the existing hook regression assertions to verify the actual `--maxWorkers 2` command
- run the existing AI push gate regression in the Lint workflow with full git history

## Root cause

A recent change reduced full renderer checks to one worker. The push shown in Wework was genuinely running `vitest run --dir src --pool=threads --maxWorkers 1`, which serialized the jsdom-heavy suite and exceeded ten minutes. The same change altered the command shape without keeping the regression assertions executable, and the regression script was not invoked by CI.

## Verification

- `bash scripts/hooks/test-ai-push-gate.sh`
- `bash -n scripts/hooks/ai-push-gate.sh scripts/hooks/test-ai-push-gate.sh`
- `.github/scripts/test-classify-ci-changes.sh`
- `.github/scripts/test-ci-cache-policy.sh`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated automated push-gate checks to run full renderer regression tests with two workers by default.
  - Preserved the option to override the worker count through the existing environment setting.
  - Updated regression expectations and test setup for more consistent automated validation.

- **Chores**
  - Configuration validation now checks the complete repository history.
  - Added the AI push-gate test script to the automated workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->