### PR TITLE
fix(wework): enable user input cards in default mode

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -68,6 +68,8 @@ const CODEX_SUPPRESS_UNSTABLE_FEATURES_WARNING_OVERRIDE: &str =
 const CODEX_DISABLE_TOOL_CALL_MCP_ELICITATION_OVERRIDE: &str =
     "features.tool_call_mcp_elicitation=false";
 const CODEX_ENABLE_UPDATE_PLAN_OVERRIDE: &str = "tools.update_plan.enabled=true";
+const CODEX_ENABLE_DEFAULT_MODE_REQUEST_USER_INPUT_OVERRIDE: &str =
+    "features.default_mode_request_user_input=true";
 const DEFAULT_EXECUTOR_SERVER_PORT: u16 = 10001;
 const DEFAULT_VISION_SIDECAR_TIMEOUT_MS: u64 = 45_000;
 const DEFAULT_VISION_SIDECAR_MAX_DESCRIPTIONS: usize = 8;
@@ -3359,6 +3361,7 @@ fn codex_runtime_default_config_overrides() -> Vec<String> {
     let mut overrides = codex_streaming_patch_config_overrides();
     overrides.push(CODEX_DISABLE_TOOL_CALL_MCP_ELICITATION_OVERRIDE.to_owned());
     overrides.push(CODEX_ENABLE_UPDATE_PLAN_OVERRIDE.to_owned());
+    overrides.push(CODEX_ENABLE_DEFAULT_MODE_REQUEST_USER_INPUT_OVERRIDE.to_owned());
     overrides
 }
 

--- a/executor/src/agents/codex/tests.rs
+++ b/executor/src/agents/codex/tests.rs
@@ -363,6 +363,9 @@ fn persistent_app_server_uses_codex_deferred_mcp_tools() {
     assert!(config
         .config_overrides
         .contains(&CODEX_ENABLE_UPDATE_PLAN_OVERRIDE.to_owned()));
+    assert!(config
+        .config_overrides
+        .contains(&CODEX_ENABLE_DEFAULT_MODE_REQUEST_USER_INPUT_OVERRIDE.to_owned()));
 }
 
 #[test]
@@ -917,6 +920,9 @@ fn codex_launch_config_enables_streaming_patch_updates() {
     assert!(launch_config
         .config_overrides
         .contains(&CODEX_ENABLE_UPDATE_PLAN_OVERRIDE.to_owned()));
+    assert!(launch_config
+        .config_overrides
+        .contains(&CODEX_ENABLE_DEFAULT_MODE_REQUEST_USER_INPUT_OVERRIDE.to_owned()));
 }
 
 #[test]
@@ -3121,6 +3127,26 @@ fn codex_permissions_approval_returns_requested_profile_and_scope() {
                 "scope": "turn",
                 "strictAutoReview": false
             })
+        );
+    }
+}
+
+#[test]
+fn codex_thread_launch_enables_user_input_in_default_mode() {
+    let request = ExecutionRequest::default();
+    let launch_config = CodexLaunchConfig {
+        config_overrides: codex_runtime_default_config_overrides(),
+        ..CodexLaunchConfig::default()
+    };
+
+    for params in [
+        thread_start_params(&request, &launch_config),
+        thread_resume_params("thread-1", &request, &launch_config),
+        thread_fork_params("thread-1", None, &request, &launch_config),
+    ] {
+        assert_eq!(
+            params["config"]["features.default_mode_request_user_input"],
+            true
         );
     }
 }

--- a/wework/e2e/desktop/modules/desktop-server.mjs
+++ b/wework/e2e/desktop/modules/desktop-server.mjs
@@ -3290,7 +3290,13 @@ class DesktopE2EServer {
 
     if (this.scenario === 'request_user_input') {
       this.recordScenarioRequest('request_user_input', modelRequest)
-      if (JSON.stringify(body.input).includes('wework-e2e-request-user-input')) {
+      const answer = toolOutputText(body, 'wework-e2e-request-user-input')
+      if (answer !== null) {
+        assert.deepEqual(
+          JSON.parse(answer),
+          { answers: { direction: { answers: ['Complete'] } } },
+          'Codex must receive the selected answer, not a mode restriction error'
+        )
         this.writeSse(response, [
           responseCreated(responseId),
           assistantMessage(REQUEST_USER_INPUT_COMPLETION_TEXT),

--- a/wework/e2e/desktop/modules/task-state-flows.mjs
+++ b/wework/e2e/desktop/modules/task-state-flows.mjs
@@ -5,7 +5,7 @@ import {
   waitForSnapshot,
 } from './conversation-layout.mjs'
 
-import { assertConversationTextOrder, ensurePlanMode } from './conversation-navigation.mjs'
+import { assertConversationTextOrder } from './conversation-navigation.mjs'
 
 import { ensureTaskRowVisible } from './memory-tool-flows.mjs'
 
@@ -49,7 +49,15 @@ async function verifyPriorityFilter({ composerSelector, control }) {
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
   await selectE2EModel(control, DEFAULT_MODEL_ID, DEFAULT_MODEL_LABEL)
-  await ensurePlanMode(control)
+  const composerSnapshot = JSON.parse(await control.command('snapshot', 'body'))
+  if (composerSnapshot.testIds.includes('plan-mode-pill')) {
+    await control.command('click', '[data-testid="cancel-plan-mode-button"]')
+  }
+  await waitForSnapshot(
+    control,
+    snapshot => !snapshot.testIds.includes('plan-mode-pill'),
+    'The request-user-input regression must run in Default mode'
+  )
   await sendPromptUntilScenarioRequest(
     control,
     composerSelector,
@@ -197,7 +205,6 @@ async function verifyPriorityFilter({ composerSelector, control }) {
       }
     }
   }
-  await control.command('click', '[data-testid="cancel-plan-mode-button"]')
 }
 
 async function findRuntimeTaskSortableListSelector(control, taskRowTestIds) {


### PR DESCRIPTION
Wework could not show a question card in Default mode because Codex rejected `request_user_input` before the request reached the UI. Enable `features.default_mode_request_user_input` in the shared runtime configuration so both the persistent app-server and newly created, resumed, or forked sessions support questions without switching to Plan mode.

Run the existing `priority-filter` desktop regression in Default mode and require the model service to receive the exact selected answer. A tool error can no longer be mistaken for successful completion. Existing Plan-mode coverage remains in place.

Validation:
- Codex adapter unit tests: 137 passed; question-card component tests: 10 passed.
- Desktop `priority-filter` checkpoint passed with real Codex 0.153.3; covered background navigation, the question card, answer submission, and task completion.
- Isolated Electron verification passed for question cards and answer submission in both Default and Plan modes.
- Formatting and ESLint passed.
- Post-rebase pre-push gate passed, including `cargo test --all-features --lib` and `cargo clippy --all-targets --all-features -- -D warnings`.

Known limitation: answered-card summaries are not displayed after reloading the conversation; this change addresses the Default-mode tool restriction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Codex can now request user input while operating in its default mode, enabling interactive workflows without requiring Plan mode.

- **Bug Fixes**
  - Improved handling of follow-up responses after users submit requested input.
  - Improved reliability of task flows involving plan-mode transitions and priority filtering.

- **Tests**
  - Expanded coverage for default-mode user input and interactive Codex sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->