### PR TITLE
fix(wework): preserve Codex signing entitlements

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -102,6 +102,13 @@ new signing timestamp alone cannot change their component hashes. Published
 content SHA-256 values are computed from these final resources rather than
 extracting components from a newly re-signed installer.
 
+Re-signing an existing Mach-O file must preserve the entitlements from its
+previous signature. Codex and `codex-code-mode-host` require `allow-jit` and
+`allow-unsigned-executable-memory` to run V8; `codesign --verify` alone does
+not detect removed entitlements. Any signing-argument change must increment
+the signing-policy version so cached components signed under the previous
+policy are invalidated.
+
 The Codex component boundary is the complete `codex/` runtime directory, not
 the standalone `codex` executable. The component must contain
 `WEGENT_CODEX_BINARY.json`, the target architecture's `codex` and

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -87,6 +87,11 @@ macOS 发布先按未签名内容、证书身份、架构、签名参数和构�
 签名时间戳单独改变组件哈希。发布组件清单中的内容 SHA-256 必须从这份最终资源
 计算，不得从重新签名后的安装包再次提取组件。
 
+重新签名已有 Mach-O 文件时必须保留原签名中的 entitlement。Codex 及其
+`codex-code-mode-host` 依赖 `allow-jit` 和 `allow-unsigned-executable-memory`
+运行 V8；仅执行 `codesign --verify` 无法发现 entitlement 被移除。任何签名参数
+变化都必须更新签名策略版本，使旧的已签名组件缓存失效。
+
 Codex 组件的发布边界是完整的 `codex/` 运行时目录，不是单独的 `codex` 可执行
 文件。组件必须包含 `WEGENT_CODEX_BINARY.json`、目标架构的 `codex` 与
 `codex-code-mode-host`、`codex-path` 工具和 legal 资源。客户端从运行时描述中的

--- a/wework/electron/scripts/prepare-signed-components.mjs
+++ b/wework/electron/scripts/prepare-signed-components.mjs
@@ -9,18 +9,15 @@ import { hashComponentPath } from '../../scripts/lib/component-content-hash.mjs'
 const execute = promisify(execFile)
 const electronRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 export const SIGNED_COMPONENT_POLICY_VERSION = 2
