### PR TITLE
fix(wework): show issue title in progress hover

### DIFF
--- a/wework/src/features/todo/CloudTodoBoardCard.test.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.test.tsx
@@ -558,6 +558,10 @@ describe('CloudTodoBoardCard', () => {
     const popup = await screen.findByTestId('cloud-todo-card-progress-popup-WEG-85')
     expect(popup).toHaveClass('w-[480px]', 'overflow-x-hidden')
     expect(popup).toHaveAttribute('role', 'dialog')
+    expect(screen.getByTestId('cloud-todo-card-progress-title-WEG-85')).toHaveTextContent(
+      'Keep the pull request popup visible'
+    )
+    expect(popup).not.toHaveTextContent('当前任务进展')
     expect(popup).toHaveTextContent('Fix the board popup')
     expect(popup).toHaveTextContent('Verify the hover behavior')
 

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -806,8 +806,12 @@ function RuntimeTaskProgressPopup({
       className="min-w-0 space-y-2"
     >
       <div className="min-w-0 border-b border-border/60 pb-2">
-        <div className="text-sm font-medium leading-5 text-text-primary">
-          {t('todo.task_progress_details', '当前任务进展')}
+        <div
+          data-testid={`cloud-todo-card-progress-title-${item.id}`}
+          className="truncate text-sm font-medium leading-5 text-text-primary"
+          title={item.title}
+        >
+          {item.title}
         </div>
         {!focusedBindingId && bindings.length > 1 ? (
           <div className="mt-0.5 text-xs leading-5 text-text-secondary">

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -1170,7 +1170,10 @@ describe('CloudTodoWorkspace', () => {
 
     fireEvent.mouseEnter(screen.getByTestId('cloud-todo-card-WEG-1'))
     const progressPopup = await screen.findByTestId('cloud-todo-card-progress-popup-WEG-1')
-    expect(progressPopup).toHaveTextContent('当前任务进展')
+    expect(screen.getByTestId('cloud-todo-card-progress-title-WEG-1')).toHaveTextContent(
+      'Implement cloud MCP'
+    )
+    expect(progressPopup).not.toHaveTextContent('当前任务进展')
     expect(progressPopup).toHaveTextContent('验证完整工作流')
     expect(screen.getByTestId('cloud-todo-card-popup-conversation-WEG-1')).toHaveAttribute(
       'data-task-id',
@@ -1260,7 +1263,10 @@ describe('CloudTodoWorkspace', () => {
     fireEvent.mouseEnter(screen.getByTestId('cloud-todo-card-WEG-1'))
     const progressPopup = await screen.findByTestId('cloud-todo-card-progress-popup-WEG-1')
     const progressResponse = screen.getByTestId('cloud-todo-card-popup-conversation-WEG-1')
-    expect(progressPopup).toHaveTextContent('当前任务进展')
+    expect(screen.getByTestId('cloud-todo-card-progress-title-WEG-1')).toHaveTextContent(
+      'Implement cloud MCP'
+    )
+    expect(progressPopup).not.toHaveTextContent('当前任务进展')
     expect(progressResponse).toHaveAttribute('data-task-id', 'runtime-review')
   })
 

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -4030,7 +4030,6 @@
     "my_work_month": "Month",
     "my_work_no_due_date": "No due date",
     "no_final_task_response": "No final response",
-    "task_progress_details": "Current task progress",
     "task_progress_empty": "No task progress details",
     "my_work_pending_approval": "Pending my approval",
     "my_work_approve": "Approve",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -4027,7 +4027,6 @@
     "my_work_month": "月",
     "my_work_no_due_date": "无截止日期",
     "no_final_task_response": "暂无最终回复",
-    "task_progress_details": "当前任务进展",
     "task_progress_empty": "暂无任务进展详情",
     "my_work_pending_approval": "待我批准",
     "my_work_approve": "批准",


### PR DESCRIPTION
## Summary
- show the Issue title in the workspace task-progress hover popup
- remove the obsolete fixed “Current task progress” translation
- update component and workspace regressions to cover the Issue title

## Root cause
The hover popup already received the complete `CloudLoopItem`, but rendered a static i18n label instead of the authoritative `item.title`.

## Verification
- `pnpm --filter wework test src/features/todo/CloudTodoBoardCard.test.tsx src/features/todo/CloudTodoWorkspace.test.tsx` (109 tests passed)
- focused Prettier and ESLint checks passed
- translation JSON parsing and `git diff --check` passed
- isolated Electron verification: created and executed an Issue, hovered its workspace card, and confirmed the popup title exactly matched the Issue title while the old fixed label was absent

Closes WORK-444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Progress popups now display the relevant todo title instead of a generic heading.
  - Long titles are truncated with tooltip support for viewing the full text.
- **Tests**
  - Updated coverage to verify todo titles appear correctly and the previous generic heading is no longer shown.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->