### PR TITLE
fix(wework): reuse immutable harness runtimes

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -486,6 +486,19 @@ jobs:
           gh release view wework-updater \
             --json assets \
             --jq '.assets[].name' > "$existing_component_assets"
+          harness_runtime_assets="$RUNNER_TEMP/harness-runtime-assets"
+          node wework/scripts/collect-harness-runtime-release-assets.mjs \
+            release-assets \
+            "$harness_runtime_assets"
+          while IFS= read -r runtime_asset; do
+            runtime_name="$(basename "$runtime_asset")"
+            if grep -Fqx "$runtime_name" "$existing_component_assets"; then
+              echo "Reusing immutable Harness Runtime asset $runtime_name."
+              continue
+            fi
+            gh release upload wework-updater "$runtime_asset"
+            echo "$runtime_name" >> "$existing_component_assets"
+          done < <(find "$harness_runtime_assets" -maxdepth 1 -type f | sort)
           while IFS= read -r component_asset; do
             component_name="$(basename "$component_asset")"
             if grep -Fqx "$component_name" "$existing_component_assets"; then

--- a/wework/scripts/collect-harness-runtime-release-assets.mjs
+++ b/wework/scripts/collect-harness-runtime-release-assets.mjs
@@ -1,0 +1,85 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { extract } from 'tar'
+
+const CORE_COMPONENT_PATTERN = /^WeworkComponent_coreDsh_.+\.tar\.gz$/
+
+export async function collectHarnessRuntimeReleaseAssets(inputDirectory, outputDirectory) {
+  const input = resolve(inputDirectory)
+  const output = resolve(outputDirectory)
+  await mkdir(output, { recursive: true })
+  const componentArchives = (await readdir(input))
+    .filter(name => CORE_COMPONENT_PATTERN.test(name))
+    .sort()
+  if (componentArchives.length === 0) {
+    throw new Error(`Core DSH component assets are unavailable: ${input}`)
+  }
+  for (const archive of componentArchives) {
+    await collectComponentArchive(join(input, archive), output)
+  }
+}
+
+async function collectComponentArchive(archive, output) {
+  const temporary = await mkdtemp(join(tmpdir(), 'wework-harness-runtime-release-'))
+  try {
+    await extract({ cwd: temporary, file: archive, strict: true })
+    const catalog = JSON.parse(await readFile(join(temporary, 'runtimes.json'), 'utf8'))
+    if (!Array.isArray(catalog.runtimes) || catalog.runtimes.length === 0) {
+      throw new Error(`Harness Runtime catalog is invalid: ${archive}`)
+    }
+    for (const descriptor of catalog.runtimes) {
+      await collectRuntime(temporary, output, descriptor)
+    }
+  } finally {
+    await rm(temporary, { recursive: true, force: true })
+  }
+}
+
+async function collectRuntime(sourceRoot, output, descriptor) {
+  const assetName = descriptor?.assetName
+  if (typeof assetName !== 'string' || basename(assetName) !== assetName) {
+    throw new Error('Harness Runtime asset name is invalid')
+  }
+  const source = join(sourceRoot, assetName)
+  const metadata = await stat(source)
+  const archiveSha256 = await fileSha256(source)
+  if (descriptor.archiveSha256 !== archiveSha256 || descriptor.archiveBytes !== metadata.size) {
+    throw new Error(`Harness Runtime asset does not match its descriptor: ${assetName}`)
+  }
+  await writeImmutableFile(join(output, assetName), await readFile(source))
+  await writeImmutableFile(
+    join(output, assetName.replace(/\.tar\.gz$/, '.json')),
+    Buffer.from(`${JSON.stringify(descriptor, null, 2)}\n`)
+  )
+}
+
+async function writeImmutableFile(target, content) {
+  try {
+    const existing = await readFile(target)
+    if (!existing.equals(content)) {
+      throw new Error(`Conflicting immutable Harness Runtime asset: ${target}`)
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+    await writeFile(target, content, { flag: 'wx' })
+  }
+}
+
+async function fileSha256(path) {
+  return createHash('sha256')
+    .update(await readFile(path))
+    .digest('hex')
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [input, output] = process.argv.slice(2)
+  if (!input || !output) {
+    throw new Error(
+      'Usage: collect-harness-runtime-release-assets.mjs <release-assets> <output-directory>'
+    )
+  }
+  await collectHarnessRuntimeReleaseAssets(input, output)
+}

--- a/wework/scripts/collect-harness-runtime-release-assets.test.mjs
+++ b/wework/scripts/collect-harness-runtime-release-assets.test.mjs
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test } from 'vitest'
+import { create } from 'tar'
+
+import { collectHarnessRuntimeReleaseAssets } from './collect-harness-runtime-release-assets.mjs'
+
+const roots = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+})
+
+test('collects immutable Harness Runtime archives and descriptors from component assets', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'wework-harness-runtime-assets-'))
+  roots.push(root)
+  const input = join(root, 'release-assets')
+  const output = join(root, 'shared-assets')
+  const component = join(root, 'component')
+  await Promise.all([mkdir(input), mkdir(component)])
+  const assetName = 'harness-runtime-macos-arm64-dsh-0.1.1-rc.2-fingerprint.tar.gz'
+  const asset = Buffer.from('immutable runtime')
+  await writeFile(join(component, assetName), asset)
+  const descriptor = {
+    dshVersion: '0.1.1-rc.2',
+    role: 'core',
+    sourceFingerprint: 'a'.repeat(64),
+    archiveSha256: createHash('sha256').update(asset).digest('hex'),
+    archiveBytes: asset.length,
+    downloadUrl: `https://updates.example/${assetName}`,
+    assetName,
+  }
+  await writeFile(
+    join(component, 'runtimes.json'),
+    `${JSON.stringify({ runtimes: [descriptor] })}\n`
+  )
+  await create(
+    {
+      cwd: component,
+      file: join(input, 'WeworkComponent_coreDsh_component_macos_arm64.tar.gz'),
+      gzip: true,
+    },
+    ['.']
+  )
+
+  await collectHarnessRuntimeReleaseAssets(input, output)
+
+  await expect(readFile(join(output, assetName))).resolves.toEqual(asset)
+  await expect(
+    readFile(join(output, assetName.replace(/\.tar\.gz$/, '.json')), 'utf8')
+  ).resolves.toBe(`${JSON.stringify(descriptor, null, 2)}\n`)
+})
+
+test('rejects conflicting assets with the same immutable name', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'wework-harness-runtime-conflict-'))
+  roots.push(root)
+  const input = join(root, 'release-assets')
+  const output = join(root, 'shared-assets')
+  await mkdir(input)
+  for (const [index, content] of ['first', 'second'].entries()) {
+    const component = join(root, `component-${index}`)
+    await mkdir(component)
+    const assetName = 'harness-runtime-linux-x64-dsh-0.1.1-rc.2-fingerprint.tar.gz'
+    const asset = Buffer.from(content)
+    await writeFile(join(component, assetName), asset)
+    await writeFile(
+      join(component, 'runtimes.json'),
+      JSON.stringify({
+        runtimes: [
+          {
+            dshVersion: '0.1.1-rc.2',
+            role: 'core',
+            sourceFingerprint: 'a'.repeat(64),
+            archiveSha256: createHash('sha256').update(asset).digest('hex'),
+            archiveBytes: asset.length,
+            downloadUrl: `https://updates.example/${assetName}`,
+            assetName,
+          },
+        ],
+      })
+    )
+    await create(
+      {
+        cwd: component,
+        file: join(input, `WeworkComponent_coreDsh_${index}_linux_x64.tar.gz`),
+        gzip: true,
+      },
+      ['.']
+    )
+  }
+
+  await expect(collectHarnessRuntimeReleaseAssets(input, output)).rejects.toThrow(
+    'Conflicting immutable Harness Runtime asset'
+  )
+})

