### PR TITLE
feat(wework): show active goals in task sidebar

### DIFF
--- a/wework/e2e/desktop/modules/goal-flows.mjs
+++ b/wework/e2e/desktop/modules/goal-flows.mjs
@@ -90,10 +90,13 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
   const goalTaskId = goalTaskRowTestId.replace('runtime-local-task-row-', '')
   const goalUnreadTestId = `runtime-local-task-unread-dot-${goalTaskId}`
   const goalRunningTestId = `runtime-local-task-running-${goalTaskId}`
+  const goalDotTestId = `runtime-local-task-goal-dot-${goalTaskId}`
   await waitForSnapshot(
     control,
     snapshot =>
-      snapshot.testIds.includes(goalRunningTestId) && !snapshot.testIds.includes(goalUnreadTestId),
+      snapshot.testIds.includes(goalRunningTestId) &&
+      snapshot.testIds.includes(goalDotTestId) &&
+      !snapshot.testIds.includes(goalUnreadTestId),
     'The running Goal turn did not render a consistent sidebar state'
   )
   await waitForSnapshot(
@@ -151,6 +154,7 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     snapshot =>
       snapshot.testIds.includes(goalTaskRowTestId) &&
       snapshot.testIds.includes(goalRunningTestId) &&
+      snapshot.testIds.includes(goalDotTestId) &&
       !snapshot.testIds.includes(goalUnreadTestId),
     'The between-turn Goal gap did not preserve the sidebar and unread state'
   )
@@ -216,6 +220,7 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     snapshot =>
       snapshot.testIds.includes(goalTaskRowTestId) &&
       snapshot.testIds.includes(goalRunningTestId) &&
+      snapshot.testIds.includes(goalDotTestId) &&
       !snapshot.testIds.includes(goalUnreadTestId),
     'Reloading lost the provider-confirmed sidebar state during Goal continuation',
     WORKBENCH_READY_TIMEOUT_MS
@@ -262,6 +267,7 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     snapshot =>
       snapshot.testIds.includes(goalTaskRowTestId) &&
       snapshot.testIds.includes(goalRunningTestId) &&
+      snapshot.testIds.includes(goalDotTestId) &&
       snapshot.testIds.includes('pause-response-button') &&
       !snapshot.testIds.includes('send-message-button') &&
       !snapshot.testIds.includes(goalUnreadTestId) &&
@@ -295,7 +301,8 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     snapshot =>
       snapshot.testIds.includes(goalTaskRowTestId) &&
       !snapshot.testIds.includes(goalUnreadTestId) &&
-      snapshot.testIds.includes(goalRunningTestId),
+      snapshot.testIds.includes(goalRunningTestId) &&
+      snapshot.testIds.includes(goalDotTestId),
     'The background Goal continuation stopped running or became unread'
   )
   await captureVerificationScreenshot(control, 'goal-idle-04-background-unread-free.png')
@@ -326,7 +333,9 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
   await waitForSnapshot(
     control,
     snapshot =>
-      !snapshot.testIds.includes(goalUnreadTestId) && !snapshot.testIds.includes(goalRunningTestId),
+      !snapshot.testIds.includes(goalUnreadTestId) &&
+      !snapshot.testIds.includes(goalRunningTestId) &&
+      !snapshot.testIds.includes(goalDotTestId),
     'Opening the completed Goal task did not clear its sidebar state'
   )
   await waitForSnapshot(
@@ -354,6 +363,7 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     false,
     'The completed Goal kept the composer busy'
   )
