### PR TITLE
fix(notifications): 通过 Wegent 页面回跳 Wework

### DIFF
--- a/backend/app/services/im/notification_dispatcher.py
+++ b/backend/app/services/im/notification_dispatcher.py
@@ -17,6 +17,7 @@ from app.services.im.session_service import im_session_service
 from app.services.subscription.notification_service import (
     subscription_notification_service,
 )
+from app.services.wework_links import browser_link, runtime_task_url
 from shared.utils.crypto import decrypt_sensitive_data
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,8 @@ class IMNotificationDispatcher:
             status=status,
             content=content,
         )
+        destination = runtime_task_url(address["deviceId"], address["localTaskId"])
+        message += f"\n\n{browser_link(destination)}"
         return await self._send_to_sessions(
             db,
             sessions,

--- a/backend/app/services/wework_links.py
+++ b/backend/app/services/wework_links.py
@@ -1,0 +1,21 @@
+"""Public browser entry links for the desktop's supported navigation routes."""
+
+from urllib.parse import quote, urlencode
+
+from app.core.config import settings
+from app.schemas.wework_navigation import validate_wework_url
+
+
+def browser_link(destination: str) -> str:
+    """Keep IM messages clickable without relying on custom-scheme detection."""
+    destination = validate_wework_url(destination)
+    base = settings.FRONTEND_URL.rstrip("/")
+    query = urlencode({"destination": destination})
+    return f"{base}/launch/wework?{query}"
+
+
+def runtime_task_url(device_id: str, task_id: str) -> str:
+    """Encode device and task identifiers independently for the desktop router."""
+    return validate_wework_url(
+        f"wework://tasks/{quote(device_id, safe='')}/{quote(task_id, safe='')}"
+    )

--- a/backend/app/services/wework_notifications.py
+++ b/backend/app/services/wework_notifications.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.models.wework_notification import WeworkNotification
 from app.schemas.wework_notification import NotificationCreate
+from app.services.wework_links import browser_link
 from shared.telemetry.decorators import trace_async, trace_sync
 
 logger = logging.getLogger(__name__)
@@ -120,7 +121,7 @@ async def deliver_notification(notification_id: str) -> None:
                     continue
                 text = notification.body
                 if notification.url:
-                    text += f"\n\n{notification.url}"
+                    text += f"\n\n{browser_link(notification.url)}"
                 result = await im_notification_dispatcher.send_text(db, session, text)
                 if not result.get("success"):
                     logger.warning(

--- a/backend/tests/services/im/test_notification_dispatcher.py
+++ b/backend/tests/services/im/test_notification_dispatcher.py
@@ -16,6 +16,7 @@ from app.services.im.session_service import im_session_service
 from app.services.subscription.notification_service import (
     subscription_notification_service,
 )
+from app.services.wework_links import browser_link
 from shared.utils.crypto import encrypt_sensitive_data
 
 
@@ -321,7 +322,8 @@ async def test_runtime_task_update_uses_global_im_notification_target(
     assert result["sent"] == 1
     assert calls[1]["chat_id"] == 100200300
     assert calls[1]["text"] == (
-        "任务「Native Codex task」有新的 AI 回复：\n\n" "Implemented from native Codex"
+        "任务「Native Codex task」有新的 AI 回复：\n\nImplemented from native Codex"
+        f"\n\n{browser_link('wework://tasks/device-1/codex-thread-1')}"
     )
 
 
@@ -534,6 +536,7 @@ async def test_runtime_task_update_uses_subscribed_native_codex_task(
     assert calls[1]["chat_id"] == 100200301
     assert "Native Codex task" in calls[1]["text"]
     assert "Subscribed update" in calls[1]["text"]
+    assert browser_link("wework://tasks/device-1/codex-thread-1") in calls[1]["text"]
     assert await im_session_service.get_runtime_task_reply_target(
         session=session,
         message_id=3201,

--- a/backend/tests/services/test_wework_links.py
+++ b/backend/tests/services/test_wework_links.py
@@ -1,0 +1,38 @@
+"""IM browser links preserve desktop destinations across URL decoding."""
+
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from app.core.config import settings
+from app.services.wework_links import browser_link, runtime_task_url
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "wework://boards",
+        "wework://boards/12",
+        "wework://boards/12/issues/gitlab%3A12%2Fissue%233",
+        "wework://tasks/device-1/task%2F1",
+    ],
+)
+def test_browser_link_uses_wegent_site(monkeypatch, destination):
+    monkeypatch.setattr(settings, "FRONTEND_URL", "https://wegent.example/")
+    link = urlsplit(browser_link(destination))
+    assert link.scheme == "https"
+    assert link.netloc == "wegent.example"
+    assert link.path == "/launch/wework"
+    assert parse_qs(link.query) == {"destination": [destination]}
+
+
+@pytest.mark.parametrize("destination", ["https://evil.test", "wework://shell/run"])
+def test_browser_link_rejects_unsupported_destination(destination):
+    with pytest.raises(ValueError):
+        browser_link(destination)
+
+
+def test_runtime_task_url_encodes_each_identifier():
+    assert runtime_task_url("device/1", "task#1") == (
+        "wework://tasks/device%2F1/task%231"
+    )

--- a/backend/tests/services/test_wework_notifications.py
+++ b/backend/tests/services/test_wework_notifications.py
@@ -10,6 +10,7 @@ from app.schemas.base_role import BaseRole
 from app.schemas.project_chat import LoopItemAssign
 from app.schemas.wework_notification import NotificationCreate
 from app.services.loop_items.service import loop_item_service
+from app.services.wework_links import browser_link
 from app.services.wework_notifications import (
     create_notification,
     deliver_notification,
@@ -267,7 +268,9 @@ async def test_im_receives_message_even_when_live_push_fails(
         ) as send,
     ):
         await deliver_notification(row.id)
-    expected = f"Review failed\n\n{row.url}" if row.url else "Review failed"
+    expected = (
+        f"Review failed\n\n{browser_link(row.url)}" if row.url else "Review failed"
+    )
     assert send.call_args.args[2] == expected
 
 

--- a/docs/en/wegent/user-guide/wework-notifications.md
+++ b/docs/en/wegent/user-guide/wework-notifications.md
@@ -14,6 +14,12 @@ Notifications belong to Wework users and do not require a project or board. With
 
 An optional `url` specifies the click destination independently of project source. For “send me a hello notification that opens the board homepage when clicked”, use `{ "title": "Hello", "body": "Hello", "url": "wework://boards" }`. Receiving it keeps the current page; clicking opens the board homepage. An explicit URL takes precedence over the source link.
 
+## Open Wework from DingTalk and other IM clients
+
+IM links open `/launch/wework?destination=...` on the Wegent website. Runtime task updates also include their task link. Click “Open Wework” on the page and allow the browser to launch the installed desktop app. The page requires no web login; resource authorization remains in the client. If DingTalk blocks the app launch, open the page in your system browser.
+
+Configure Backend `FRONTEND_URL` to the recipient-accessible Wegent website (HTTPS in production). Route `/launch/wework` to the Wegent frontend, not the separate Wework website. Stored destinations remain `wework://...`; the page and desktop share the same parser and accept only the destinations below.
+
 ## Scheme addresses
 
 | Address                                       | Destination                         |
@@ -39,7 +45,8 @@ flowchart LR
   Inbox --> Live[Live invalidation]
   Inbox --> IM[Private IM delivery]
   Live --> Bell[Notification center]
-  IM --> Scheme[Wework scheme parser]
+  IM --> Web[Wegent launch page]
+  Web -->|User clicks Open Wework| Scheme[Wework scheme parser]
   Bell --> Scheme
   Scheme --> Issue[Board tab and Issue]
 ```

--- a/docs/en/wegent/user-guide/wework-notifications.md
+++ b/docs/en/wegent/user-guide/wework-notifications.md
@@ -16,7 +16,9 @@ An optional `url` specifies the click destination independently of project sourc
 
 ## Open Wework from DingTalk and other IM clients
 
-IM links open `/launch/wework?destination=...` on the Wegent website. Runtime task updates also include their task link. Click “Open Wework” on the page and allow the browser to launch the installed desktop app. The page requires no web login; resource authorization remains in the client. If DingTalk blocks the app launch, open the page in your system browser.
+IM links open `/launch/wework?destination=...` on the Wegent website. Runtime task updates also include their task link. The page validates the destination and automatically requests the installed desktop app; confirm the browser prompt without clicking a page button first. Each destination is requested once. After cancellation, the page button can request it again. The page requires no web login; resource authorization remains in the client. If DingTalk blocks the app launch, open the page in your system browser.
+
+Set frontend runtime environment variable `RUNTIME_WEWORK_APP_NAME` to configure the page’s app name (default: `Wework`; for example, `Weibo WeWork` internally), then restart the frontend. This changes page copy only; the browser prompt names the locally registered handler for `wework://`.
 
 Configure Backend `FRONTEND_URL` to the recipient-accessible Wegent website (HTTPS in production). Route `/launch/wework` to the Wegent frontend, not the separate Wework website. Stored destinations remain `wework://...`; the page and desktop share the same parser and accept only the destinations below.
 
@@ -46,7 +48,7 @@ flowchart LR
   Inbox --> IM[Private IM delivery]
   Live --> Bell[Notification center]
   IM --> Web[Wegent launch page]
-  Web -->|User clicks Open Wework| Scheme[Wework scheme parser]
+  Web -->|Automatic request and browser confirmation| Scheme[Wework scheme parser]
   Bell --> Scheme
   Scheme --> Issue[Board tab and Issue]
 ```

--- a/docs/zh/wegent/user-guide/wework-notifications.md
+++ b/docs/zh/wegent/user-guide/wework-notifications.md
@@ -14,6 +14,12 @@ sidebar_position: 35
 
 通知点击目标通过可选 `url` 指定，与项目来源独立。例如“给我发个你好的通知，然后点击打开看板页面”使用 `{ "title": "你好", "body": "你好", "url": "wework://boards" }`。收到通知时页面不变，点击后打开看板首页；不需要指定项目。显式地址优先于来源生成的地址。
 
+## 从钉钉等 IM 打开 Wework
+
+IM 通知中的链接指向 Wegent 网站的 `/launch/wework?destination=...` 页面；运行任务更新也携带对应任务的链接。打开网页后点击“打开 Wework”，并允许浏览器启动已安装的客户端。网页无需登录，目标资源的权限仍由客户端校验。如果钉钉限制唤起应用，请在系统浏览器打开该网页。
+
+部署时将 Backend 的 `FRONTEND_URL` 配置为收件人可访问的 Wegent 网站地址（生产环境使用 HTTPS）。`/launch/wework` 必须路由到 Wegent 前端；不要将它路由到独立 Wework 网站。通知原始目标仍保存为 `wework://...`，网页和客户端复用同一解析器，只接受下表中的目标。
+
 ## Scheme 地址
 
 | 地址                                          | 目标                     |
@@ -39,12 +45,15 @@ sequenceDiagram
   participant Delivery as 异步通知服务
   participant App as Wework
   participant IM as 私人 IM
+  participant Web as Wegent 跳转页
   Caller->>Service: 分配负责人及通知选择
   Service->>DB: 同一事务更新分配并创建通知
   DB-->>Service: 提交成功
   Service->>Delivery: 提交后调度
   Delivery-->>App: 通知列表变更事件
-  Delivery-->>IM: 正文及 scheme
+  Delivery-->>IM: 正文及 Wegent 网页链接
+  IM->>Web: 用户点击链接
+  Web->>App: 用户点击打开 Wework
   App->>DB: 查询收件箱 / 标记已读
   App->>App: scheme 解析 → 项目标签页 → Issue
 ```

--- a/docs/zh/wegent/user-guide/wework-notifications.md
+++ b/docs/zh/wegent/user-guide/wework-notifications.md
@@ -16,7 +16,9 @@ sidebar_position: 35
 
 ## 从钉钉等 IM 打开 Wework
 
-IM 通知中的链接指向 Wegent 网站的 `/launch/wework?destination=...` 页面；运行任务更新也携带对应任务的链接。打开网页后点击“打开 Wework”，并允许浏览器启动已安装的客户端。网页无需登录，目标资源的权限仍由客户端校验。如果钉钉限制唤起应用，请在系统浏览器打开该网页。
+IM 通知中的链接指向 Wegent 网站的 `/launch/wework?destination=...` 页面；运行任务更新也携带对应任务的链接。网页校验目标后自动请求启动已安装的客户端，无需先点击页面按钮；在浏览器提示中确认即可。每个目标只自动请求一次，取消后可点击页面按钮再次打开。网页无需登录，目标资源的权限仍由客户端校验。如果钉钉限制唤起应用，请在系统浏览器打开该网页。
+
+跳转页应用名称由前端运行时环境变量 `RUNTIME_WEWORK_APP_NAME` 配置，默认 `Wework`；例如内网可设为 `Weibo WeWork`，重启前端后生效。此变量只影响网页文案；浏览器确认框中的名称取决于本机 `wework://` 协议关联的应用。
 
 部署时将 Backend 的 `FRONTEND_URL` 配置为收件人可访问的 Wegent 网站地址（生产环境使用 HTTPS）。`/launch/wework` 必须路由到 Wegent 前端；不要将它路由到独立 Wework 网站。通知原始目标仍保存为 `wework://...`，网页和客户端复用同一解析器，只接受下表中的目标。
 
@@ -53,7 +55,7 @@ sequenceDiagram
   Delivery-->>App: 通知列表变更事件
   Delivery-->>IM: 正文及 Wegent 网页链接
   IM->>Web: 用户点击链接
-  Web->>App: 用户点击打开 Wework
+  Web->>App: 自动请求唤起；浏览器确认后打开
   App->>DB: 查询收件箱 / 标记已读
   App->>App: scheme 解析 → 项目标签页 → Issue
 ```

--- a/frontend/e2e/tests/wework-open.spec.ts
+++ b/frontend/e2e/tests/wework-open.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test'
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test('notification link opens the public Wegent launch page and preserves its target', async ({
+  page,
+}) => {
+  const destination = 'wework://boards/12/issues/gitlab%3A12%2Fissue%233'
+  await page.goto(`/launch/wework?${new URLSearchParams({ destination })}`)
+  const launch = page.getByTestId('open-wework')
+  await expect(launch).toBeVisible()
+  await expect(launch).toHaveAttribute('href', destination)
+  await expect(page).toHaveURL(/\/launch\/wework\?/)
+  await page.setViewportSize({ width: 375, height: 812 })
+  await expect(launch).toBeInViewport()
+  const bounds = await launch.boundingBox()
+  expect(bounds?.height).toBeGreaterThanOrEqual(44)
+})
+
+test('invalid target cannot launch an app and a corrected link recovers', async ({ page }) => {
+  await page.goto('/launch/wework?destination=javascript%3Aalert(1)')
+  await expect(page.getByTestId('open-wework-invalid')).toBeVisible()
+  await expect(page.getByTestId('open-wework')).toHaveCount(0)
+  await page.goto('/launch/wework?destination=wework%3A%2F%2Fboards')
+  await expect(page.getByTestId('open-wework')).toHaveAttribute('href', 'wework://boards')
+})

--- a/frontend/e2e/tests/wework-open.spec.ts
+++ b/frontend/e2e/tests/wework-open.spec.ts
@@ -6,7 +6,16 @@ test('notification link opens the public Wegent launch page and preserves its ta
   page,
 }) => {
   const destination = 'wework://boards/12/issues/gitlab%3A12%2Fissue%233'
+  const navigationRequests: string[] = []
+  const cdp = await page.context().newCDPSession(page)
+  await cdp.send('Page.enable')
+  cdp.on('Page.frameRequestedNavigation', event => {
+    if (event.url.startsWith('wework:')) navigationRequests.push(event.url)
+  })
+  const runtimeConfig = page.waitForResponse(response => response.url().endsWith('/runtime-config'))
   await page.goto(`/launch/wework?${new URLSearchParams({ destination })}`)
+  expect((await runtimeConfig).ok()).toBe(true)
+  await expect.poll(() => navigationRequests).toEqual([destination])
   const launch = page.getByTestId('open-wework')
   await expect(launch).toBeVisible()
   await expect(launch).toHaveAttribute('href', destination)

--- a/frontend/src/__tests__/app/runtime-config-cache.test.ts
+++ b/frontend/src/__tests__/app/runtime-config-cache.test.ts
@@ -99,6 +99,19 @@ describe('runtime config caching', () => {
     }
   })
 
+  test('desktop app name is configurable at runtime', async () => {
+    const previous = process.env.RUNTIME_WEWORK_APP_NAME
+    try {
+      process.env.RUNTIME_WEWORK_APP_NAME = '  Weibo WeWork  '
+      expect(await (await GET()).json()).toMatchObject({ weworkAppName: 'Weibo WeWork' })
+      delete process.env.RUNTIME_WEWORK_APP_NAME
+      expect(await (await GET()).json()).toMatchObject({ weworkAppName: 'Wework' })
+    } finally {
+      if (previous === undefined) delete process.env.RUNTIME_WEWORK_APP_NAME
+      else process.env.RUNTIME_WEWORK_APP_NAME = previous
+    }
+  })
+
   test('getPublicApiBaseUrl uses the public backend URL from runtime config', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,

--- a/frontend/src/__tests__/config/coding-route.test.ts
+++ b/frontend/src/__tests__/config/coding-route.test.ts
@@ -33,6 +33,7 @@ const baseConfig: RuntimeConfig = {
   bindGroupSteps: '{"variables":{"botName":"机器人"},"steps":[]}',
   appVersion: 'dev',
   weworkCodeUrl: '',
+  weworkAppName: 'Wework',
 }
 
 describe('coding route helpers', () => {

--- a/frontend/src/__tests__/features/common/AuthGuard.test.tsx
+++ b/frontend/src/__tests__/features/common/AuthGuard.test.tsx
@@ -140,22 +140,25 @@ describe('AuthGuard', () => {
       })
     })
 
-    it('should allow access to Wework authorization without authentication', async () => {
-      ;(usePathname as jest.Mock).mockReturnValue(paths.auth.wework_authorize.getHref())
-      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+    it.each([paths.auth.wework_authorize.getHref(), paths.wework.open.getHref()])(
+      'should allow access to Wework public page %s without authentication',
+      async pathname => {
+        ;(usePathname as jest.Mock).mockReturnValue(pathname)
+        ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
 
-      const { getByText } = render(
-        <AuthGuard>
-          <div>Wework Authorization</div>
-        </AuthGuard>
-      )
+        const { getByText } = render(
+          <AuthGuard>
+            <div>Wework Authorization</div>
+          </AuthGuard>
+        )
 
-      await waitFor(() => {
-        expect(userApis.isAuthenticated).not.toHaveBeenCalled()
-        expect(mockRouter.replace).not.toHaveBeenCalled()
-        expect(getByText('Wework Authorization')).toBeInTheDocument()
-      })
-    })
+        await waitFor(() => {
+          expect(userApis.isAuthenticated).not.toHaveBeenCalled()
+          expect(mockRouter.replace).not.toHaveBeenCalled()
+          expect(getByText('Wework Authorization')).toBeInTheDocument()
+        })
+      }
+    )
 
     it('should allow access to shared task page without authentication', async () => {
       // Arrange

--- a/frontend/src/__tests__/features/common/WeworkOpenPage.test.tsx
+++ b/frontend/src/__tests__/features/common/WeworkOpenPage.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { render, screen } from '@testing-library/react'
 import { useSearchParams } from 'next/navigation'
 import WeworkOpenPage from '@/app/launch/wework/page'
@@ -8,16 +9,38 @@ jest.mock('@/hooks/useTranslation', () => ({
 }))
 
 describe('Wegent desktop launch page', () => {
+  const originalLocation = window.location
+  const assign = jest.fn()
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: { assign } })
+  })
+  afterAll(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+  })
+  beforeEach(() => assign.mockClear())
+
   it.each([
     'wework://boards',
     'wework://boards/12',
     'wework://boards/12/issues/gitlab%3A12%2Fissue%233',
     'wework://tasks/device/task%2F1',
-  ])('preserves the destination for explicit app launch: %s', destination => {
+  ])('automatically launches the exact destination once: %s', destination => {
     jest
       .mocked(useSearchParams)
       .mockReturnValue(new URLSearchParams({ destination }) as ReturnType<typeof useSearchParams>)
-    render(<WeworkOpenPage />)
+    const { rerender } = render(
+      <StrictMode>
+        <WeworkOpenPage />
+      </StrictMode>
+    )
+    rerender(
+      <StrictMode>
+        <WeworkOpenPage />
+      </StrictMode>
+    )
+    expect(assign).toHaveBeenCalledTimes(1)
+    expect(assign).toHaveBeenCalledWith(destination)
     expect(screen.getByTestId('open-wework')).toHaveAttribute('href', destination)
   })
 
@@ -36,6 +59,7 @@ describe('Wegent desktop launch page', () => {
       .mocked(useSearchParams)
       .mockReturnValue(new URLSearchParams({ destination }) as ReturnType<typeof useSearchParams>)
     render(<WeworkOpenPage />)
+    expect(assign).not.toHaveBeenCalled()
     expect(screen.getByRole('alert')).toBeInTheDocument()
     expect(screen.queryByTestId('open-wework')).not.toBeInTheDocument()
   })
@@ -49,6 +73,7 @@ describe('Wegent desktop launch page', () => {
         ) as ReturnType<typeof useSearchParams>
       )
     render(<WeworkOpenPage />)
+    expect(assign).not.toHaveBeenCalled()
     expect(screen.getByRole('alert')).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/features/common/WeworkOpenPage.test.tsx
+++ b/frontend/src/__tests__/features/common/WeworkOpenPage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { useSearchParams } from 'next/navigation'
+import WeworkOpenPage from '@/app/launch/wework/page'
+
+jest.mock('next/navigation', () => ({ useSearchParams: jest.fn() }))
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+describe('Wegent desktop launch page', () => {
+  it.each([
+    'wework://boards',
+    'wework://boards/12',
+    'wework://boards/12/issues/gitlab%3A12%2Fissue%233',
+    'wework://tasks/device/task%2F1',
+  ])('preserves the destination for explicit app launch: %s', destination => {
+    jest
+      .mocked(useSearchParams)
+      .mockReturnValue(new URLSearchParams({ destination }) as ReturnType<typeof useSearchParams>)
+    render(<WeworkOpenPage />)
+    expect(screen.getByTestId('open-wework')).toHaveAttribute('href', destination)
+  })
+
+  it.each([
+    '',
+    'https://evil.test',
+    'javascript:alert(1)',
+    'wework://shell/run',
+    'wework://boards/12/../13',
+    'wework://boards/12/issues/%FF',
+    'wework://boards/12/issues/%00',
+    'wework://user@boards/12',
+    'wework://boards?redirect=https://evil.test',
+  ])('does not offer an invalid launch target: %s', destination => {
+    jest
+      .mocked(useSearchParams)
+      .mockReturnValue(new URLSearchParams({ destination }) as ReturnType<typeof useSearchParams>)
+    render(<WeworkOpenPage />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.queryByTestId('open-wework')).not.toBeInTheDocument()
+  })
+
+  it('rejects ambiguous duplicate destinations', () => {
+    jest
+      .mocked(useSearchParams)
+      .mockReturnValue(
+        new URLSearchParams(
+          'destination=wework://boards&destination=wework://boards/12'
+        ) as ReturnType<typeof useSearchParams>
+      )
+    render(<WeworkOpenPage />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/launch/wework/page.tsx
+++ b/frontend/src/app/launch/wework/page.tsx
@@ -1,31 +1,40 @@
 'use client'
 
-import { Suspense } from 'react'
+import { Suspense, useEffect, useRef } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { parseWeworkScheme } from '@wegent/chat-core'
+import { getRuntimeConfigSync } from '@/lib/runtime-config'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'
 
 function WeworkOpenContent() {
   const { t } = useTranslation('common')
+  const { weworkAppName: appName } = getRuntimeConfigSync()
   const searchParams = useSearchParams()
   const destinations = searchParams.getAll('destination')
   const destination = destinations.length === 1 ? destinations[0] : ''
   const valid = destination.length <= 2048 && parseWeworkScheme(destination) !== null
+  const launchedDestination = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!valid || launchedDestination.current === destination) return
+    launchedDestination.current = destination
+    window.location.assign(destination)
+  }, [destination, valid])
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-base p-6">
       <section className="w-full max-w-md space-y-6 rounded-xl border border-border bg-surface p-8">
-        <h1 className="text-2xl font-semibold">{t('wework_open.title')}</h1>
+        <h1 className="text-2xl font-semibold">{t('wework_open.title', { appName })}</h1>
         {valid ? (
           <>
-            <p className="text-text-secondary">{t('wework_open.description')}</p>
+            <p className="text-text-secondary">{t('wework_open.description', { appName })}</p>
             <Button asChild variant="primary" className="min-h-11 w-full">
               <a href={destination} data-testid="open-wework">
-                {t('wework_open.open')}
+                {t('wework_open.open', { appName })}
               </a>
             </Button>
-            <p className="text-sm text-text-secondary">{t('wework_open.hint')}</p>
+            <p className="text-sm text-text-secondary">{t('wework_open.hint', { appName })}</p>
           </>
         ) : (
           <p role="alert" data-testid="open-wework-invalid">

--- a/frontend/src/app/launch/wework/page.tsx
+++ b/frontend/src/app/launch/wework/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { parseWeworkScheme } from '@wegent/chat-core'
+import { Button } from '@/components/ui/button'
+import { useTranslation } from '@/hooks/useTranslation'
+
+function WeworkOpenContent() {
+  const { t } = useTranslation('common')
+  const searchParams = useSearchParams()
+  const destinations = searchParams.getAll('destination')
+  const destination = destinations.length === 1 ? destinations[0] : ''
+  const valid = destination.length <= 2048 && parseWeworkScheme(destination) !== null
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-base p-6">
+      <section className="w-full max-w-md space-y-6 rounded-xl border border-border bg-surface p-8">
+        <h1 className="text-2xl font-semibold">{t('wework_open.title')}</h1>
+        {valid ? (
+          <>
+            <p className="text-text-secondary">{t('wework_open.description')}</p>
+            <Button asChild variant="primary" className="min-h-11 w-full">
+              <a href={destination} data-testid="open-wework">
+                {t('wework_open.open')}
+              </a>
+            </Button>
+            <p className="text-sm text-text-secondary">{t('wework_open.hint')}</p>
+          </>
+        ) : (
+          <p role="alert" data-testid="open-wework-invalid">
+            {t('wework_open.invalid')}
+          </p>
+        )}
+      </section>
+    </main>
+  )
+}
+
+export default function WeworkOpenPage() {
+  return (
+    <Suspense>
+      <WeworkOpenContent />
+    </Suspense>
+  )
+}

--- a/frontend/src/app/runtime-config/route.ts
+++ b/frontend/src/app/runtime-config/route.ts
@@ -167,6 +167,7 @@ export async function GET() {
       // External Wework URL for coding entry points.
       // Runtime-only by design; no NEXT_PUBLIC_* fallback.
       weworkCodeUrl: process.env.RUNTIME_WEWORK_CODE_URL || '',
+      weworkAppName: process.env.RUNTIME_WEWORK_APP_NAME?.trim() || 'Wework',
     },
     {
       headers: {

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -9,6 +9,9 @@ export const paths = {
   home: {
     getHref: () => '/',
   },
+  wework: {
+    open: { getHref: () => '/launch/wework' },
+  },
   docs: {
     getHref: () => getRuntimeConfigSync().docsUrl,
   },

--- a/frontend/src/features/common/AuthGuard.tsx
+++ b/frontend/src/features/common/AuthGuard.tsx
@@ -26,6 +26,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
     const loginPath = paths.auth.login.getHref()
     const allowedPaths = [
       loginPath,
+      paths.wework.open.getHref(),
       '/login/oidc',
       paths.home.getHref(),
       paths.auth.password_login.getHref(),

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1757,10 +1757,10 @@
     }
   },
   "wework_open": {
-    "title": "Open Wework",
-    "description": "View this notification’s destination in the Wework desktop app.",
-    "open": "Open Wework",
-    "hint": "Install Wework and allow your browser to open the app. If DingTalk blocks opening it, open this page in your system browser.",
+    "title": "Open {{appName}}",
+    "description": "Requesting to open {{appName}}. Confirm the browser prompt. If no prompt appears, use the button below to try again.",
+    "open": "Open {{appName}}",
+    "hint": "Install {{appName}} and allow your browser to open the app. If DingTalk blocks opening it, open this page in your system browser.",
     "invalid": "This link is invalid. Open it again from your notification."
   }
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1755,5 +1755,12 @@
       "save_api_key_failed": "Failed to save API key",
       "sync_failed": "Failed to sync servers"
     }
+  },
+  "wework_open": {
+    "title": "Open Wework",
+    "description": "View this notification’s destination in the Wework desktop app.",
+    "open": "Open Wework",
+    "hint": "Install Wework and allow your browser to open the app. If DingTalk blocks opening it, open this page in your system browser.",
+    "invalid": "This link is invalid. Open it again from your notification."
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1749,5 +1749,12 @@
       "save_api_key_failed": "保存 API 密钥失败",
       "sync_failed": "同步服务器失败"
     }
+  },
+  "wework_open": {
+    "title": "打开 Wework",
+    "description": "在 Wework 桌面客户端中查看通知对应的内容。",
+    "open": "打开 Wework",
+    "hint": "请先安装 Wework，并允许浏览器打开应用。若钉钉阻止打开，请在系统浏览器中打开此页面。",
+    "invalid": "此链接无效，请从通知中重新打开。"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1751,10 +1751,10 @@
     }
   },
   "wework_open": {
-    "title": "打开 Wework",
-    "description": "在 Wework 桌面客户端中查看通知对应的内容。",
-    "open": "打开 Wework",
-    "hint": "请先安装 Wework，并允许浏览器打开应用。若钉钉阻止打开，请在系统浏览器中打开此页面。",
+    "title": "打开 {{appName}}",
+    "description": "正在请求打开 {{appName}}，请在浏览器提示中确认。若未出现提示，可点击下方按钮再次打开。",
+    "open": "打开 {{appName}}",
+    "hint": "请先安装 {{appName}}，并允许浏览器打开应用。若钉钉阻止打开，请在系统浏览器中打开此页面。",
     "invalid": "此链接无效，请从通知中重新打开。"
   }
 }

--- a/frontend/src/lib/runtime-config.ts
+++ b/frontend/src/lib/runtime-config.ts
@@ -62,6 +62,8 @@ export interface RuntimeConfig {
   appVersion: string
   /** External Wework URL for coding entry points. Empty means use in-app chat code-agent mode. */
   weworkCodeUrl: string
+  /** Display name used by the desktop launch page. */
+  weworkAppName: string
 }
 
 /** Default bind group steps configuration */
@@ -141,6 +143,7 @@ export const fetchRuntimeConfig = async (): Promise<RuntimeConfig> => {
         bindGroupSteps: process.env.NEXT_PUBLIC_BIND_GROUP_STEPS || DEFAULT_BIND_GROUP_STEPS,
         appVersion: process.env.NEXT_PUBLIC_APP_VERSION || 'dev',
         weworkCodeUrl: '',
+        weworkAppName: 'Wework',
       }
       runtimeConfigCache = fallback
       return fallback
@@ -186,6 +189,7 @@ export const getRuntimeConfigSync = (): RuntimeConfig => {
     bindGroupSteps: process.env.NEXT_PUBLIC_BIND_GROUP_STEPS || DEFAULT_BIND_GROUP_STEPS,
     appVersion: process.env.NEXT_PUBLIC_APP_VERSION || 'dev',
     weworkCodeUrl: '',
+    weworkAppName: 'Wework',
   }
 }
 

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -66,3 +66,5 @@ export type {
   SocketClientStateListener,
   SocketReconnectCallback,
 } from './socket'
+
+export { parseWeworkScheme, type WeworkDestination } from './wework-navigation'

--- a/packages/chat-core/src/wework-navigation.ts
+++ b/packages/chat-core/src/wework-navigation.ts
@@ -1,0 +1,53 @@
+export type WeworkDestination =
+  | { kind: 'boards' }
+  | { kind: 'board'; projectId: string; itemId?: string }
+  | { kind: 'task'; deviceId: string; taskId: string }
+
+function segment(value: string): string | null {
+  const decoded = decodeURIComponent(value)
+  return decoded &&
+    decoded.length <= 128 &&
+    !Array.from(decoded).some(char => char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127)
+    ? decoded
+    : null
+}
+
+export function parseWeworkScheme(input: string): WeworkDestination | null {
+  try {
+    if (
+      input !== input.trim() ||
+      input.includes('?') ||
+      input.includes('#') ||
+      Array.from(input).some(char => char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127) ||
+      input.split('/').some(part => ['.', '..'].includes(decodeURIComponent(part)))
+    )
+      return null
+    const url = new URL(input)
+    if (
+      url.protocol !== 'wework:' ||
+      url.username ||
+      url.password ||
+      url.port ||
+      url.search ||
+      url.hash
+    )
+      return null
+    if (url.hostname === 'boards' && ['', '/'].includes(url.pathname)) return { kind: 'boards' }
+    const parts = url.pathname.split('/').slice(1)
+    if (url.hostname === 'boards' && (parts.length === 1 || parts.length === 3)) {
+      const projectId = segment(parts[0])
+      if (!projectId || !/^[1-9]\d*$/.test(projectId)) return null
+      if (parts.length === 1) return { kind: 'board', projectId }
+      const itemId = segment(parts[2])
+      return parts[1] === 'issues' && itemId ? { kind: 'board', projectId, itemId } : null
+    }
+    if (url.hostname === 'tasks' && parts.length === 2) {
+      const deviceId = segment(parts[0])
+      const taskId = segment(parts[1])
+      return deviceId && taskId ? { kind: 'task', deviceId, taskId } : null
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/wework/src/features/notifications/scheme.ts
+++ b/wework/src/features/notifications/scheme.ts
@@ -1,56 +1,6 @@
-export type WeworkDestination =
-  | { kind: 'boards' }
-  | { kind: 'board'; projectId: string; itemId?: string }
-  | { kind: 'task'; deviceId: string; taskId: string }
+import type { WeworkDestination } from '@wegent/chat-core'
 
-function segment(value: string): string | null {
-  const decoded = decodeURIComponent(value)
-  return decoded &&
-    decoded.length <= 128 &&
-    !Array.from(decoded).some(char => char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127)
-    ? decoded
-    : null
-}
-
-export function parseWeworkScheme(input: string): WeworkDestination | null {
-  try {
-    if (
-      input !== input.trim() ||
-      input.includes('?') ||
-      input.includes('#') ||
-      Array.from(input).some(char => char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127) ||
-      input.split('/').some(part => ['.', '..'].includes(decodeURIComponent(part)))
-    )
-      return null
-    const url = new URL(input)
-    if (
-      url.protocol !== 'wework:' ||
-      url.username ||
-      url.password ||
-      url.port ||
-      url.search ||
-      url.hash
-    )
-      return null
-    if (url.hostname === 'boards' && ['', '/'].includes(url.pathname)) return { kind: 'boards' }
-    const parts = url.pathname.split('/').slice(1)
-    if (url.hostname === 'boards' && (parts.length === 1 || parts.length === 3)) {
-      const projectId = segment(parts[0])
-      if (!projectId || !/^[1-9]\d*$/.test(projectId)) return null
-      if (parts.length === 1) return { kind: 'board', projectId }
-      const itemId = segment(parts[2])
-      return parts[1] === 'issues' && itemId ? { kind: 'board', projectId, itemId } : null
-    }
-    if (url.hostname === 'tasks' && parts.length === 2) {
-      const deviceId = segment(parts[0])
-      const taskId = segment(parts[1])
-      return deviceId && taskId ? { kind: 'task', deviceId, taskId } : null
-    }
-    return null
-  } catch {
-    return null
-  }
-}
+export { parseWeworkScheme, type WeworkDestination } from '@wegent/chat-core'
 
 export function weworkDestinationRoute(destination: WeworkDestination): string {
   if (destination.kind === 'boards') return '/todo'


### PR DESCRIPTION
钉钉收到 Wework 通知后，原来的 `wework://` 纯文本无法提供可点击的回跳入口；运行任务更新也缺少目标链接。现在 IM 通知使用 Wegent 网站的 `/launch/wework?destination=...`，网页校验目标后自动请求打开 Wework，用户仅需处理浏览器的应用确认提示，进入原看板、Issue 或任务。

页面免网页登录，中英文文案齐全，支持移动端；前端运行时 `RUNTIME_WEWORK_APP_NAME` 可配置网页应用名称，内网可使用 `Weibo WeWork`，不改变本机协议关联。路由避开已转发到独立网站的 `/wework` 前缀。网页与桌面复用原有目标解析器，拒绝非法协议、命令、路径穿越和重复目标参数。Backend `FRONTEND_URL` 应为收件人可访问的 Wegent 网站地址。

```mermaid
sequenceDiagram
  participant IM as 钉钉通知
  participant Web as Wegent /launch/wework
  participant App as Wework
  IM->>Web: 点击 HTTPS 链接
  Web->>Web: 共享解析器校验目标
  Web->>App: 自动请求打开 Wework；浏览器确认
  App->>App: 现有路由定位目标并校验权限
```

验证：
- Backend 通知、链接、IM 分发：49 项通过；最终前缀变更后的链接测试 7 项通过。
- 前端页面和免登录守卫：22 项通过；桌面路由与桥接：18 项通过。
- Playwright：2 项通过，使用真实 Wegent 页面，覆盖免登录、特殊字符编码、375px 布局、非法目标与恢复；由现有 GitHub Chromium 分片套件自动收集。
- 隔离真实 Electron：看板路由打开、非法目标保持当前页、恢复打开均通过；会话已停止。
- 前端与共享包 TypeScript、定向 ESLint、格式及翻译检查通过。

验证范围：尚未从真实钉钉消息执行点击；浏览器页面与 Electron 路由已分别验证。未改数据库表、迁移或事务边界。按用户要求在配置测试与文档中增加 `Weibo WeWork` 示例。

补充验证：自动唤起、Strict Mode 去重、非法目标及运行时名称配置相关 24 项单测通过；Playwright 2 项通过，CDP 捕获未经页面按钮点击的真实协议导航请求。

Issue: WEGENTMR0BE6C1-10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a web launch page that automatically opens valid Wework notification links in the desktop app.
  - Notifications now include clickable browser links for runtime tasks and other destinations.
  - Added configurable desktop app naming, with English and Chinese interface text.

- **Bug Fixes**
  - Invalid or unsafe destinations are rejected instead of being opened.
  - Authentication is no longer required to access the Wework launch page.

- **Documentation**
  - Documented the IM-to-Wework link-opening flow and required routing configuration.

- **Tests**
  - Added coverage for automatic launching, validation, configuration, and authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->