### PR TITLE
fix(wework): reuse release signing keychain

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -281,6 +281,8 @@ jobs:
             exit 1
           }
           echo "APPLE_SIGNING_IDENTITY=$identity" >> "$GITHUB_ENV"
+          # Reuse one keychain so parallel electron-builder processes do not race during cleanup.
+          echo "CSC_KEYCHAIN=$keychain_path" >> "$GITHUB_ENV"
           echo "MACOS_KEYCHAIN_PATH=$keychain_path" >> "$GITHUB_ENV"
 
       - name: Prepare Apple notarization key
@@ -311,8 +313,6 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CARGO_BUILD_TARGET: ${{ matrix.cargo_target }}
-          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          CSC_LINK: ${{ matrix.platform == 'macos' && secrets.MACOS_CERTIFICATE_BASE64 || '' }}
           VITE_WEGENT_BACKEND_URL: https://api.wecode.ai
           VITE_WEWORK_RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.channel }}
           VITE_WEWORK_RUNTIME_MODE: local-first

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -236,6 +236,9 @@ describe('bundled plugin resources', () => {
       resolve(process.cwd(), '../.github/workflows/wework-app.yml'),
       'utf8'
     )
+    const signingKeychainStep = workflow.match(
+      / {6}- name: Prepare Apple signing keychain\n(?:(?!\n {6}- name:)[\s\S])*/
+    )?.[0]
     const packageManifest = JSON.parse(
       readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')
     ) as {
@@ -263,10 +266,15 @@ describe('bundled plugin resources', () => {
     expect(builderConfig).toContain('productName: identity.productName')
     expect(builderConfig).toContain('executableName: identity.executableName')
     expect(builderConfig).toContain('weworkAppId: identity.identifier')
-    expect(workflow).toMatch(
-      /- name: Prepare Apple signing keychain[\s\S]*?security import[\s\S]*?APPLE_SIGNING_IDENTITY=[\s\S]*?CSC_KEYCHAIN=[\s\S]*?MACOS_KEYCHAIN_PATH=/
+    expect(signingKeychainStep).toContain('security import')
+    expect(signingKeychainStep).toContain('security list-keychains -d user -s')
+    expect(signingKeychainStep).toContain(
+      'echo "APPLE_SIGNING_IDENTITY=$identity" >> "$GITHUB_ENV"'
     )
-    expect(workflow).toContain('security list-keychains -d user -s')
+    expect(signingKeychainStep).toContain('echo "CSC_KEYCHAIN=$keychain_path" >> "$GITHUB_ENV"')
+    expect(signingKeychainStep).toContain(
+      'echo "MACOS_KEYCHAIN_PATH=$keychain_path" >> "$GITHUB_ENV"'
+    )
     expect(workflow).not.toMatch(/^\s+CSC_LINK:/m)
     expect(workflow).not.toMatch(/^\s+CSC_KEY_PASSWORD:/m)
     expect(workflow).toContain('generate-desktop-update-manifests.mjs')

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -264,9 +264,11 @@ describe('bundled plugin resources', () => {
     expect(builderConfig).toContain('executableName: identity.executableName')
     expect(builderConfig).toContain('weworkAppId: identity.identifier')
     expect(workflow).toMatch(
-      /- name: Prepare Apple signing keychain[\s\S]*?security import[\s\S]*?APPLE_SIGNING_IDENTITY=[\s\S]*?MACOS_KEYCHAIN_PATH=/
+      /- name: Prepare Apple signing keychain[\s\S]*?security import[\s\S]*?APPLE_SIGNING_IDENTITY=[\s\S]*?CSC_KEYCHAIN=[\s\S]*?MACOS_KEYCHAIN_PATH=/
     )
     expect(workflow).toContain('security list-keychains -d user -s')
+    expect(workflow).not.toMatch(/^\s+CSC_LINK:/m)
+    expect(workflow).not.toMatch(/^\s+CSC_KEY_PASSWORD:/m)
     expect(workflow).toContain('generate-desktop-update-manifests.mjs')
     expect(workflow).toContain('plan-desktop-release.mjs')
     expect(workflow).not.toContain('prepare-rolling-desktop-installers.mjs')


### PR DESCRIPTION
## Summary

- reuse the workflow-prepared macOS signing keychain through `CSC_KEYCHAIN`
- remove the duplicate `CSC_LINK`/`CSC_KEY_PASSWORD` electron-builder signing path
- preserve parallel installer and online-update builds without temporary-keychain cleanup races
- add a workflow regression assertion for the single-keychain contract

## Root cause

The installer and online-update electron-builder processes run concurrently. With `CSC_LINK` set, app-builder-lib 26.15.3 creates a deterministic temporary keychain from the shared project directory, so both processes use and clean up the same file. The second cleanup logs `SecKeychainDelete: The specified keychain could not be found`.

## Verification

- `pnpm --filter wework test src/test/bundled-plugin-resources.test.ts`
- `pnpm --filter wework exec prettier --check ../.github/workflows/wework-app.yml src/test/bundled-plugin-resources.test.ts`
- `pnpm --filter wework exec eslint src/test/bundled-plugin-resources.test.ts`
- pre-push Wework ESLint, TypeScript, and unit tests

Task: WEWORKC2FA61-519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS release signing to reuse a shared keychain during parallel build processes.
  * Removed direct certificate and password environment variables from the signed release build step.
  * Improved signing workflow configuration for more consistent release builds.

* **Tests**
  * Added validation that signing setup is checked in the correct workflow step.
  * Confirmed removed certificate and password environment variables are not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->