### PR TITLE
feat(observability): instrument skill downloads

### DIFF
--- a/backend/app/api/endpoints/kind/skills.py
+++ b/backend/app/api/endpoints/kind/skills.py
@@ -62,6 +62,7 @@ from app.services.group_permission import check_group_permission
 from app.services.marketplace_tag_service import marketplace_tag_service
 from app.services.resource_library_service import resource_library_service
 from app.services.skill_binding_service import skill_binding_service
+from app.services.skill_download_observability import set_skill_download_metadata
 
 router = APIRouter(prefix="/kinds/skills")
 
@@ -989,12 +990,26 @@ def download_public_skill(
     if not skill:
         raise HTTPException(status_code=404, detail="Public skill not found")
 
+    set_skill_download_metadata(
+        request,
+        skill_name=skill.name,
+        cache_source="none",
+        bytes_count=0,
+    )
+
     # Get binary data using service with user_id=0
     binary_data = skill_kinds_service.get_skill_binary(
         db=db, skill_id=skill_id, user_id=0
     )
     if not binary_data:
         raise HTTPException(status_code=404, detail="Public skill binary not found")
+
+    set_skill_download_metadata(
+        request,
+        skill_name=skill.name,
+        cache_source="skill_binary",
+        bytes_count=len(binary_data),
+    )
 
     filename = f"{skill.name}.zip"
     encoded_filename = quote(filename, safe="")
@@ -1005,7 +1020,10 @@ def download_public_skill(
     return StreamingResponse(
         io.BytesIO(binary_data),
         media_type="application/zip",
-        headers={"Content-Disposition": content_disposition},
+        headers={
+            "Content-Disposition": content_disposition,
+            "Content-Length": str(len(binary_data)),
+        },
     )
 
 
@@ -1777,13 +1795,33 @@ def download_skill(
     if not skill:
         raise HTTPException(status_code=404, detail="Skill not found")
 
+    set_skill_download_metadata(
+        request,
+        skill_name=skill.metadata.name,
+        cache_source="none",
+        bytes_count=0,
+    )
+
     if not binary_data:
         raise HTTPException(status_code=404, detail="Skill binary not found")
 
     etag = _skill_content_etag(binary_data)
     if _etag_matches(if_none_match, etag):
+        set_skill_download_metadata(
+            request,
+            skill_name=skill.metadata.name,
+            cache_source="conditional_etag",
+            bytes_count=0,
+        )
         _release_read_transaction(db)
         return Response(status_code=304, headers={"ETag": etag})
+
+    set_skill_download_metadata(
+        request,
+        skill_name=skill.metadata.name,
+        cache_source="skill_binary",
+        bytes_count=len(binary_data),
+    )
 
     # Return as streaming response
     # RFC 5987 encoding for non-ASCII filenames
@@ -1796,7 +1834,11 @@ def download_skill(
     return StreamingResponse(
         io.BytesIO(binary_data),
         media_type="application/zip",
-        headers={"Content-Disposition": content_disposition, "ETag": etag},
+        headers={
+            "Content-Disposition": content_disposition,
+            "Content-Length": str(len(binary_data)),
+            "ETag": etag,
+        },
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,11 @@ from app.services.auth.internal_service_token import (
     require_internal_service_token_configured,
 )
 from app.services.jobs import start_background_jobs, stop_background_jobs
+from app.services.skill_download_observability import (
+    add_skill_download_headers,
+    begin_skill_download,
+    get_skill_download_metadata,
+)
 from shared.telemetry.context.large_data import log_json_body
 
 # Redis lock key for startup operations (migrations + YAML init)
@@ -767,8 +772,33 @@ def create_app():
             logger.info(request_log_message)
 
         # Process request
-        response = await call_next(request)
+        skill_download_observation = begin_skill_download(request.url.path)
+        try:
+            response = await call_next(request)
+        except BaseException:
+            if skill_download_observation is not None:
+                skill_download_observation.finish(
+                    metadata=get_skill_download_metadata(request),
+                    status_code=500,
+                    request_id=request_id,
+                    result="handler_error",
+                )
+            raise
         process_time = (time.time() - start_time) * 1000
+
+        if skill_download_observation is not None:
+            skill_download_metadata = get_skill_download_metadata(request)
+            backend_time_ms = skill_download_observation.finish(
+                metadata=skill_download_metadata,
+                status_code=response.status_code,
+                request_id=request_id,
+            )
+            add_skill_download_headers(
+                response,
+                observation=skill_download_observation,
+                metadata=skill_download_metadata,
+                backend_time_ms=backend_time_ms,
+            )
 
         # Capture response headers and body if OTEL is enabled
         if otel_config.enabled:
@@ -860,7 +890,15 @@ def create_app():
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
-        expose_headers=["Content-Disposition", "X-Request-ID"],
+        expose_headers=[
+            "Content-Disposition",
+            "X-Request-ID",
+            "X-Wegent-Skill-Id",
+            "X-Wegent-Skill-Name",
+            "X-Wegent-Skill-Cache-Source",
+            "X-Wegent-Skill-Bytes",
+            "X-Wegent-Backend-Time-Ms",
+        ],
     )
 
     # Register exception handlers

--- a/backend/app/services/skill_download_observability.py
+++ b/backend/app/services/skill_download_observability.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Low-cardinality metrics and structured logs for Skill downloads."""
+
+import logging
+import re
+import threading
+import time
+from dataclasses import dataclass
+from urllib.parse import quote
+
+from fastapi import Request, Response
+from prometheus_client import Counter, Gauge, Histogram
+
+logger = logging.getLogger(__name__)
+
+_SKILL_DOWNLOAD_PATH = re.compile(
+    r"^/api/v1/kinds/skills/(?:public/)?(?P<skill_id>\d+)/download$"
+)
+_INFLIGHT_LOCK = threading.Lock()
+_inflight = 0
+
+SKILL_DOWNLOADS_TOTAL = Counter(
+    "backend_skill_downloads_total",
+    "Backend Skill download responses",
+    ["cache_source", "result", "status"],
+)
+SKILL_DOWNLOAD_DURATION_SECONDS = Histogram(
+    "backend_skill_download_duration_seconds",
+    "Time spent resolving a Skill archive and preparing its response",
+    ["cache_source", "result"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
+SKILL_DOWNLOAD_BYTES_TOTAL = Counter(
+    "backend_skill_download_bytes_total",
+    "Bytes returned by Backend Skill download responses",
+    ["cache_source", "result"],
+)
+SKILL_DOWNLOAD_INFLIGHT = Gauge(
+    "backend_skill_download_inflight",
+    "Skill download requests currently executing in this Backend process",
+)
+
+
+@dataclass(frozen=True)
+class SkillDownloadMetadata:
+    """Response metadata populated by a Skill download endpoint."""
+
+    skill_name: str = "unknown"
+    cache_source: str = "none"
+    bytes_count: int = 0
+
+
+class SkillDownloadObservation:
+    """One Backend Skill download request observed by the HTTP middleware."""
+
+    def __init__(self, skill_id: str) -> None:
+        global _inflight
+
+        self.skill_id = skill_id
+        self.started_at = time.perf_counter()
+        self._finished = False
+        with _INFLIGHT_LOCK:
+            _inflight += 1
+            self.inflight = _inflight
+            SKILL_DOWNLOAD_INFLIGHT.set(_inflight)
+
+    def finish(
+        self,
+        *,
+        metadata: SkillDownloadMetadata,
+        status_code: int,
+        request_id: str,
+        result: str | None = None,
+    ) -> float:
+        """Record exactly one completion and return elapsed milliseconds."""
+        global _inflight
+
+        if self._finished:
+            return (time.perf_counter() - self.started_at) * 1000
+        self._finished = True
+        duration_seconds = max(0.0, time.perf_counter() - self.started_at)
+        observed_result = result or _result_for_status(status_code)
+        status = str(status_code)
+        bytes_count = max(0, metadata.bytes_count)
+
+        duration_ms = duration_seconds * 1000
+        try:
+            SKILL_DOWNLOADS_TOTAL.labels(
+                cache_source=metadata.cache_source,
+                result=observed_result,
+                status=status,
+            ).inc()
+            SKILL_DOWNLOAD_DURATION_SECONDS.labels(
+                cache_source=metadata.cache_source,
+                result=observed_result,
+            ).observe(duration_seconds)
+            SKILL_DOWNLOAD_BYTES_TOTAL.labels(
+                cache_source=metadata.cache_source,
+                result=observed_result,
+            ).inc(bytes_count)
+
+            logger.info(
+                "skill download observed component=backend skill_id=%s skill_name=%s "
+                "cache_source=%s bytes=%s duration_ms=%.2f result=%s inflight=%s "
+                "status=%s request_id=%s",
+                self.skill_id,
+                metadata.skill_name,
+                metadata.cache_source,
+                bytes_count,
+                duration_ms,
+                observed_result,
+                self.inflight,
+                status,
+                request_id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to record Skill download observation: skill_id=%s",
+                self.skill_id,
+            )
+        finally:
+            with _INFLIGHT_LOCK:
+                _inflight = max(0, _inflight - 1)
+                SKILL_DOWNLOAD_INFLIGHT.set(_inflight)
+        return duration_ms
+
+
+def begin_skill_download(path: str) -> SkillDownloadObservation | None:
+    """Start observation when *path* is a Skill archive download route."""
+    match = _SKILL_DOWNLOAD_PATH.fullmatch(path)
+    if match is None:
+        return None
+    return SkillDownloadObservation(match.group("skill_id"))
+
+
+def set_skill_download_metadata(
+    request: Request,
+    *,
+    skill_name: str,
+    cache_source: str,
+    bytes_count: int,
+) -> None:
+    """Attach non-sensitive endpoint metadata for the request middleware."""
+    request.state.skill_download_metadata = SkillDownloadMetadata(
+        skill_name=skill_name,
+        cache_source=cache_source,
+        bytes_count=max(0, bytes_count),
+    )
+
+
+def get_skill_download_metadata(request: Request) -> SkillDownloadMetadata:
+    metadata = getattr(request.state, "skill_download_metadata", None)
+    return (
+        metadata
+        if isinstance(metadata, SkillDownloadMetadata)
+        else SkillDownloadMetadata()
+    )
+
+
+def add_skill_download_headers(
+    response: Response,
+    *,
+    observation: SkillDownloadObservation,
+    metadata: SkillDownloadMetadata,
+    backend_time_ms: float,
+) -> None:
+    """Expose safe correlation data to an API gateway and Executor."""
+    response.headers["X-Wegent-Skill-Id"] = observation.skill_id
+    response.headers["X-Wegent-Skill-Name"] = quote(metadata.skill_name, safe="")
+    response.headers["X-Wegent-Skill-Cache-Source"] = metadata.cache_source
+    response.headers["X-Wegent-Skill-Bytes"] = str(max(0, metadata.bytes_count))
+    response.headers["X-Wegent-Backend-Time-Ms"] = f"{max(0.0, backend_time_ms):.2f}"
+
+
+def _result_for_status(status_code: int) -> str:
+    if status_code == 304:
+        return "not_modified"
+    if 200 <= status_code < 300:
+        return "success"
+    return "http_error"

--- a/backend/tests/api/test_skill_download_transactions.py
+++ b/backend/tests/api/test_skill_download_transactions.py
@@ -22,6 +22,10 @@ class _QueryStub:
         return self.result
 
 
+def _request_stub():
+    return SimpleNamespace(headers={}, state=SimpleNamespace())
+
+
 @pytest.mark.unit
 def test_download_skill_releases_transaction_before_streaming_response(monkeypatch):
     call_order = []
@@ -49,7 +53,7 @@ def test_download_skill_releases_transaction_before_streaming_response(monkeypat
 
     skills_endpoint.download_skill(
         skill_id=42,
-        request=SimpleNamespace(headers={}),
+        request=_request_stub(),
         namespace="default",
         task_id=None,
         current_user=SimpleNamespace(id=current_user.id, role="user"),
@@ -78,9 +82,10 @@ def test_download_skill_returns_not_modified_for_matching_etag(monkeypatch):
         Mock(return_value=archive),
     )
 
+    request = _request_stub()
     response = skills_endpoint.download_skill(
         skill_id=42,
-        request=SimpleNamespace(headers={}),
+        request=request,
         namespace="default",
         task_id=None,
         if_none_match=f'"sha256:{expected_hash}"',
@@ -91,6 +96,8 @@ def test_download_skill_returns_not_modified_for_matching_etag(monkeypatch):
     assert isinstance(response, Response)
     assert response.status_code == 304
     assert response.headers["etag"] == f'"sha256:{expected_hash}"'
+    assert request.state.skill_download_metadata.cache_source == "conditional_etag"
+    assert request.state.skill_download_metadata.bytes_count == 0
 
 
 @pytest.mark.unit
@@ -117,7 +124,7 @@ def test_download_public_skill_releases_transaction_before_streaming_response(
 
     skills_endpoint.download_public_skill(
         skill_id=42,
-        request=SimpleNamespace(headers={}),
+        request=_request_stub(),
         current_user=SimpleNamespace(id=7, role="admin"),
         db=db,
     )
@@ -137,9 +144,10 @@ def test_download_public_skill_encodes_content_disposition_filename(monkeypatch)
         Mock(return_value=b"zip-data"),
     )
 
+    request = _request_stub()
     response = skills_endpoint.download_public_skill(
         skill_id=42,
-        request=SimpleNamespace(headers={}),
+        request=request,
         current_user=SimpleNamespace(id=7, role="admin"),
         db=db,
     )
@@ -148,3 +156,7 @@ def test_download_public_skill_encodes_content_disposition_filename(monkeypatch)
         response.headers["Content-Disposition"]
         == "attachment; filename*=UTF-8''%E5%88%86%E6%9E%90%20Tool.zip"
     )
+    assert response.headers["Content-Length"] == "8"
+    assert request.state.skill_download_metadata.skill_name == "分析 Tool"
+    assert request.state.skill_download_metadata.cache_source == "skill_binary"
+    assert request.state.skill_download_metadata.bytes_count == 8

--- a/backend/tests/services/test_skill_download_observability.py
+++ b/backend/tests/services/test_skill_download_observability.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from starlette.responses import Response
+
+from app.services.skill_download_observability import (
+    SkillDownloadMetadata,
+    add_skill_download_headers,
+    begin_skill_download,
+)
+
+
+def test_skill_download_observation_records_safe_fields(caplog) -> None:
+    observation = begin_skill_download("/api/v1/kinds/skills/42/download")
+    assert observation is not None
+
+    with caplog.at_level(
+        logging.INFO,
+        logger="app.services.skill_download_observability",
+    ):
+        duration_ms = observation.finish(
+            metadata=SkillDownloadMetadata(
+                skill_name="wegent-knowledge",
+                cache_source="skill_binary",
+                bytes_count=8192,
+            ),
+            status_code=200,
+            request_id="skill-download-request",
+        )
+
+    assert duration_ms >= 0
+    message = caplog.records[-1].message
+    assert "skill_id=42" in message
+    assert "skill_name=wegent-knowledge" in message
+    assert "cache_source=skill_binary" in message
+    assert "bytes=8192" in message
+    assert "duration_ms=" in message
+    assert "result=success" in message
+    assert "inflight=" in message
+    assert "status=200" in message
+    assert "token" not in message.lower()
+
+
+def test_skill_download_headers_encode_non_ascii_name() -> None:
+    observation = begin_skill_download("/api/v1/kinds/skills/public/7/download")
+    assert observation is not None
+    metadata = SkillDownloadMetadata(
+        skill_name="知识库 Skill",
+        cache_source="skill_binary",
+        bytes_count=12,
+    )
+    response = Response()
+
+    add_skill_download_headers(
+        response,
+        observation=observation,
+        metadata=metadata,
+        backend_time_ms=3.5,
+    )
+    observation.finish(
+        metadata=metadata,
+        status_code=200,
+        request_id="request-7",
+    )
+
+    assert response.headers["X-Wegent-Skill-Id"] == "7"
+    assert (
+        response.headers["X-Wegent-Skill-Name"] == "%E7%9F%A5%E8%AF%86%E5%BA%93%20Skill"
+    )
+    assert response.headers["X-Wegent-Skill-Cache-Source"] == "skill_binary"
+    assert response.headers["X-Wegent-Skill-Bytes"] == "12"
+    assert response.headers["X-Wegent-Backend-Time-Ms"] == "3.50"
+
+
+def test_non_skill_download_path_is_ignored() -> None:
+    assert begin_skill_download("/api/v1/kinds/skills/42") is None
+
+
+def test_inflight_reflects_concurrent_backend_downloads(caplog) -> None:
+    first = begin_skill_download("/api/v1/kinds/skills/1/download")
+    second = begin_skill_download("/api/v1/kinds/skills/2/download")
+    assert first is not None
+    assert second is not None
+    metadata = SkillDownloadMetadata(
+        skill_name="wegent-knowledge",
+        cache_source="skill_binary",
+        bytes_count=1,
+    )
+
+    with caplog.at_level(
+        logging.INFO,
+        logger="app.services.skill_download_observability",
+    ):
+        second.finish(metadata=metadata, status_code=200, request_id="request-2")
+        first.finish(metadata=metadata, status_code=200, request_id="request-1")
+
+    observations = [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("skill download observed")
+    ]
+    assert "skill_id=2" in observations[0]
+    assert "inflight=2" in observations[0]
+    assert "skill_id=1" in observations[1]
+    assert "inflight=1" in observations[1]

--- a/backend/tests/test_request_logging.py
+++ b/backend/tests/test_request_logging.py
@@ -90,6 +90,38 @@ def test_cors_exposes_request_id_header(test_client):
     assert response.headers["X-Request-ID"]
 
 
+def test_skill_download_error_is_observed_without_credentials(test_client, caplog):
+    with caplog.at_level(
+        logging.INFO,
+        logger="app.services.skill_download_observability",
+    ):
+        response = test_client.get(
+            "/api/v1/kinds/skills/42/download",
+            headers={
+                "X-Request-ID": "skill-download-42",
+                "Authorization": "Bearer must-not-be-logged",
+            },
+        )
+
+    assert response.status_code == 401
+    assert response.headers["X-Wegent-Skill-Id"] == "42"
+    assert response.headers["X-Wegent-Skill-Name"] == "unknown"
+    assert response.headers["X-Wegent-Skill-Cache-Source"] == "none"
+    assert response.headers["X-Wegent-Skill-Bytes"] == "0"
+    assert response.headers["X-Wegent-Backend-Time-Ms"]
+
+    observations = [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("skill download observed")
+    ]
+    assert observations
+    assert "skill_id=42" in observations[-1]
+    assert "result=http_error" in observations[-1]
+    assert "inflight=" in observations[-1]
+    assert "must-not-be-logged" not in observations[-1]
+
+
 def test_access_logs_redact_sensitive_query_parameters(test_client, caplog):
     with caplog.at_level(logging.INFO, logger="app.main"):
         response = test_client.get("/api/health?token=opencut-secret&probe=visible")

--- a/executor/src/agents/claude_code.rs
+++ b/executor/src/agents/claude_code.rs
@@ -6,6 +6,7 @@ use std::{
     collections::BTreeMap,
     env, fs,
     path::{Path, PathBuf},
+    time::Instant,
 };
 
 use futures_util::{stream, StreamExt};
@@ -13,8 +14,10 @@ use serde_json::{json, Map, Value};
 
 use crate::{
     agents::{
-        backend_url::request_backend_url, interactive_mcp::build_interactive_form_answer_query,
-        runtime_capabilities::resolve_skill, skill_download::skill_download_concurrency,
+        backend_url::request_backend_url,
+        interactive_mcp::build_interactive_form_answer_query,
+        runtime_capabilities::resolve_skill,
+        skill_download::{log_skill_cache_observation, skill_download_concurrency},
         task_identity::task_identity_env,
     },
     attachments::{
@@ -777,6 +780,7 @@ pub(super) async fn deploy_claude_task_skills(request: &ExecutionRequest, spec: 
             let provider = provider.clone();
             let plan = &plan;
             async move {
+                let cache_started_at = Instant::now();
                 let Some(skill_ref) = plan.resolved_skill_map.get(&skill_name) else {
                     return;
                 };
@@ -784,6 +788,12 @@ pub(super) async fn deploy_claude_task_skills(request: &ExecutionRequest, spec: 
                 let Some(cache_miss_reason) =
                     claude_task_skill_cache_miss_reason(&target, skill_ref)
                 else {
+                    log_skill_cache_observation(
+                        Some(skill_ref.skill_id),
+                        &skill_name,
+                        cache_started_at,
+                        "cache_hit",
+                    );
                     return;
                 };
                 let mut fields = task_fields(&request.task_id, &request.subtask_id);

--- a/executor/src/agents/mod.rs
+++ b/executor/src/agents/mod.rs
@@ -20,7 +20,7 @@ mod image_validator;
 pub mod interactive_mcp;
 mod pnpm_worktree;
 pub(crate) mod runtime_capabilities;
-mod skill_download;
+pub(crate) mod skill_download;
 mod task_identity;
 
 use crate::{

--- a/executor/src/agents/runtime_capabilities.rs
+++ b/executor/src/agents/runtime_capabilities.rs
@@ -7,7 +7,7 @@ use std::{
     env, fs,
     io::Cursor,
     path::{Component, Path, PathBuf},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use futures_util::{stream, StreamExt};
@@ -22,7 +22,12 @@ use crate::{
     agents::{
         backend_url::{is_local_mode, request_backend_url_or_default},
         claude_config_dir, claude_task_dir, extract_claude_options,
-        skill_download::skill_download_concurrency,
+        skill_download::{
+            encoded_skill_name, log_skill_cache_observation, response_milliseconds,
+            response_request_id, skill_download_concurrency, SkillDownloadObservation,
+            SkillDownloadOutcome, BACKEND_TIME_HEADER, CACHE_SOURCE_HEADER,
+            GATEWAY_UPSTREAM_TIME_HEADER, REQUEST_ID_HEADER, SKILL_ID_HEADER, SKILL_NAME_HEADER,
+        },
     },
     attachments::{process_prompt, AttachmentPromptProcessor, AttachmentRecord},
     logging::{log_executor_event, push_error_fields, task_fields},
@@ -906,6 +911,7 @@ async fn deploy_skills(
         .map(|skill| {
             let client = &client;
             async move {
+                let cache_started_at = Instant::now();
                 let target = plan.skills_dir.join(&skill);
                 let skill_ref = plan.resolved_skill_map.get(&skill);
                 let cache_miss_reason =
@@ -916,6 +922,12 @@ async fn deploy_skills(
                             let mut fields = vec![("skill", skill.clone())];
                             fields.push(("reason", reason.clone()));
                             log_executor_event("skill cache validation failed", &fields);
+                            log_skill_cache_observation(
+                                skill_ref.map(|value| value.skill_id),
+                                &skill,
+                                cache_started_at,
+                                "cache_validation_error",
+                            );
                             return SkillDeploymentResult {
                                 skill_name: skill,
                                 success: false,
@@ -925,6 +937,12 @@ async fn deploy_skills(
                         }
                     };
                 let Some(cache_miss_reason) = cache_miss_reason else {
+                    log_skill_cache_observation(
+                        skill_ref.map(|value| value.skill_id),
+                        &skill,
+                        cache_started_at,
+                        "cache_hit",
+                    );
                     return SkillDeploymentResult {
                         skill_name: skill.clone(),
                         success: true,
@@ -1173,6 +1191,10 @@ async fn download_skill(
     let local_hash = installed_skill_hash(&plan.skills_dir, skill_name);
     let download = get_skill_archive(
         client,
+        SkillDownloadIdentity {
+            skill_id,
+            skill_name,
+        },
         &plan.auth_token,
         api_base_url,
         &path,
@@ -1252,49 +1274,133 @@ enum SkillArchiveResponse {
     },
 }
 
+struct SkillDownloadIdentity<'a> {
+    skill_id: i64,
+    skill_name: &'a str,
+}
+
 async fn get_skill_archive(
     client: &reqwest::Client,
+    identity: SkillDownloadIdentity<'_>,
     auth_token: &str,
     api_base_url: &str,
     path: &str,
     local_hash: Option<&str>,
     timeout: Duration,
 ) -> Result<SkillArchiveResponse, String> {
+    let observation = SkillDownloadObservation::begin(identity.skill_id, identity.skill_name);
     let mut request = client
         .get(api_url(api_base_url, path))
         .bearer_auth(auth_token)
+        .header(REQUEST_ID_HEADER, observation.request_id())
+        .header(SKILL_ID_HEADER, identity.skill_id.to_string())
+        .header(SKILL_NAME_HEADER, encoded_skill_name(identity.skill_name))
         .timeout(timeout);
     if let Some(local_hash) = local_hash.map(str::trim).filter(|value| !value.is_empty()) {
         request = request.header(IF_NONE_MATCH, quote_etag(local_hash));
     }
-    let response = request.send().await.map_err(|error| {
-        if error.is_timeout() {
-            "backend download timed out".to_owned()
-        } else if error.is_connect() {
-            "backend download connection failed".to_owned()
-        } else {
-            "backend download request failed".to_owned()
+    let upstream_started_at = Instant::now();
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            let result = if error.is_timeout() {
+                "timeout"
+            } else if error.is_connect() {
+                "connection_error"
+            } else {
+                "request_error"
+            };
+            observation.finish(SkillDownloadOutcome {
+                cache_source: "none",
+                bytes: 0,
+                result,
+                upstream_time_ms: upstream_started_at.elapsed().as_secs_f64() * 1000.0,
+                upstream_status: None,
+                backend_time_ms: None,
+                response_request_id: None,
+            });
+            return Err(if error.is_timeout() {
+                "backend download timed out".to_owned()
+            } else if error.is_connect() {
+                "backend download connection failed".to_owned()
+            } else {
+                "backend download request failed".to_owned()
+            });
         }
-    })?;
-    if response.status() == StatusCode::NOT_MODIFIED {
+    };
+    let status = response.status();
+    let upstream_time_ms =
+        response_milliseconds(response.headers().get(GATEWAY_UPSTREAM_TIME_HEADER))
+            .unwrap_or_else(|| upstream_started_at.elapsed().as_secs_f64() * 1000.0);
+    let backend_time_ms = response_milliseconds(response.headers().get(BACKEND_TIME_HEADER));
+    let request_id = response_request_id(response.headers().get(REQUEST_ID_HEADER));
+    let reported_cache_source = response
+        .headers()
+        .get(CACHE_SOURCE_HEADER)
+        .and_then(|value| value.to_str().ok());
+    let cache_source = if status == StatusCode::NOT_MODIFIED {
+        "executor_local"
+    } else if status == StatusCode::OK && reported_cache_source == Some("skill_binary") {
+        "skill_binary"
+    } else if status == StatusCode::OK {
+        "backend"
+    } else {
+        "none"
+    };
+
+    if status == StatusCode::NOT_MODIFIED {
+        observation.finish(SkillDownloadOutcome {
+            cache_source,
+            bytes: 0,
+            result: "not_modified",
+            upstream_time_ms,
+            upstream_status: Some(status.as_u16()),
+            backend_time_ms,
+            response_request_id: request_id.as_deref(),
+        });
         return Ok(SkillArchiveResponse::NotModified);
     }
-    if response.status() != StatusCode::OK {
-        return Err(format!(
-            "backend download failed with HTTP {}",
-            response.status()
-        ));
+    if status != StatusCode::OK {
+        observation.finish(SkillDownloadOutcome {
+            cache_source,
+            bytes: 0,
+            result: "http_error",
+            upstream_time_ms,
+            upstream_status: Some(status.as_u16()),
+            backend_time_ms,
+            response_request_id: request_id.as_deref(),
+        });
+        return Err(format!("backend download failed with HTTP {}", status));
     }
     let content_hash = response
         .headers()
         .get(ETAG)
         .and_then(|value| value.to_str().ok())
         .map(normalize_etag_hash);
-    let bytes = response
-        .bytes()
-        .await
-        .map(|bytes| bytes.to_vec())
-        .map_err(|_| "backend download body read failed".to_owned())?;
+    let bytes = match response.bytes().await {
+        Ok(bytes) => bytes.to_vec(),
+        Err(_) => {
+            observation.finish(SkillDownloadOutcome {
+                cache_source,
+                bytes: 0,
+                result: "body_read_error",
+                upstream_time_ms,
+                upstream_status: Some(status.as_u16()),
+                backend_time_ms,
+                response_request_id: request_id.as_deref(),
+            });
+            return Err("backend download body read failed".to_owned());
+        }
+    };
+    observation.finish(SkillDownloadOutcome {
+        cache_source,
+        bytes: bytes.len(),
+        result: "success",
+        upstream_time_ms,
+        upstream_status: Some(status.as_u16()),
+        backend_time_ms,
+        response_request_id: request_id.as_deref(),
+    });
     Ok(SkillArchiveResponse::Archive {
         bytes,
         content_hash,
@@ -2819,6 +2925,15 @@ mod tests {
                     .and_then(|rest| rest.split('/').next())
                     .and_then(|value| value.parse::<i64>().ok())
                     .unwrap();
+                let request_lower = request.to_ascii_lowercase();
+                assert!(
+                    request_lower.contains("x-request-id: skill-download-"),
+                    "{request}"
+                );
+                assert!(
+                    request_lower.contains(&format!("x-wegent-skill-id: {skill_id}")),
+                    "{request}"
+                );
                 let body = bodies.get(&skill_id).unwrap();
                 let header = format!(
                     "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",

--- a/executor/src/agents/skill_download.rs
+++ b/executor/src/agents/skill_download.rs
@@ -2,10 +2,185 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
+use std::{
+    env,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Instant,
+};
+
+use uuid::Uuid;
+
+use crate::logging::log_executor_event;
 
 const DEFAULT_SKILL_DOWNLOAD_CONCURRENCY: usize = 3;
 const SKILL_DOWNLOAD_CONCURRENCY_ENV: &str = "WEGENT_SKILL_DOWNLOAD_CONCURRENCY";
+pub(crate) const REQUEST_ID_HEADER: &str = "X-Request-ID";
+pub(crate) const SKILL_ID_HEADER: &str = "X-Wegent-Skill-Id";
+pub(crate) const SKILL_NAME_HEADER: &str = "X-Wegent-Skill-Name";
+pub(crate) const CACHE_SOURCE_HEADER: &str = "X-Wegent-Skill-Cache-Source";
+pub(crate) const BACKEND_TIME_HEADER: &str = "X-Wegent-Backend-Time-Ms";
+pub(crate) const GATEWAY_UPSTREAM_TIME_HEADER: &str = "X-Wegent-Gateway-Upstream-Time-Ms";
+
+static SKILL_DOWNLOAD_INFLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+pub(crate) struct SkillDownloadObservation {
+    skill_id: i64,
+    skill_name: String,
+    request_id: String,
+    started_at: Instant,
+    inflight: usize,
+}
+
+pub(crate) struct SkillDownloadOutcome<'a> {
+    pub(crate) cache_source: &'a str,
+    pub(crate) bytes: usize,
+    pub(crate) result: &'a str,
+    pub(crate) upstream_time_ms: f64,
+    pub(crate) upstream_status: Option<u16>,
+    pub(crate) backend_time_ms: Option<f64>,
+    pub(crate) response_request_id: Option<&'a str>,
+}
+
+impl SkillDownloadObservation {
+    pub(crate) fn begin(skill_id: i64, skill_name: &str) -> Self {
+        Self {
+            skill_id,
+            skill_name: skill_name.to_owned(),
+            request_id: format!("skill-download-{}", Uuid::new_v4().simple()),
+            started_at: Instant::now(),
+            inflight: SKILL_DOWNLOAD_INFLIGHT.fetch_add(1, Ordering::Relaxed) + 1,
+        }
+    }
+
+    pub(crate) fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    pub(crate) fn finish(self, outcome: SkillDownloadOutcome<'_>) {
+        let fields = skill_download_fields(SkillDownloadFields {
+            skill_id: Some(self.skill_id),
+            skill_name: &self.skill_name,
+            cache_source: outcome.cache_source,
+            bytes: outcome.bytes,
+            duration_ms: self.started_at.elapsed().as_secs_f64() * 1000.0,
+            result: outcome.result,
+            inflight: self.inflight,
+            upstream_time_ms: Some(outcome.upstream_time_ms),
+            upstream_status: outcome.upstream_status,
+            backend_time_ms: outcome.backend_time_ms,
+            request_id: outcome.response_request_id.unwrap_or(&self.request_id),
+        });
+        log_executor_event("skill download observed", &fields);
+    }
+}
+
+impl Drop for SkillDownloadObservation {
+    fn drop(&mut self) {
+        SKILL_DOWNLOAD_INFLIGHT.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+pub(crate) fn log_skill_cache_observation(
+    skill_id: Option<i64>,
+    skill_name: &str,
+    started_at: Instant,
+    result: &str,
+) {
+    let fields = skill_download_fields(SkillDownloadFields {
+        skill_id,
+        skill_name,
+        cache_source: "executor_local",
+        bytes: 0,
+        duration_ms: started_at.elapsed().as_secs_f64() * 1000.0,
+        result,
+        inflight: SKILL_DOWNLOAD_INFLIGHT.load(Ordering::Relaxed),
+        upstream_time_ms: None,
+        upstream_status: None,
+        backend_time_ms: None,
+        request_id: "none",
+    });
+    log_executor_event("skill download observed", &fields);
+}
+
+struct SkillDownloadFields<'a> {
+    skill_id: Option<i64>,
+    skill_name: &'a str,
+    cache_source: &'a str,
+    bytes: usize,
+    duration_ms: f64,
+    result: &'a str,
+    inflight: usize,
+    upstream_time_ms: Option<f64>,
+    upstream_status: Option<u16>,
+    backend_time_ms: Option<f64>,
+    request_id: &'a str,
+}
+
+fn skill_download_fields(values: SkillDownloadFields<'_>) -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "skill_id",
+            values
+                .skill_id
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_owned()),
+        ),
+        ("skill_name", values.skill_name.to_owned()),
+        ("cache_source", values.cache_source.to_owned()),
+        ("bytes", values.bytes.to_string()),
+        ("duration_ms", format!("{:.2}", values.duration_ms)),
+        ("result", values.result.to_owned()),
+        ("inflight", values.inflight.to_string()),
+        (
+            "upstream_time_ms",
+            values
+                .upstream_time_ms
+                .map(|value| format!("{value:.2}"))
+                .unwrap_or_else(|| "none".to_owned()),
+        ),
+        (
+            "upstream_status",
+            values
+                .upstream_status
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unavailable".to_owned()),
+        ),
+        (
+            "backend_time_ms",
+            values
+                .backend_time_ms
+                .map(|value| format!("{value:.2}"))
+                .unwrap_or_else(|| "unavailable".to_owned()),
+        ),
+        ("request_id", safe_header_value(values.request_id)),
+    ]
+}
+
+pub(crate) fn response_milliseconds(value: Option<&reqwest::header::HeaderValue>) -> Option<f64> {
+    value
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<f64>().ok())
+        .filter(|value| value.is_finite() && *value >= 0.0)
+}
+
+pub(crate) fn response_request_id(value: Option<&reqwest::header::HeaderValue>) -> Option<String> {
+    value
+        .and_then(|value| value.to_str().ok())
+        .map(safe_header_value)
+        .filter(|value| !value.is_empty())
+}
+
+pub(crate) fn encoded_skill_name(skill_name: &str) -> String {
+    url::form_urlencoded::byte_serialize(skill_name.as_bytes()).collect()
+}
+
+fn safe_header_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(128)
+        .collect()
+}
 
 pub(crate) fn skill_download_concurrency() -> usize {
     env::var(SKILL_DOWNLOAD_CONCURRENCY_ENV)
@@ -69,5 +244,48 @@ mod tests {
         let _guard = EnvGuard::set("0");
 
         assert_eq!(skill_download_concurrency(), 3);
+    }
+
+    #[test]
+    fn observation_fields_cover_download_correlation_without_credentials() {
+        let fields = skill_download_fields(SkillDownloadFields {
+            skill_id: Some(110603),
+            skill_name: "wegent-knowledge",
+            cache_source: "skill_binary",
+            bytes: 4096,
+            duration_ms: 125.25,
+            result: "success",
+            inflight: 3,
+            upstream_time_ms: Some(120.5),
+            upstream_status: Some(200),
+            backend_time_ms: Some(80.0),
+            request_id: "skill-download-request",
+        });
+
+        assert_eq!(
+            fields,
+            vec![
+                ("skill_id", "110603".to_owned()),
+                ("skill_name", "wegent-knowledge".to_owned()),
+                ("cache_source", "skill_binary".to_owned()),
+                ("bytes", "4096".to_owned()),
+                ("duration_ms", "125.25".to_owned()),
+                ("result", "success".to_owned()),
+                ("inflight", "3".to_owned()),
+                ("upstream_time_ms", "120.50".to_owned()),
+                ("upstream_status", "200".to_owned()),
+                ("backend_time_ms", "80.00".to_owned()),
+                ("request_id", "skill-download-request".to_owned()),
+            ]
+        );
+        assert!(fields.iter().all(|(key, _)| !key.contains("token")));
+    }
+
+    #[test]
+    fn encoded_skill_name_is_safe_for_request_headers() {
+        assert_eq!(
+            encoded_skill_name("知识库 Skill"),
+            "%E7%9F%A5%E8%AF%86%E5%BA%93+Skill"
+        );
     }
 }

--- a/executor/src/local/backend/capability.rs
+++ b/executor/src/local/backend/capability.rs
@@ -9,6 +9,7 @@ use std::{
     path::{Component, Path, PathBuf},
     pin::Pin,
     sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
 };
 
 use reqwest::Url;
@@ -17,7 +18,15 @@ use sha2::{Digest, Sha256};
 use zip::ZipArchive;
 
 use crate::{
-    agents::wework_codex_home,
+    agents::{
+        skill_download::{
+            encoded_skill_name, response_milliseconds, response_request_id,
+            SkillDownloadObservation, SkillDownloadOutcome, BACKEND_TIME_HEADER,
+            CACHE_SOURCE_HEADER, GATEWAY_UPSTREAM_TIME_HEADER, REQUEST_ID_HEADER, SKILL_ID_HEADER,
+            SKILL_NAME_HEADER,
+        },
+        wework_codex_home,
+    },
     local::capabilities::{
         default_manifest_path, CapabilityPackageProvider, CapabilitySyncError,
         CapabilitySyncHandler, GlobalCapabilityReporter, GlobalCapabilityStore,
@@ -116,35 +125,119 @@ impl HttpPackageProvider {
         }
     }
 
-    async fn get_bytes(&self, path: &str) -> Result<Vec<u8>, CapabilitySyncError> {
+    async fn get_bytes(
+        &self,
+        path: &str,
+        skill: Option<&SkillSyncSpec>,
+    ) -> Result<Vec<u8>, CapabilitySyncError> {
         let url = self.resolve_backend_url(path)?;
         let backend = parse_url_with_trailing_slash(&self.backend_url)?;
         let should_send_backend_auth = same_origin(&backend, &url);
         let mut request = self.client.get(url);
+        let mut observation =
+            skill.map(|spec| SkillDownloadObservation::begin(spec.skill_id, &spec.name));
         let auth_token = self.auth_token.trim();
         if should_send_backend_auth && !auth_token.is_empty() {
             request = request.bearer_auth(auth_token);
         }
-        let response = request.send().await.map_err(|error| {
-            CapabilitySyncError::invalid_payload(format!(
-                "Capability package download failed: {error}"
-            ))
-        })?;
+        if let (Some(observation), Some(spec)) = (observation.as_ref(), skill) {
+            request = request
+                .header(REQUEST_ID_HEADER, observation.request_id())
+                .header(SKILL_ID_HEADER, spec.skill_id.to_string())
+                .header(SKILL_NAME_HEADER, encoded_skill_name(&spec.name));
+        }
+        let upstream_started_at = Instant::now();
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(error) => {
+                if let Some(observation) = observation.take() {
+                    let result = if error.is_timeout() {
+                        "timeout"
+                    } else if error.is_connect() {
+                        "connection_error"
+                    } else {
+                        "request_error"
+                    };
+                    observation.finish(SkillDownloadOutcome {
+                        cache_source: "none",
+                        bytes: 0,
+                        result,
+                        upstream_time_ms: upstream_started_at.elapsed().as_secs_f64() * 1000.0,
+                        upstream_status: None,
+                        backend_time_ms: None,
+                        response_request_id: None,
+                    });
+                }
+                return Err(CapabilitySyncError::invalid_payload(format!(
+                    "Capability package download failed: {error}"
+                )));
+            }
+        };
         let status = response.status();
+        let upstream_time_ms =
+            response_milliseconds(response.headers().get(GATEWAY_UPSTREAM_TIME_HEADER))
+                .unwrap_or_else(|| upstream_started_at.elapsed().as_secs_f64() * 1000.0);
+        let backend_time_ms = response_milliseconds(response.headers().get(BACKEND_TIME_HEADER));
+        let request_id = response_request_id(response.headers().get(REQUEST_ID_HEADER));
+        let cache_source = if response
+            .headers()
+            .get(CACHE_SOURCE_HEADER)
+            .and_then(|value| value.to_str().ok())
+            == Some("skill_binary")
+        {
+            "skill_binary"
+        } else if status.is_success() {
+            "backend"
+        } else {
+            "none"
+        };
         if !status.is_success() {
+            if let Some(observation) = observation.take() {
+                observation.finish(SkillDownloadOutcome {
+                    cache_source,
+                    bytes: 0,
+                    result: "http_error",
+                    upstream_time_ms,
+                    upstream_status: Some(status.as_u16()),
+                    backend_time_ms,
+                    response_request_id: request_id.as_deref(),
+                });
+            }
             return Err(CapabilitySyncError::invalid_payload(format!(
                 "Capability package download failed with HTTP {status}"
             )));
         }
-        response
-            .bytes()
-            .await
-            .map(|bytes| bytes.to_vec())
-            .map_err(|error| {
-                CapabilitySyncError::invalid_payload(format!(
+        let bytes = match response.bytes().await {
+            Ok(bytes) => bytes.to_vec(),
+            Err(error) => {
+                if let Some(observation) = observation.take() {
+                    observation.finish(SkillDownloadOutcome {
+                        cache_source,
+                        bytes: 0,
+                        result: "body_read_error",
+                        upstream_time_ms,
+                        upstream_status: Some(status.as_u16()),
+                        backend_time_ms,
+                        response_request_id: request_id.as_deref(),
+                    });
+                }
+                return Err(CapabilitySyncError::invalid_payload(format!(
                     "Capability package read failed: {error}"
-                ))
-            })
+                )));
+            }
+        };
+        if let Some(observation) = observation.take() {
+            observation.finish(SkillDownloadOutcome {
+                cache_source,
+                bytes: bytes.len(),
+                result: "success",
+                upstream_time_ms,
+                upstream_status: Some(status.as_u16()),
+                backend_time_ms,
+                response_request_id: request_id.as_deref(),
+            });
+        }
+        Ok(bytes)
     }
 
     fn resolve_backend_url(&self, path: &str) -> Result<Url, CapabilitySyncError> {
@@ -173,7 +266,9 @@ impl CapabilityPackageProvider for HttpPackageProvider {
         target: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<(), CapabilitySyncError>> + Send + 'a>> {
         Box::pin(async move {
-            let package = self.get_bytes(&skill_download_path(spec)?).await?;
+            let package = self
+                .get_bytes(&skill_download_path(spec)?, Some(spec))
+                .await?;
             extract_skill_zip(&package, target)
         })
     }
@@ -182,7 +277,7 @@ impl CapabilityPackageProvider for HttpPackageProvider {
         &'a self,
         download_path: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, CapabilitySyncError>> + Send + 'a>> {
-        Box::pin(async move { self.get_bytes(download_path).await })
+        Box::pin(async move { self.get_bytes(download_path, None).await })
     }
 }
 

--- a/executor/tests/local_backend_device_migration_contract.rs
+++ b/executor/tests/local_backend_device_migration_contract.rs
@@ -261,6 +261,16 @@ async fn http_capability_provider_supports_signed_external_package_urls_without_
             .contains("authorization: bearer secret-token"),
         "{request}"
     );
+    let request_lower = request.to_ascii_lowercase();
+    assert!(
+        request_lower.contains("x-request-id: skill-download-"),
+        "{request}"
+    );
+    assert!(request_lower.contains("x-wegent-skill-id: 42"), "{request}");
+    assert!(
+        request_lower.contains("x-wegent-skill-name: browser"),
+        "{request}"
+    );
 
     let external_requests = Arc::new(Mutex::new(Vec::new()));
     let external_url =

--- a/frontend/src/__tests__/app/api/proxy-route-auth.test.ts
+++ b/frontend/src/__tests__/app/api/proxy-route-auth.test.ts
@@ -12,10 +12,17 @@ jest.mock('@/lib/server-config', () => ({
 
 type ProxyRequestOptions = {
   authorization?: string
+  requestId?: string
+  skillName?: string
   tokenCookie?: string
 }
 
-function createProxyRequest({ authorization, tokenCookie }: ProxyRequestOptions = {}) {
+function createProxyRequest({
+  authorization,
+  requestId,
+  skillName,
+  tokenCookie,
+}: ProxyRequestOptions = {}) {
   const headers = new Headers({
     'sec-fetch-site': 'same-origin',
     referer: 'http://127.0.0.1:3001/chat?taskId=2941',
@@ -23,6 +30,12 @@ function createProxyRequest({ authorization, tokenCookie }: ProxyRequestOptions 
 
   if (authorization) {
     headers.set('Authorization', authorization)
+  }
+  if (requestId) {
+    headers.set('X-Request-ID', requestId)
+  }
+  if (skillName) {
+    headers.set('X-Wegent-Skill-Name', encodeURIComponent(skillName))
   }
 
   return {
@@ -84,5 +97,124 @@ describe('API proxy auth forwarding', () => {
     const forwardedHeaders = init.headers as Headers
 
     expect(forwardedHeaders.get('Authorization')).toBe('Bearer explicit.header.token')
+  })
+})
+
+describe('API proxy Skill download observability', () => {
+  test('logs safe upstream fields and returns gateway timing headers', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response('zip-data', {
+        status: 200,
+        headers: {
+          'Content-Length': '8',
+          'X-Request-ID': 'skill-request-42',
+          'X-Wegent-Backend-Time-Ms': '12.5',
+          'X-Wegent-Skill-Bytes': '8',
+          'X-Wegent-Skill-Cache-Source': 'skill_binary',
+          'X-Wegent-Skill-Name': 'wegent-knowledge',
+        },
+      })
+    ) as jest.Mock
+    const info = jest.spyOn(console, 'info').mockImplementation()
+    const request = createProxyRequest({
+      authorization: 'Bearer must-not-be-logged',
+      requestId: 'skill-request-42',
+      skillName: 'wegent-knowledge',
+    })
+
+    const response = await GET(request, {
+      params: Promise.resolve({
+        path: ['v1', 'kinds', 'skills', '42', 'download'],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Wegent-Gateway-Upstream-Time-Ms')).not.toBeNull()
+    expect(response.headers.get('X-Wegent-Gateway-Upstream-Status')).toBe('200')
+    const observation = JSON.parse(info.mock.calls[0][1])
+    expect(info.mock.calls[0][0]).toBe('[Skill Download]')
+    expect(observation).toEqual(
+      expect.objectContaining({
+        component: 'gateway',
+        skill_id: '42',
+        skill_name: 'wegent-knowledge',
+        cache_source: 'skill_binary',
+        bytes: 8,
+        result: 'success',
+        inflight: 1,
+        upstream_status: 200,
+        backend_time_ms: 12.5,
+        request_id: 'skill-request-42',
+      })
+    )
+    expect(JSON.stringify(info.mock.calls)).not.toContain('must-not-be-logged')
+    info.mockRestore()
+  })
+
+  test('records an upstream 504 without response content or credentials', async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 504 })) as jest.Mock
+    const info = jest.spyOn(console, 'info').mockImplementation()
+    const request = createProxyRequest({
+      authorization: 'Bearer gateway-secret',
+      skillName: 'wegent-knowledge',
+    })
+
+    const response = await GET(request, {
+      params: Promise.resolve({
+        path: ['v1', 'kinds', 'skills', '110603', 'download'],
+      }),
+    })
+
+    expect(response.status).toBe(504)
+    const observation = JSON.parse(info.mock.calls[0][1])
+    expect(info.mock.calls[0][0]).toBe('[Skill Download]')
+    expect(observation).toEqual(
+      expect.objectContaining({
+        skill_id: '110603',
+        skill_name: 'wegent-knowledge',
+        cache_source: 'none',
+        bytes: 0,
+        result: 'http_error',
+        inflight: 1,
+        upstream_status: 504,
+      })
+    )
+    expect(JSON.stringify(info.mock.calls)).not.toContain('gateway-secret')
+    info.mockRestore()
+  })
+
+  test('captures concurrent upstream downloads in the inflight field', async () => {
+    const resolvers: Array<(response: Response) => void> = []
+    global.fetch = jest.fn(
+      () =>
+        new Promise<Response>(resolve => {
+          resolvers.push(resolve)
+        })
+    ) as jest.Mock
+    const info = jest.spyOn(console, 'info').mockImplementation()
+
+    const first = GET(createProxyRequest({ skillName: 'first-skill' }), {
+      params: Promise.resolve({ path: ['v1', 'kinds', 'skills', '1', 'download'] }),
+    })
+    const second = GET(createProxyRequest({ skillName: 'second-skill' }), {
+      params: Promise.resolve({ path: ['v1', 'kinds', 'skills', '2', 'download'] }),
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(resolvers).toHaveLength(2)
+    resolvers[1](new Response('second', { status: 200 }))
+    await second
+    resolvers[0](new Response('first', { status: 200 }))
+    await first
+
+    const observations = info.mock.calls.map(call => JSON.parse(call[1]))
+    expect(observations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ skill_id: '1', inflight: 1 }),
+        expect.objectContaining({ skill_id: '2', inflight: 2 }),
+      ])
+    )
+    info.mockRestore()
   })
 })

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -34,6 +34,107 @@ const ALLOWED_EXTERNAL_PATHS = [
   '/api/attachments/download/shared', // Signed attachment downloads for model providers
 ]
 
+const SKILL_DOWNLOAD_PATH = /^\/api\/v1\/kinds\/skills\/(?:public\/)?(\d+)\/download$/
+let skillDownloadInflight = 0
+
+type SkillDownloadObservation = {
+  skillId: string
+  skillName: string
+  requestId: string
+  startedAt: number
+  inflight: number
+}
+
+function beginSkillDownloadObservation(
+  targetPath: string,
+  headers: Headers
+): SkillDownloadObservation | null {
+  const match = SKILL_DOWNLOAD_PATH.exec(targetPath)
+  if (!match) {
+    return null
+  }
+
+  const requestId = headers.get('X-Request-ID') || `skill-download-${crypto.randomUUID()}`
+  headers.set('X-Request-ID', requestId)
+  skillDownloadInflight += 1
+
+  return {
+    skillId: match[1],
+    skillName: decodeHeaderValue(headers.get('X-Wegent-Skill-Name')) || 'unknown',
+    requestId,
+    startedAt: performance.now(),
+    inflight: skillDownloadInflight,
+  }
+}
+
+function finishSkillDownloadObservation(): void {
+  skillDownloadInflight = Math.max(0, skillDownloadInflight - 1)
+}
+
+function decodeHeaderValue(value: string | null): string {
+  if (!value) {
+    return ''
+  }
+  try {
+    return decodeURIComponent(value.replace(/\+/g, ' '))
+  } catch {
+    return value
+  }
+}
+
+function nonNegativeHeaderNumber(value: string | null): number {
+  const number = Number(value)
+  return Number.isFinite(number) && number >= 0 ? number : 0
+}
+
+function skillDownloadResult(status: number): string {
+  if (status === 304) {
+    return 'not_modified'
+  }
+  return status >= 200 && status < 300 ? 'success' : 'http_error'
+}
+
+function logSkillDownloadObservation(
+  observation: SkillDownloadObservation,
+  response?: Response
+): number {
+  const upstreamTimeMs = Math.max(0, performance.now() - observation.startedAt)
+  const upstreamStatus = response?.status ?? 'unavailable'
+  const responseSkillName = decodeHeaderValue(response?.headers.get('X-Wegent-Skill-Name') ?? null)
+  const result = response ? skillDownloadResult(response.status) : 'gateway_error'
+  const cacheSource =
+    response && response.status < 400
+      ? response.headers.get('X-Wegent-Skill-Cache-Source') || 'backend'
+      : 'none'
+  const bytes = response
+    ? nonNegativeHeaderNumber(
+        response.headers.get('X-Wegent-Skill-Bytes') || response.headers.get('Content-Length')
+      )
+    : 0
+
+  console.info(
+    '[Skill Download]',
+    JSON.stringify({
+      component: 'gateway',
+      skill_id: observation.skillId,
+      skill_name: responseSkillName || observation.skillName,
+      cache_source: cacheSource,
+      bytes,
+      duration_ms: Number(upstreamTimeMs.toFixed(2)),
+      result,
+      inflight: observation.inflight,
+      upstream_time_ms: Number(upstreamTimeMs.toFixed(2)),
+      upstream_status: upstreamStatus,
+      backend_time_ms: response
+        ? nonNegativeHeaderNumber(response.headers.get('X-Wegent-Backend-Time-Ms'))
+        : 0,
+      request_id: response?.headers.get('X-Request-ID') || observation.requestId,
+    })
+  )
+
+  return upstreamTimeMs
+}
+
 /**
  * Check if the request path is in the allowed external paths list
  */
@@ -112,6 +213,7 @@ async function proxyRequest(
     targetUrl.searchParams.append(key, value)
   })
 
+  let skillDownloadObservation: SkillDownloadObservation | null = null
   try {
     // Forward headers, excluding host-related ones
     const headers = new Headers()
@@ -135,6 +237,8 @@ async function proxyRequest(
       }
     }
 
+    skillDownloadObservation = beginSkillDownloadObservation(targetPath, headers)
+
     // Get request body for methods that support it
     let body: BodyInit | null = null
     if (request.method !== 'GET' && request.method !== 'HEAD') {
@@ -149,6 +253,9 @@ async function proxyRequest(
       // Don't follow redirects, let the client handle them
       redirect: 'manual',
     })
+    const gatewayUpstreamTimeMs = skillDownloadObservation
+      ? logSkillDownloadObservation(skillDownloadObservation, response)
+      : null
 
     // Create response headers, excluding hop-by-hop headers
     const responseHeaders = new Headers()
@@ -162,6 +269,10 @@ async function proxyRequest(
         responseHeaders.set(key, value)
       }
     })
+    if (gatewayUpstreamTimeMs !== null) {
+      responseHeaders.set('X-Wegent-Gateway-Upstream-Time-Ms', gatewayUpstreamTimeMs.toFixed(2))
+      responseHeaders.set('X-Wegent-Gateway-Upstream-Status', String(response.status))
+    }
 
     // Return the proxied response
     return new Response(response.body, {
@@ -170,8 +281,26 @@ async function proxyRequest(
       headers: responseHeaders,
     })
   } catch (error) {
+    if (skillDownloadObservation) {
+      const gatewayUpstreamTimeMs = logSkillDownloadObservation(skillDownloadObservation)
+      return NextResponse.json(
+        { error: 'Failed to proxy request to backend' },
+        {
+          status: 502,
+          headers: {
+            'X-Request-ID': skillDownloadObservation.requestId,
+            'X-Wegent-Gateway-Upstream-Time-Ms': gatewayUpstreamTimeMs.toFixed(2),
+            'X-Wegent-Gateway-Upstream-Status': 'unavailable',
+          },
+        }
+      )
+    }
     console.error('[API Proxy] Error proxying request:', error)
     return NextResponse.json({ error: 'Failed to proxy request to backend' }, { status: 502 })
+  } finally {
+    if (skillDownloadObservation) {
+      finishSkillDownloadObservation()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- add structured Skill download observations across Executor, the Next.js gateway, and Backend
- record skill ID/name, cache source, bytes, duration, result, inflight count, and upstream time/status with a correlated request ID
- expose Backend Prometheus metrics and download timing headers without logging authorization tokens or credentials

## Validation

- Backend: 17 focused pytest cases; Black and isort checks
- Frontend: 5 focused Jest cases; full pre-push unit tests, ESLint, and TypeScript
- Executor: cargo fmt, full lib tests, Clippy, and 11 focused tests
- Alembic multi-head and settings configuration checks
- verified the 14-file patch contains no wecode/ paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skill downloads now provide more complete response metadata, including download size, request identifiers, cache information, and timing details.
  - Download requests now preserve skill identity and request context across the application layers.
  - Download failures return more consistent status and diagnostic information.

- **Bug Fixes**
  - Improved handling and reporting of download errors, including authentication failures, upstream issues, and interrupted transfers.

- **Tests**
  - Added coverage for download metadata, response headers, error handling, cache behavior, and concurrent downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->