+const SIGNED_COMPONENT_CODESIGN_FLAGS = [
+  '--timestamp',
+  '--options',
+  'runtime',
+  '--preserve-metadata=entitlements',
+]
 
 export function signedComponentCodesignArguments(identity, file) {
-  return [
-    '--force',
-    '--sign',
-    identity,
-    '--timestamp',
-    '--options',
-    'runtime',
-    '--preserve-metadata=entitlements',
-    file,
-  ]
+  return ['--force', '--sign', identity, ...SIGNED_COMPONENT_CODESIGN_FLAGS, file]
 }
 
 export async function reuseSignedComponent({ source, cacheRoot, identity, policy, sign, verify }) {
@@ -73,7 +70,7 @@ export async function prepareSignedComponents(environment = process.env) {
     platform: 'darwin',
     arch: environment.WEWORK_RELEASE_ARCH || process.arch,
     builder: toolchain.devDependencies['electron-builder'],
-    flags: ['--timestamp', '--options', 'runtime', '--preserve-metadata=entitlements'],
+    flags: SIGNED_COMPONENT_CODESIGN_FLAGS,
   }
   for (const [id, component] of Object.entries(manifest.components)) {
     if (!component.path) continue

--- a/wework/electron/scripts/prepare-signed-components.mjs
+++ b/wework/electron/scripts/prepare-signed-components.mjs
@@ -8,6 +8,20 @@ import { hashComponentPath } from '../../scripts/lib/component-content-hash.mjs'
 
 const execute = promisify(execFile)
 const electronRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+export const SIGNED_COMPONENT_POLICY_VERSION = 2
+
+export function signedComponentCodesignArguments(identity, file) {
+  return [
+    '--force',
+    '--sign',
+    identity,
+    '--timestamp',
+    '--options',
+    'runtime',
+    '--preserve-metadata=entitlements',
+    file,
+  ]
+}
 
 export async function reuseSignedComponent({ source, cacheRoot, identity, policy, sign, verify }) {
   const inputSha256 = await hashComponentPath(source)
@@ -55,11 +69,11 @@ export async function prepareSignedComponents(environment = process.env) {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
   const toolchain = JSON.parse(await readFile(join(electronRoot, 'package.json'), 'utf8'))
   const policy = {
-    version: 1,
+    version: SIGNED_COMPONENT_POLICY_VERSION,
     platform: 'darwin',
     arch: environment.WEWORK_RELEASE_ARCH || process.arch,
     builder: toolchain.devDependencies['electron-builder'],
-    flags: ['--timestamp', '--options', 'runtime'],
+    flags: ['--timestamp', '--options', 'runtime', '--preserve-metadata=entitlements'],
   }
   for (const [id, component] of Object.entries(manifest.components)) {
     if (!component.path) continue
@@ -73,15 +87,7 @@ export async function prepareSignedComponents(environment = process.env) {
       policy,
       sign: async source => {
         for (const file of await machOFiles(source)) {
-          await execute('codesign', [
-            '--force',
-            '--sign',
-            identity,
-            '--timestamp',
-            '--options',
-            'runtime',
-            file,
-          ])
+          await execute('codesign', signedComponentCodesignArguments(identity, file))
         }
       },
       verify: async source => {

--- a/wework/electron/scripts/prepare-signed-components.test.mjs
+++ b/wework/electron/scripts/prepare-signed-components.test.mjs
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  SIGNED_COMPONENT_POLICY_VERSION,
+  signedComponentCodesignArguments,
+} from './prepare-signed-components.mjs'
+
+describe('signed component codesign arguments', () => {
+  test('preserves entitlements required by nested runtimes', () => {
+    expect(
+      signedComponentCodesignArguments('Developer ID Application: Example', '/tmp/component')
+    ).toEqual([
+      '--force',
+      '--sign',
+      'Developer ID Application: Example',
+      '--timestamp',
+      '--options',
+      'runtime',
+      '--preserve-metadata=entitlements',
+      '/tmp/component',
+    ])
+  })
+
+  test('invalidates signed component caches created without preserved entitlements', () => {
+    expect(SIGNED_COMPONENT_POLICY_VERSION).toBe(2)
+  })
+})

--- a/wework/electron/vitest.config.ts
+++ b/wework/electron/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.mjs'],
   },
 })


### PR DESCRIPTION
## Summary

- preserve existing Mach-O entitlements when re-signing managed desktop components
- invalidate signed-component caches created under the old signing policy
- include Electron script tests in the package-owned Vitest suite
- document the Codex JIT entitlement requirement in Chinese and English release guides

## Root cause

The release signing step replaced the upstream Codex signatures without preserving their entitlements. This could remove `com.apple.security.cs.allow-jit` and `com.apple.security.cs.allow-unsigned-executable-memory` from `codex` and `codex-code-mode-host`, while `codesign --verify` still passed. V8 startup could then terminate the host and surface `code-mode host closed its stdout` or `SIGTRAP`.

## Verification

- `pnpm --dir wework/electron test scripts/prepare-signed-components.test.mjs scripts/build-release.test.mjs`
- `pnpm --dir wework/electron typecheck`
- `pnpm --filter wework exec prettier --check electron/scripts/prepare-signed-components.mjs electron/scripts/prepare-signed-components.test.mjs electron/vitest.config.ts ../docs/zh/wework/developer-guide/wework-macos-release.md ../docs/en/wework/developer-guide/wework-macos-release.md`
- `pnpm --filter wework exec eslint electron/scripts/prepare-signed-components.mjs electron/scripts/prepare-signed-components.test.mjs electron/vitest.config.ts`
- re-signed a real Codex 0.153.3 `codex-code-mode-host` copy and verified both JIT entitlements remained present
- pre-push Wework checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS release guidance to require preserving existing entitlements when re-signing application files.
  * Documented required runtime entitlements for Codex components and clarified signing verification considerations.
  * Added guidance to update the signing policy version when signing arguments change.

* **Bug Fixes**
  * Improved macOS component signing to preserve entitlements and invalidate components signed under older signing policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->