+  await captureVerificationScreenshot(control, 'goal-idle-06-completed-read.png')
 }
 
 async function verifyBusyTurnGoalHandoff({ composerSelector, control, executorLogPath }) {

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -3530,7 +3530,7 @@ describe('DesktopSidebar', () => {
         projects: [
           {
             project: { id: 7, name: 'Wegent' },
-            totalTasks: 2,
+            totalTasks: 3,
             deviceWorkspaces: [
               {
                 id: 91,
@@ -3546,7 +3546,16 @@ describe('DesktopSidebar', () => {
                     title: 'Investigate stream',
                     runtime: 'codex',
                     running: true,
+                    goalStatus: 'active',
                     updatedAt: '2026-06-20T03:00:00Z',
+                  },
+                  {
+                    taskId: 'codex-running-without-goal',
+                    workspacePath: '/repo/Wegent',
+                    title: 'Investigate logs',
+                    runtime: 'codex',
+                    running: true,
+                    updatedAt: '2026-06-20T02:30:00Z',
                   },
                   {
                     taskId: 'codex-idle',
@@ -3562,19 +3571,23 @@ describe('DesktopSidebar', () => {
           },
         ],
         chats: [],
-        totalTasks: 2,
+        totalTasks: 3,
       },
     })
 
     await userEvent.click(screen.getByTestId('project-item-button'))
 
     const runningStatus = screen.getByTestId('runtime-local-task-running-codex-running')
-    expect(runningStatus).toHaveAttribute('aria-label', '运行中')
-    expect(runningStatus).not.toHaveTextContent('运行中')
+    expect(runningStatus).toHaveAttribute('aria-label', '运行中，有目标')
+    expect(runningStatus).not.toHaveTextContent('运行中，有目标')
     const spinnerLayer = runningStatus.querySelector('.animate-spin')
     expect(spinnerLayer).toBeInstanceOf(HTMLSpanElement)
     expect(spinnerLayer).toHaveClass('will-change-transform')
     expect(spinnerLayer?.querySelector('svg')).not.toHaveClass('animate-spin')
+    expect(screen.getByTestId('runtime-local-task-goal-dot-codex-running')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('runtime-local-task-goal-dot-codex-running-without-goal')
+    ).not.toBeInTheDocument()
     expect(screen.queryByTestId('runtime-local-task-running-codex-idle')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1494,6 +1494,7 @@ function RuntimeTaskRow({
     !workspace.available || !onArchiveRuntimeTask || archiving || archivePending
   const taskAddress = getRuntimeTaskAddress(workspace, task)
   const taskLifecycle = useRuntimeTaskLifecycle(taskAddress)
+  const hasActiveGoal = taskLifecycle?.goalStatus === 'active'
   const queuePaused = useRuntimeTaskQueuePaused(taskAddress)
   const queued = isRuntimeTaskQueued(task)
   const queuePosition =
@@ -1875,14 +1876,31 @@ function RuntimeTaskRow({
                   <span
                     data-testid={`runtime-local-task-running-${task.taskId}`}
                     role="status"
-                    title={t('workbench.runtime_task_running')}
-                    aria-label={t('workbench.runtime_task_running')}
+                    title={
+                      hasActiveGoal
+                        ? t('workbench.runtime_task_running_with_goal')
+                        : t('workbench.runtime_task_running')
+                    }
+                    aria-label={
+                      hasActiveGoal
+                        ? t('workbench.runtime_task_running_with_goal')
+                        : t('workbench.runtime_task_running')
+                    }
                     className="flex h-[30px] w-[30px] items-center justify-center"
                   >
-                    <CompositedSpinner
-                      icon={Loader2}
-                      className="h-4 w-4 text-[rgb(var(--color-sidebar-text-muted))]"
-                    />
+                    <span className="relative flex h-4 w-4 items-center justify-center">
+                      <CompositedSpinner
+                        icon={Loader2}
+                        className="h-4 w-4 text-[rgb(var(--color-sidebar-text-muted))]"
+                      />
+                      {hasActiveGoal ? (
+                        <span
+                          data-testid={`runtime-local-task-goal-dot-${task.taskId}`}
+                          aria-hidden="true"
+                          className="absolute h-1.5 w-1.5 rounded-full bg-primary"
+                        />
+                      ) : null}
+                    </span>
                   </span>
                 ) : priorityReason === 'waiting' ? (
                   <span

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -600,6 +600,7 @@
     "archive_runtime_task_remove_failed": "Task archived, but failed to remove the worktree",
     "archive_runtime_task_remove_failed_detail": "Task archived, but failed to remove the worktree: {{message}}",
     "runtime_task_running": "Running",
+    "runtime_task_running_with_goal": "Running with goal",
     "runtime_task_queue_paused": "Follow-up queue paused",
     "task_plan_progress": "Step {{current}} / {{total}}",
     "task_plan_completed": "Task steps completed",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -599,6 +599,7 @@
     "archive_runtime_task_remove_failed": "任务已归档，但删除工作树失败",
     "archive_runtime_task_remove_failed_detail": "任务已归档，但删除工作树失败：{{message}}",
     "runtime_task_running": "运行中",
+    "runtime_task_running_with_goal": "运行中，有目标",
     "runtime_task_queue_paused": "追问队列已暂停",
     "task_plan_progress": "第 {{current}} / {{total}} 步",
     "task_plan_completed": "任务步骤已完成",


### PR DESCRIPTION
## Summary

- show a centered goal dot inside the existing sidebar running spinner for tasks with an active goal
- reuse the runtime task lifecycle goalStatus already delivered with runtimeWork and stream updates; add no goal fetch, polling, or per-task request
- keep the spinner on its existing composited animation layer and render the static dot outside that rotating layer
- add accessible running-with-goal labels in Chinese and English
- cover goal creation, continuation, reload, background execution, unread completion, and completed-read cleanup in desktop E2E

## Verification

- PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=false pnpm --filter wework typecheck
- PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=false pnpm --filter wework test src/components/layout/DesktopSidebar.test.tsx (115 tests passed)
- pnpm --filter wework exec prettier --check on all changed files
- pnpm --filter wework exec eslint on changed TypeScript/E2E files
- PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=false pnpm --filter wework e2e:desktop --segment goal-lifecycle
  - real Electron build passed
  - goal-lifecycle checkpoint passed with assertion-errors=none
  - six reviewed screenshots cover running, automatic continuation, reload recovery, background running, settled unread, and completed-read states

## Evidence

Local ignored evidence directory: wework/test-results/desktop-e2e/2026-09-08T16-34-53-321Z-78705

The screenshots and runtime logs are intentionally not committed.