### PR TITLE
fix(wework): handle Astra deferred tool search

### DIFF
--- a/executor/src/server/local_model_proxy/chat.rs
+++ b/executor/src/server/local_model_proxy/chat.rs
@@ -803,6 +803,39 @@ fn responses_tools(
     converted
 }
 
+fn sanitize_defer_loading_tools_for_responses(body: &mut Value) {
+    let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+        return;
+    };
+    if tools
+        .iter()
+        .any(|tool| tool.get("type").and_then(Value::as_str) == Some("tool_search"))
+    {
+        return;
+    }
+    for tool in tools {
+        remove_defer_loading(tool);
+    }
+}
+
+fn remove_defer_loading(tool: &mut Value) {
+    let Some(object) = tool.as_object_mut() else {
+        return;
+    };
+    object.remove("defer_loading");
+    if object.get("type").and_then(Value::as_str) != Some("namespace") {
+        return;
+    }
+    for inner_tool in object
+        .get_mut("tools")
+        .and_then(Value::as_array_mut)
+        .into_iter()
+        .flatten()
+    {
+        remove_defer_loading(inner_tool);
+    }
+}
+
 fn responses_tool_choice(
     choice: &Value,
     context: &ToolContext,
@@ -863,6 +896,7 @@ pub(super) fn responses_to_responses(
             ));
         }
     }
+    sanitize_defer_loading_tools_for_responses(&mut result);
 
     if let Some(input) = result.get("input") {
         result["input"] = convert_responses_input_items(
@@ -4280,13 +4314,18 @@ mod tests {
     }
 
     #[test]
-    fn responses_bridge_completes_native_tool_search_contract() {
+    fn responses_bridge_removes_defer_loading_without_native_tool_search() {
         let input = json!({
             "model": "third-party-responses-model",
             "tools": [{
                 "type": "tool_search",
                 "execution": "client",
                 "parameters": {"type": "object"}
+            }, {
+                "type": "function",
+                "name": "multi_agent_v1__spawn_agent",
+                "parameters": {"type": "object"},
+                "defer_loading": true
             }]
         });
 
@@ -4314,6 +4353,7 @@ mod tests {
             converted["tools"][0]["parameters"]["additionalProperties"],
             false
         );
+        assert!(converted["tools"][1].get("defer_loading").is_none());
     }
 
     #[test]
@@ -4358,6 +4398,12 @@ mod tests {
                         "name": "create_issue",
                         "parameters": {"type": "object"}
                     }]
+                },
+                {
+                    "type": "function",
+                    "name": "multi_agent_v1__spawn_agent",
+                    "parameters": {"type": "object"},
+                    "defer_loading": true
                 },
                 {"type": "web_search_preview"}
             ],

