### PR TITLE
fix(wework): detect initial workbench mode

### DIFF
--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -42,7 +42,10 @@ import { RendererHealthService } from './host/renderer-health.js'
 import { SmartAppManager, type SmartAppRuntimeHost } from './host/smart-app-manager.js'
 import { SystemSleepController } from './host/system-sleep-controller.js'
 import { PreferencesStore } from './host/preferences-store.js'
-import { normalizeWorkbenchMode } from './runtime/workbench-mode.js'
+import {
+  initializeWorkbenchModePreference,
+  normalizeWorkbenchMode,
+} from './runtime/workbench-mode.js'
 import { RendererStorageStore } from './host/renderer-storage-store.js'
 import {
   EMBEDDED_BROWSER_PARTITION,
@@ -1272,6 +1275,10 @@ function smartAppRuntimeHost(): SmartAppRuntimeHost | null {
 async function configureDesktopRuntime(): Promise<void> {
   if (desktopRuntime) return
   logStartupStep('runtime-configure', 'started')
+  await initializeWorkbenchModePreference(requiredPreferences(), {
+    environment: process.env,
+    homeDirectory: app.getPath('home'),
+  })
   const environment = await desktopEnvironment()
   if (!pluginDevelopmentInstance && !pluginDevelopment) {
     pluginDevelopment = new PluginDevelopmentManager({

--- a/wework/electron/src/runtime/workbench-mode.test.ts
+++ b/wework/electron/src/runtime/workbench-mode.test.ts
@@ -10,6 +10,7 @@ import {
   MODE_MANAGED_FOCUS_HOME_PLUGIN,
   MODE_MANAGED_GIT_PLUGIN,
   normalizeWorkbenchMode,
+  probeDevelopmentCommand,
 } from './workbench-mode.js'
 
 const gitPlugin = {
@@ -118,6 +119,12 @@ describe('workbench mode runtime policy', () => {
     } finally {
       await rm(root, { force: true, recursive: true })
     }
+  })
+
+  test('ignores the macOS system Git placeholder', async () => {
+    await expect(probeDevelopmentCommand('git', { PATH: '/usr/bin' }, 'darwin')).resolves.toBe(
+      false
+    )
   })
 
   test('does not treat Python alone as a development environment', async () => {

--- a/wework/electron/src/runtime/workbench-mode.test.ts
+++ b/wework/electron/src/runtime/workbench-mode.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -116,6 +116,19 @@ describe('workbench mode runtime policy', () => {
       ).resolves.toBe('focus')
 
       expect(preferences.update).toHaveBeenCalledWith({ workbenchMode: 'focus' })
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  test('ignores directories named like development commands', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'wework-mode-'))
+    try {
+      await mkdir(join(root, 'git.exe'))
+
+      await expect(
+        probeDevelopmentCommand('git', { PATH: root, PATHEXT: '.EXE' }, 'win32')
+      ).resolves.toBe(false)
     } finally {
       await rm(root, { force: true, recursive: true })
     }

--- a/wework/electron/src/runtime/workbench-mode.test.ts
+++ b/wework/electron/src/runtime/workbench-mode.test.ts
@@ -1,6 +1,11 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, test, vi } from 'vitest'
 import {
   applyWorkbenchModeToCorePlugins,
+  initializeWorkbenchModePreference,
   MODE_MANAGED_DEVELOPER_HOME_PLUGIN,
   MODE_MANAGED_FOCUS_HOME_PLUGIN,
   MODE_MANAGED_GIT_PLUGIN,
@@ -28,6 +33,129 @@ describe('workbench mode runtime policy', () => {
     expect(normalizeWorkbenchMode('developer')).toBe('developer')
     expect(normalizeWorkbenchMode('unknown')).toBe('developer')
     expect(normalizeWorkbenchMode(undefined)).toBe('developer')
+  })
+
+  test('selects and persists developer mode when a development command is available', async () => {
+    const preferences = {
+      read: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockImplementation(async patch => patch),
+    }
+    const probeCommand = vi.fn(async command => command === 'git')
+
+    await expect(
+      initializeWorkbenchModePreference(preferences, {
+        environment: { PATH: '/custom/bin' },
+        homeDirectory: '/home/alice',
+        probeCommand,
+      })
+    ).resolves.toBe('developer')
+
+    expect(preferences.update).toHaveBeenCalledWith({ workbenchMode: 'developer' })
+    expect(probeCommand).toHaveBeenCalledWith(
+      'git',
+      expect.objectContaining({
+        PATH: expect.stringContaining('/custom/bin'),
+      })
+    )
+  })
+
+  test('selects and persists focus mode when no development command is available', async () => {
+    const preferences = {
+      read: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockImplementation(async patch => patch),
+    }
+
+    await expect(
+      initializeWorkbenchModePreference(preferences, {
+        environment: {},
+        homeDirectory: '/home/alice',
+        probeCommand: vi.fn().mockResolvedValue(false),
+      })
+    ).resolves.toBe('focus')
+
+    expect(preferences.update).toHaveBeenCalledWith({ workbenchMode: 'focus' })
+  })
+
+  test('checks executable files without running development commands', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'wework-mode-'))
+    const preferences = {
+      read: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockImplementation(async patch => patch),
+    }
+    try {
+      await writeFile(join(root, 'git.exe'), '')
+
+      await expect(
+        initializeWorkbenchModePreference(preferences, {
+          environment: { PATH: root, PATHEXT: '.EXE' },
+          homeDirectory: root,
+          platform: 'win32',
+        })
+      ).resolves.toBe('developer')
+
+      expect(preferences.update).toHaveBeenCalledWith({ workbenchMode: 'developer' })
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  test('uses focus mode when the executable search path is empty', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'wework-mode-'))
+    const preferences = {
+      read: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockImplementation(async patch => patch),
+    }
+    try {
+      await expect(
+        initializeWorkbenchModePreference(preferences, {
+          environment: { PATH: root, PATHEXT: '.EXE' },
+          homeDirectory: root,
+          platform: 'win32',
+        })
+      ).resolves.toBe('focus')
+
+      expect(preferences.update).toHaveBeenCalledWith({ workbenchMode: 'focus' })
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  test('does not treat Python alone as a development environment', async () => {
+    const preferences = {
+      read: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockImplementation(async patch => patch),
+    }
+    const probeCommand = vi.fn(async command => command === 'python3')
+
+    await expect(
+      initializeWorkbenchModePreference(preferences, {
+        environment: {},
+        homeDirectory: '/home/alice',
+        probeCommand,
+      })
+    ).resolves.toBe('focus')
+
+    expect(probeCommand).not.toHaveBeenCalledWith('python3', expect.anything())
+    expect(preferences.update).toHaveBeenCalledWith({ workbenchMode: 'focus' })
+  })
+
+  test('preserves a stored mode without probing the machine again', async () => {
+    const preferences = {
+      read: vi.fn().mockResolvedValue({ workbenchMode: 'focus' }),
+      update: vi.fn(),
+    }
+    const probeCommand = vi.fn()
+
+    await expect(
+      initializeWorkbenchModePreference(preferences, {
+        environment: {},
+        homeDirectory: '/home/alice',
+        probeCommand,
+      })
+    ).resolves.toBe('focus')
+
+    expect(probeCommand).not.toHaveBeenCalled()
+    expect(preferences.update).not.toHaveBeenCalled()
   })
 
   test('disables the Git plugin in focus mode', async () => {

--- a/wework/electron/src/runtime/workbench-mode.ts
+++ b/wework/electron/src/runtime/workbench-mode.ts
@@ -1,5 +1,5 @@
 import { constants } from 'node:fs'
-import { access } from 'node:fs/promises'
+import { access, stat } from 'node:fs/promises'
 import { delimiter, join, normalize } from 'node:path'
 
 import type { CoreDshPluginManager } from './core-dsh-plugin-manager.js'
@@ -140,7 +140,7 @@ export async function probeDevelopmentCommand(
       }
       try {
         await access(candidate, platform === 'win32' ? constants.F_OK : constants.X_OK)
-        return true
+        if ((await stat(candidate)).isFile()) return true
       } catch {
         // Continue searching the remaining PATH entries.
       }

--- a/wework/electron/src/runtime/workbench-mode.ts
+++ b/wework/electron/src/runtime/workbench-mode.ts
@@ -1,3 +1,7 @@
+import { constants } from 'node:fs'
+import { access } from 'node:fs/promises'
+import { delimiter, join, normalize } from 'node:path'
+
 import type { CoreDshPluginManager } from './core-dsh-plugin-manager.js'
 
 export type WorkbenchMode = 'focus' | 'developer'
@@ -6,8 +10,63 @@ export const MODE_MANAGED_GIT_PLUGIN = '@wegent/dsh-ui-git'
 export const MODE_MANAGED_FOCUS_HOME_PLUGIN = '@wegent/dsh-ui-home-focus'
 export const MODE_MANAGED_DEVELOPER_HOME_PLUGIN = '@wegent/dsh-ui-home-developer'
 
+const DEVELOPMENT_COMMANDS = [
+  'git',
+  'node',
+  'npm',
+  'pnpm',
+  'yarn',
+  'bun',
+  'deno',
+  'go',
+  'cargo',
+  'rustc',
+  'docker',
+  'kubectl',
+  'code',
+] as const
+
+interface WorkbenchModePreferences {
+  read(): Promise<Record<string, unknown>>
+  update(patch: Record<string, unknown>): Promise<Record<string, unknown>>
+}
+
+interface InitializeWorkbenchModeOptions {
+  environment: NodeJS.ProcessEnv
+  homeDirectory: string
+  platform?: NodeJS.Platform
+  probeCommand?: (command: string, environment: NodeJS.ProcessEnv) => Promise<boolean>
+}
+
 export function normalizeWorkbenchMode(value: unknown): WorkbenchMode {
   return value === 'focus' ? 'focus' : 'developer'
+}
+
+export async function initializeWorkbenchModePreference(
+  preferences: WorkbenchModePreferences,
+  options: InitializeWorkbenchModeOptions
+): Promise<WorkbenchMode> {
+  const stored = await preferences.read()
+  if (Object.hasOwn(stored, 'workbenchMode')) {
+    return normalizeWorkbenchMode(stored.workbenchMode)
+  }
+
+  const platform = options.platform ?? process.platform
+  const environment = developmentCommandEnvironment(
+    options.environment,
+    options.homeDirectory,
+    platform
+  )
+  const probeCommand =
+    options.probeCommand ??
+    ((command, commandEnvironment) =>
+      probeDevelopmentCommand(command, commandEnvironment, platform))
+  const results = await Promise.all(
+    DEVELOPMENT_COMMANDS.map(command => probeCommand(command, environment))
+  )
+  const mode: WorkbenchMode = results.some(Boolean) ? 'developer' : 'focus'
+  await preferences.update({ workbenchMode: mode })
+  return mode
 }
 
 export async function applyWorkbenchModeToCorePlugins(
@@ -26,4 +85,66 @@ export async function applyWorkbenchModeToCorePlugins(
       await plugins.setEnabled(plugin.name, shouldEnable)
     }
   }
+}
+
+function developmentCommandEnvironment(
+  environment: NodeJS.ProcessEnv,
+  homeDirectory: string,
+  platform: NodeJS.Platform
+): NodeJS.ProcessEnv {
+  if (platform === 'win32') return environment
+  const currentPath = environment.PATH?.split(delimiter).filter(Boolean) ?? []
+  const commonPaths = [
+    join(homeDirectory, '.local', 'bin'),
+    join(homeDirectory, 'bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/opt/local/bin',
+    '/Library/Developer/CommandLineTools/usr/bin',
+    '/Applications/Xcode.app/Contents/Developer/usr/bin',
+    '/usr/bin',
+    '/bin',
+  ]
+  return {
+    ...environment,
+    PATH: [...new Set([...currentPath, ...commonPaths])].join(delimiter),
+  }
+}
+
+async function probeDevelopmentCommand(
+  command: string,
+  environment: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform
+): Promise<boolean> {
+  const pathValue =
+    environment.PATH ??
+    (platform === 'win32'
+      ? Object.entries(environment).find(([key]) => key.toLowerCase() === 'path')?.[1]
+      : undefined)
+  if (!pathValue) return false
+
+  const extensions =
+    platform === 'win32'
+      ? (environment.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+          .split(';')
+          .filter(Boolean)
+          .map(extension => extension.toLowerCase())
+      : ['']
+  for (const directory of pathValue.split(platform === 'win32' ? ';' : delimiter)) {
+    const unquotedDirectory = directory.trim().replace(/^"(.*)"$/, '$1')
+    if (!unquotedDirectory) continue
+    for (const extension of extensions) {
+      const candidate = normalize(join(unquotedDirectory, `${command}${extension}`))
+      if (platform === 'darwin' && command === 'git' && candidate === '/usr/bin/git') {
+        continue
+      }
+      try {
+        await access(candidate, platform === 'win32' ? constants.F_OK : constants.X_OK)
+        return true
+      } catch {
+        // Continue searching the remaining PATH entries.
+      }
+    }
+  }
+  return false
 }

--- a/wework/electron/src/runtime/workbench-mode.ts
+++ b/wework/electron/src/runtime/workbench-mode.ts
@@ -111,7 +111,7 @@ function developmentCommandEnvironment(
   }
 }
 
-async function probeDevelopmentCommand(
+export async function probeDevelopmentCommand(
   command: string,
   environment: NodeJS.ProcessEnv,
   platform: NodeJS.Platform


### PR DESCRIPTION
## Summary

- detect common development command executables before the first desktop runtime startup
- default first-time users to developer mode when a development tool is present, otherwise focus mode
- persist the detected mode once without overriding later user choices
- avoid executing external commands or treating Python alone and the macOS `/usr/bin/git` placeholder as development signals

## Verification

- `pnpm --dir wework/electron test src/runtime/workbench-mode.test.ts`
- `pnpm --dir wework/electron typecheck`
- Wework pre-push ESLint and unit-test checks
- isolated real Electron first-launch verification with `pnpm --filter wework ai:verify start`

Task: WORK-433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Desktop startup now automatically selects Developer or Focus workbench mode based on available development tools.
  - Existing workbench mode preferences are preserved and used instead of re-detecting the environment.
  - Detection supports platform-specific executable paths, including Windows command extensions and common development-tool locations.
  - macOS system Git placeholders are excluded from detection, helping ensure the selected mode reflects actual development-tool availability.

- **Bug Fixes**
  - Improved detection accuracy by preventing directories with executable-like names from being treated as development tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->