--- a/wework/scripts/desktop-resource-migration.test.mjs
+++ b/wework/scripts/desktop-resource-migration.test.mjs
@@ -198,6 +198,11 @@ describe('desktop resource migration', () => {
     expect(source).toContain("['prepare:harness-runtime', '--materialize']")
     expect(source).toContain('resolveHarnessRuntimeCachePaths(')
     expect(source).toContain('join(harnessRuntimeAssetDirectory, runtime.assetName)')
+    expect(harnessRuntimeSource).toContain('`wework-harness-runtime-${runtime.sourceFingerprint}`')
+    expect(harnessRuntimeSource).not.toContain(
+      '`wework-harness-runtime-${runtime.dshVersion}-${process.pid}`'
+    )
+    expect(harnessRuntimeSource).toContain('mtime: new Date(0)')
     expect(source).not.toContain(
       "join(weworkRoot, 'node_modules', '.cache', 'harness-runtime-assets'"
     )

--- a/wework/scripts/lib/harness-runtime-pruning.mjs
+++ b/wework/scripts/lib/harness-runtime-pruning.mjs
@@ -10,6 +10,7 @@ const TARGET_NATIVE_ARTIFACTS = {
 }
 
 const NON_RUNTIME_SUFFIXES = ['.d.cts', '.d.mts', '.d.ts', '.map']
+const NON_RUNTIME_FILES = new Set(['.modules.yaml', '.pnpm-workspace-state-v1.json'])
 
 export async function pruneHarnessRuntime(root, target) {
   const nativeArtifacts = TARGET_NATIVE_ARTIFACTS[target]
@@ -43,7 +44,8 @@ async function visit(directory, nativeArtifacts, removed) {
         await visit(child, nativeArtifacts, removed)
       } else if (
         entry.isFile() &&
-        NON_RUNTIME_SUFFIXES.some(suffix => entry.name.endsWith(suffix))
+        (NON_RUNTIME_FILES.has(entry.name) ||
+          NON_RUNTIME_SUFFIXES.some(suffix => entry.name.endsWith(suffix)))
       ) {
         await rm(child, { force: true })
         removed.files += 1

--- a/wework/scripts/lib/harness-runtime-pruning.test.mjs
+++ b/wework/scripts/lib/harness-runtime-pruning.test.mjs
@@ -25,6 +25,8 @@ describe('pruneHarnessRuntime', () => {
     await expectMissing(join(root, 'package', 'index.js.map'))
     await expectMissing(join(root, 'package', 'index.d.ts'))
     await expectExists(join(root, 'package', 'index.js'))
+    await expectMissing(join(root, 'node_modules', '.modules.yaml'))
+    await expectMissing(join(root, 'node_modules', '.pnpm-workspace-state-v1.json'))
   })
 
   test('removes unsupported reflink native packages for Linux', async () => {
@@ -51,6 +53,7 @@ async function runtimeFixture() {
     ['@reflink', 'reflink-darwin-arm64'],
     ['@reflink', 'reflink-darwin-x64'],
     ['@reflink', 'reflink-win32-x64-msvc'],
+    ['node_modules'],
     ['package'],
   ]
   await Promise.all(directories.map(parts => mkdir(join(root, ...parts), { recursive: true })))
@@ -64,6 +67,11 @@ async function runtimeFixture() {
     writeFile(join(root, '@reflink', 'reflink-darwin-arm64', 'reflink.node'), ''),
     writeFile(join(root, '@reflink', 'reflink-darwin-x64', 'reflink.node'), ''),
     writeFile(join(root, '@reflink', 'reflink-win32-x64-msvc', 'reflink.node'), ''),
+    writeFile(join(root, 'node_modules', '.modules.yaml'), 'prunedAt: now\n'),
+    writeFile(
+      join(root, 'node_modules', '.pnpm-workspace-state-v1.json'),
+      JSON.stringify({ lastValidatedTimestamp: Date.now() })
+    ),
     writeFile(join(root, 'package', 'index.js'), ''),
     writeFile(join(root, 'package', 'index.js.map'), ''),
     writeFile(join(root, 'package', 'index.d.ts'), ''),

--- a/wework/scripts/prepare-harness-runtime.mjs
+++ b/wework/scripts/prepare-harness-runtime.mjs
@@ -40,7 +40,7 @@ const {
   prepareLockPath,
 } = resolveHarnessRuntimeCachePaths(root)
 const sharedFiles = ['.npmrc', 'pnpm-workspace.yaml']
-const archiveFormatVersion = 'dsh-runtime-tar-gzip-v7'
+const archiveFormatVersion = 'dsh-runtime-tar-gzip-v8'
 const materializeRequested = process.argv.includes('--materialize')
 const skipRemoteReuse = process.env.WEWORK_HARNESS_RUNTIME_SKIP_REMOTE_REUSE === '1'
 const baseUrl = (
@@ -293,10 +293,7 @@ async function pruneMaterializedRuntimes(descriptors) {
 }
 
 async function buildRuntime(runtime) {
-  const staging = path.join(
-    cacheDirectory,
-    `wework-harness-runtime-${runtime.dshVersion}-${process.pid}`
-  )
+  const staging = path.join(cacheDirectory, `wework-harness-runtime-${runtime.sourceFingerprint}`)
   const temporaryArchive = `${runtime.assetPath}.${process.pid}.tar.gz`
   try {
     await rm(staging, { recursive: true, force: true })
@@ -345,6 +342,7 @@ async function buildRuntime(runtime) {
         cwd: staging,
         file: temporaryArchive,
         gzip: { level: zlibConstants.Z_BEST_SPEED },
+        mtime: new Date(0),
         portable: true,
         strict: true,
       },

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -278,6 +278,8 @@ describe('bundled plugin resources', () => {
     expect(workflow).toContain('desktop-component-release.mjs release-assets version')
     expect(workflow).toContain('desktop-component-release.mjs release-assets shared')
     expect(workflow).toContain('Reusing immutable component asset')
+    expect(workflow).toContain('collect-harness-runtime-release-assets.mjs')
+    expect(workflow).toContain('Reusing immutable Harness Runtime asset')
     expect(workflow).toContain('components-${channel}-linux-x64.json')
     expect(
       readFileSync(


### PR DESCRIPTION
## Summary

- make Harness Runtime builds independent of per-process staging paths and generated PNPM timestamps
- publish embedded Harness Runtime archives and descriptors to the shared updater release
- reuse those immutable assets across Beta and stable desktop releases

## Verification

- `pnpm --filter wework test scripts/collect-harness-runtime-release-assets.test.mjs scripts/lib/harness-runtime-pruning.test.mjs scripts/desktop-resource-migration.test.mjs`
- `pnpm --filter wework test src/test/bundled-plugin-resources.test.ts`
- focused ESLint and Prettier checks
- verified the collector against the real Wework 0.4.3 macOS arm64 Core DSH component archive

Fixes WORK-441