--- a/wework/e2e/desktop/modules/desktop-server.mjs
+++ b/wework/e2e/desktop/modules/desktop-server.mjs
@@ -4246,6 +4246,20 @@ class DesktopE2EServer {
     )
     assert.ok(applyPatch, `${matrixCaseId(model)} did not advertise apply_patch`)
     if (model.protocol === 'responses') {
+      const hasNativeToolSearch = tools.some(tool => tool?.type === 'tool_search')
+      if (model.modelId === 'gpt-6-astra') {
+        assert.ok(
+          hasNativeToolSearch,
+          `${matrixCaseId(model)} did not preserve Astra native tool_search`
+        )
+      }
+      if (!hasNativeToolSearch) {
+        assert.equal(
+          tools.some(tool => tool?.defer_loading === true),
+          false,
+          `${matrixCaseId(model)} advertised defer_loading without native tool_search`
+        )
+      }
       assert.equal(
         applyPatch.type,
         model.source === 'local' ? 'function' : 'custom',

--- a/wework/e2e/desktop/modules/goal-flows.mjs
+++ b/wework/e2e/desktop/modules/goal-flows.mjs
@@ -43,6 +43,7 @@ import {
   selectE2EModel,
   sendPromptUntilScenarioRequest,
   waitForExecutorRuntimeEvidence,
+  waitForLogPattern,
   withTimeout,
 } from './shared.mjs'
 
@@ -137,7 +138,11 @@ async function verifyActiveGoalIdleUnreadLifecycle({ composerSelector, control, 
     DEFAULT_STEP_TIMEOUT_MS,
     'The active Goal did not start its automatic continuation'
   )
-  const goalExecutorLog = (await readFile(executorLogPath, 'utf8')).slice(executorLogOffset)
+  const goalExecutorLog = (
+    await waitForLogPattern(executorLogPath, /codex shared goal turn awaiting/, {
+      fromOffset: executorLogOffset,
+    })
+  ).slice(executorLogOffset)
   assert.equal(
     (goalExecutorLog.match(/codex shared goal turn awaiting/g) ?? []).length,
     1,
@@ -439,7 +444,11 @@ async function verifyBusyTurnGoalHandoff({ composerSelector, control, executorLo
     DEFAULT_STEP_TIMEOUT_MS,
     'The queued Goal did not start after the planning turn completed'
   )
-  const handoffExecutorLog = (await readFile(executorLogPath, 'utf8')).slice(executorLogOffset)
+  const handoffExecutorLog = (
+    await waitForLogPattern(executorLogPath, /codex shared goal turn awaiting/, {
+      fromOffset: executorLogOffset,
+    })
+  ).slice(executorLogOffset)
   assert.equal(
     (handoffExecutorLog.match(/codex shared turn request started/g) ?? []).length,
     1,

--- a/wework/e2e/desktop/modules/shared.mjs
+++ b/wework/e2e/desktop/modules/shared.mjs
@@ -326,8 +326,19 @@ const CLOUD_MODEL_CASES = MODEL_PROTOCOLS.map(protocol => ({
   source: 'cloud',
   protocol,
   optionIds: [`desktop-e2e-cloud-${protocol}`],
-  labels: [protocol === 'chat' ? 'moonshot-kimi-k3' : `desktop-e2e-cloud-${protocol}`],
-  modelId: protocol === 'chat' ? 'moonshot-kimi-k3' : `desktop-e2e-cloud-${protocol}-upstream`,
+  labels: [
+    protocol === 'responses'
+      ? 'gpt-6-astra'
+      : protocol === 'chat'
+        ? 'moonshot-kimi-k3'
+        : `desktop-e2e-cloud-${protocol}`,
+  ],
+  modelId:
+    protocol === 'responses'
+      ? 'gpt-6-astra'
+      : protocol === 'chat'
+        ? 'moonshot-kimi-k3'
+        : `desktop-e2e-cloud-${protocol}-upstream`,
 }))
 const MODEL_PROTOCOL_MATRIX_CASES = [
   ...LOCAL_MODEL_CASES.map(model => ({ ...model, source: 'local' })),

--- a/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/claude-runtime.scenario.mjs
@@ -23,7 +23,7 @@ const CLAUDE_BINARY = localHarnessCliPath(
   'claude'
 )
 const MODEL_LABEL = 'Desktop E2E DeepSeek Pro Vision Main'
-const REMOTE_MODEL_LABEL = 'desktop-e2e-cloud-responses-upstream'
+const REMOTE_MODEL_LABEL = 'gpt-6-astra'
 const LOCAL_INITIAL_PROMPT =
   'WEWORK_CLAUDE_LOCAL_INITIAL: create the requested local verification file.'
 const LOCAL_INITIAL_COMPLETION = 'WEWORK_CLAUDE_LOCAL_INITIAL_COMPLETE'

--- a/wework/src/features/workbench/runtimeModelSelection.test.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.test.ts
@@ -260,31 +260,34 @@ describe('runtimeModelSelection', () => {
     )
   })
 
-  test('enables native Responses tools for supported GPT cloud models', () => {
-    const cloudModel: UnifiedModel = {
-      name: 'shared-gpt-model',
-      modelId: 'gpt-5.6-sol',
-      type: 'user',
-      namespace: 'default',
-      resourceUserId: 42,
-      provider: 'openai',
-      runtime: { family: 'openai.openai-responses' },
-      config: {},
-    }
+  test.each(['gpt-5.6-sol', 'gpt-6-astra'])(
+    'enables native Responses tools for supported GPT cloud model %s',
+    modelId => {
+      const cloudModel: UnifiedModel = {
+        name: 'shared-gpt-model',
+        modelId,
+        type: 'user',
+        namespace: 'default',
+        resourceUserId: 42,
+        provider: 'openai',
+        runtime: { family: 'openai.openai-responses' },
+        config: {},
+      }
 
-    expect(selectedModelExecutionFields(cloudModel, {})).toEqual({
-      modelId: 'shared-gpt-model',
-      modelType: 'user',
-      modelOptions: {
-        collaborationMode: 'default',
-        weworkCloudModelNamespace: 'default',
-        weworkCloudModelResourceUserId: '42',
-        weworkCloudModelUpstreamApiFormat: 'openai-responses',
-        weworkCloudModelNativeToolSearch: 'true',
-        weworkCloudModelNativeNamespaceTools: 'true',
-      },
-    })
-  })
+      expect(selectedModelExecutionFields(cloudModel, {})).toEqual({
+        modelId: 'shared-gpt-model',
+        modelType: 'user',
+        modelOptions: {
+          collaborationMode: 'default',
+          weworkCloudModelNamespace: 'default',
+          weworkCloudModelResourceUserId: '42',
+          weworkCloudModelUpstreamApiFormat: 'openai-responses',
+          weworkCloudModelNativeToolSearch: 'true',
+          weworkCloudModelNativeNamespaceTools: 'true',
+        },
+      })
+    }
+  )
 
   test.each([
     {

--- a/wework/src/features/workbench/runtimeModelSelection.ts
+++ b/wework/src/features/workbench/runtimeModelSelection.ts
@@ -117,10 +117,10 @@ function isNativeOpenAIResponsesModel(model: UnifiedModel, upstreamApiFormat: st
     const match = candidate
       ?.trim()
       .toLowerCase()
-      .match(/^gpt-(\d+)\.(\d+)(?:-|$)/)
+      .match(/^gpt-(\d+)(?:\.(\d+))?(?:-|$)/)
     if (!match) return false
     const major = Number(match[1])
-    const minor = Number(match[2])
+    const minor = Number(match[2] ?? 0)
     return major > 5 || (major === 5 && minor >= 4)
   })
 }


### PR DESCRIPTION
## Problem

`gpt-6-astra` was not recognized as a native Responses tool-search model because model capability detection only accepted dotted GPT versions. Wework therefore converted the native `tool_search` entry into the `search_deferred_tools` function while a deferred tool still carried `defer_loading: true`, causing the upstream Responses API to reject the request with HTTP 400.

## Changes

- Recognize both dotted and major-only GPT model IDs, including `gpt-6-astra`.
- Enforce the Responses tool invariant after protocol conversion: when no native `type: "tool_search"` remains, remove `defer_loading` recursively so tools load immediately.
- Cover the Astra route and both valid/invalid deferred-tool combinations in unit and desktop E2E tests.
- Wait for executor Goal protocol evidence before asserting log counts, avoiding a child-process stdout flush race exposed by CI.

## Validation

- `pnpm --filter wework test src/api/local/localServices.test.ts src/features/workbench/runtimeModelSelection.test.ts scripts/response-protocol.test.mjs` — 110 tests passed.
- `cargo test --manifest-path executor/Cargo.toml --lib server::local_model_proxy::chat::tests::responses_` — 10 tests passed.
- `pnpm --filter wework e2e:desktop:cloud -- --segment model-routing` — all 9 protocol matrix cases passed with real Electron and Codex, including `gpt-6-astra`.
- `pnpm --filter wework e2e:desktop -- --segment goal-lifecycle` — passed with real Electron after the CI synchronization fix.
- Pre-push checks passed: frontend/Wework lint, type checks and tests; backend formatting/syntax; executor format, tests and clippy; Alembic multi-head check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing GPT model identifiers with or without minor version numbers.
  - Expanded native Responses tool-search support to include GPT-6 Astra.
  - Preserved deferred tool-loading settings when native tool search is available.

- **Bug Fixes**
  - Removed unsupported deferred tool-loading settings when native tool search is unavailable, improving Responses compatibility across models.
  - Improved Goal workflow monitoring for more reliable continuation and handoff behavior.

- **Tests**
  - Updated validation coverage for GPT-5.6 Sol and GPT-6 Astra tool-search behavior.
  - Updated cloud model mappings and Responses protocol validation for GPT-6 Astra.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->