### PR TITLE
fix(wework): show unread completed tasks in Dock badge

### DIFF
--- a/wework/e2e/desktop/scenarios/codex-notification-isolation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/codex-notification-isolation.scenario.mjs
@@ -163,6 +163,27 @@ async function selectTask(control, sidebar, task, completion, timeoutMs) {
   )
 }
 
+async function waitForUnreadBadge(control, count, timeoutMs) {
+  const { platform } = JSON.parse(await control.command('getNativeWindowState', 'body'))
+  const deadline = Date.now() + timeoutMs
+  let latest
+  while (Date.now() < deadline) {
+    latest = JSON.parse(await control.command('getTraySnapshot', 'body'))
+    const unreadHeading = latest.menu.findIndex(item => item.id === 'heading:unread')
+    const unreadItems = []
+    if (unreadHeading >= 0) {
+      for (const item of latest.menu.slice(unreadHeading + 1)) {
+        if (item.type === 'separator') break
+        if (item.id?.startsWith('task:')) unreadItems.push(item)
+      }
+    }
+    const expectedBadge = platform === 'darwin' ? (count > 0 ? String(count) : '') : null
+    if (unreadItems.length === count && latest.dockBadge === expectedBadge) return
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  assert.fail(`Expected ${count} unread tasks and matching Dock badge: ${JSON.stringify(latest)}`)
+}
+
 export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspacePath }) {
   let active = false
   const requests = []
@@ -224,7 +245,6 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
       response.flushHeaders()
       for (const event of streamStart(id)) response.write(sse(event))
       streams.set(prompt, { id, itemId, response })
-      emitBurstAndCompletions()
       return true
     },
 
@@ -270,13 +290,41 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
         `${ACTIVE_WORKSPACE_TAB_SELECTOR} [data-testid="project-row-${createdProjectId}"] ` +
         '[data-testid="project-new-conversation-button"]'
       await control.command('waitFor', newConversationSelector, { timeoutMs: uiTimeoutMs })
+      await waitForUnreadBadge(control, 0, uiTimeoutMs)
       const quiet = await sendTask(control, newConversationSelector, PROMPTS.quiet, uiTimeoutMs)
       await waitForRequestCount(requests, 1, uiTimeoutMs)
       const noisy = await sendTask(control, newConversationSelector, PROMPTS.noisy, uiTimeoutMs)
       await waitForRequestCount(requests, 2, uiTimeoutMs)
       const burstSettleTimeoutMs = Math.max(uiTimeoutMs, BURST_RENDER_TIMEOUT_MS)
 
+      await control.command('clickWhenEnabled', newConversationSelector, { timeoutMs: uiTimeoutMs })
+      await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      emitBurstAndCompletions()
+      await waitForUnreadBadge(control, 2, burstSettleTimeoutMs)
+
+      for (const enabled of [false, true]) {
+        await control.command('click', '[data-testid="settings-button"]')
+        await control.command('click', '[data-testid="settings-menu-button"]')
+        await control.command('clickWhenEnabled', '[data-testid="general-tray-unread-toggle"]', {
+          timeoutMs: uiTimeoutMs,
+        })
+        await control.command(
+          'waitFor',
+          `[data-testid="general-tray-unread-toggle"][aria-pressed="${enabled}"]`,
+          { timeoutMs: uiTimeoutMs }
+        )
+        await control.command('click', '[data-testid="settings-back-button"]')
+        await waitForUnreadBadge(control, enabled ? 2 : 0, uiTimeoutMs)
+      }
+
+      const readyCountBeforeReload = control.readyCount
+      await control.command('reloadApp', 'body')
+      await control.awaitReadyAfter(readyCountBeforeReload)
+      await control.command('waitFor', COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await waitForUnreadBadge(control, 2, uiTimeoutMs)
+
       const sidebar = `${ACTIVE_WORKSPACE_TAB_SELECTOR} [data-testid="desktop-sidebar"]`
+      let remainingUnread = 2
       for (const [task, completion] of [
         [quiet, COMPLETIONS.quiet],
         [noisy, COMPLETIONS.noisy],
@@ -287,7 +335,12 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
           `${ACTIVE_WORKBENCH_SELECTOR} [data-testid="message-assistant"]`,
           { text: completion, timeoutMs: uiTimeoutMs }
         )
+        remainingUnread -= 1
+        await waitForUnreadBadge(control, remainingUnread, uiTimeoutMs)
       }
+
+      await selectTask(control, sidebar, quiet, COMPLETIONS.quiet, uiTimeoutMs)
+      await waitForUnreadBadge(control, 0, uiTimeoutMs)
 
       await captureScreenshot(control, 'codex-notification-isolation-complete.png', 'body')
       active = false

--- a/wework/electron/src/host/dock-badge.test.ts
+++ b/wework/electron/src/host/dock-badge.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from 'vitest'
+import { syncDockBadge } from './dock-badge.js'
+
+function createDock() {
+  let badge = ''
+  return {
+    getBadge: () => badge,
+    setBadge: vi.fn((value: string) => {
+      badge = value
+    }),
+  }
+}
+
+describe('syncDockBadge', () => {
+  test('counts unread completions and clears the badge after all tasks are read', () => {
+    const dock = createDock()
+    for (const count of [0, 1, 2, 2, 1, 0]) syncDockBadge(dock, count)
+
+    expect(dock.setBadge.mock.calls).toEqual([['1'], ['2'], ['1'], ['']])
+    expect(dock.getBadge()).toBe('')
+  })
+
+  test('shows unread counts before the existing development instance badge', () => {
+    const dock = createDock()
+    for (const count of [0, 2, 0]) syncDockBadge(dock, count, 'a1b2')
+
+    expect(dock.setBadge.mock.calls).toEqual([['a1b2'], ['2'], ['a1b2']])
+  })
+
+  test('does nothing on platforms without a Dock', () => {
+    expect(() => syncDockBadge(undefined, 2)).not.toThrow()
+  })
+})

--- a/wework/electron/src/host/dock-badge.ts
+++ b/wework/electron/src/host/dock-badge.ts
@@ -1,0 +1,11 @@
+import type { Dock } from 'electron'
+
+export function syncDockBadge(
+  dock: Pick<Dock, 'getBadge' | 'setBadge'> | undefined,
+  unreadCount: number,
+  idleBadge = ''
+): void {
+  if (!dock) return
+  const badge = unreadCount > 0 ? String(unreadCount) : idleBadge
+  if (dock.getBadge() !== badge) dock.setBadge(badge)
+}

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -193,7 +193,7 @@ export interface ElectronE2EHost {
   startupSplashSnapshot: () => StartupSplashSnapshot | null
   trayActivate: (activation: TrayActivation) => boolean
   traySetState: (state: TrayMenuState) => void
-  traySnapshot: () => TraySnapshot | null
+  traySnapshot: () => (TraySnapshot & { dockBadge: string | null }) | null
   scheduleCoreDshRestart: () => void
   openWorkspace: (input: { label: string; route: string; title: string }) => Promise<void>
   popoutWindowSnapshot: () => {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -119,6 +119,7 @@ import {
 } from './runtime/local-workspace-cli.js'
 import { SecureValueStore } from './host/secure-value-store.js'
 import { resolveDevelopmentDockIdentity } from './host/development-dock-identity.js'
+import { syncDockBadge } from './host/dock-badge.js'
 import { isEffectivePackagedApplication } from './host/application-packaging-mode.js'
 import {
   createWeworkSyncRequestSignal,
@@ -1493,9 +1494,13 @@ async function configureDesktopRuntime(): Promise<void> {
           trayActivate: activation => trayManager?.activate(activation) ?? false,
           traySetState: state => {
             trayManager?.setState(state)
+            syncDockBadge(app.dock, state.unreadCount, developmentDockIdentity?.badge)
             void trayNativeStatus?.refresh()
           },
-          traySnapshot: () => trayManager?.snapshot() ?? null,
+          traySnapshot: () => {
+            const snapshot = trayManager?.snapshot()
+            return snapshot ? { ...snapshot, dockBadge: app.dock?.getBadge() ?? null } : null
+          },
           openWorkspace: openWorkspaceWindow,
           popoutWindowSnapshot: () => ({
             exists: Boolean(popoutWindow && !popoutWindow.isDestroyed()),
@@ -1668,7 +1673,7 @@ if (hasSingleInstanceLock) {
   app.whenReady().then(async () => {
     logStartupStep('electron-ready', 'completed')
     if (process.platform === 'darwin' && app.dock && developmentDockIdentity) {
-      app.dock.setBadge(developmentDockIdentity.badge)
+      syncDockBadge(app.dock, 0, developmentDockIdentity.badge)
       console.info('[development] Dock identity configured', developmentDockIdentity)
     }
     logStartupStep('log-retention-start', 'started')

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -2778,7 +2778,7 @@
     "general_settings_tray_display_content": "Tray display content",
     "general_settings_tray_display_content_description": "Choose which statuses appear in the tray icon and menu.",
     "general_settings_tray_unread": "Unread tasks",
-    "general_settings_tray_unread_description": "Unread completed tasks show a green numeric reminder inside the tray icon.",
+    "general_settings_tray_unread_description": "List unread completed tasks in the tray menu and show their count on the macOS app icon.",
     "general_settings_tray_running": "Running tasks",
     "general_settings_tray_running_description": "Running tasks show a vertical status bar between the icon and quota text.",
     "general_settings_tray_usage": "Codex quota",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -2776,7 +2776,7 @@
     "general_settings_tray_display_content": "托盘显示内容",
     "general_settings_tray_display_content_description": "选择托盘图标和菜单里展示的状态。",
     "general_settings_tray_unread": "未读任务",
-    "general_settings_tray_unread_description": "未读完成任务会在托盘图标内显示绿色数字提醒。",
+    "general_settings_tray_unread_description": "在托盘菜单中列出未读完成任务，并在 macOS 应用图标上显示未读数量。",
     "general_settings_tray_running": "进行中任务",
     "general_settings_tray_running_description": "进行中的任务会在图标和额度之间显示竖条状态。",
     "general_settings_tray_usage": "Codex 额度",


### PR DESCRIPTION
Completed background tasks appear as unread in Wework, but their count never reaches the macOS Dock. Synchronize the Dock badge from the existing tray unread state: show the count, reduce it when tasks are read, and clear it when no unread tasks remain or the existing unread-task preference is disabled.

Preserve the development-instance badge when there are no unread tasks. Update the existing English and Chinese setting descriptions and extend the CI-registered `codex-notification-isolation` scenario without adding another counter, preference, or IPC command.

Validation:

- Full pre-push checks passed: 5,421 renderer tests, the full Electron test suite, renderer/Electron TypeScript and ESLint. The 116 focused lifecycle/tray/Dock/host tests and formatting checks also passed.
- Isolated real Electron 43.4.1 on macOS arm64, with real local executor and Codex plus deterministic HTTP model responses: two background completions show `2`; disabling/re-enabling unread reminders clears/restores it; reload preserves `2`; opening tasks changes it to `1`, then empty; reopening a read task keeps it empty. Assertions read the native `dock.getBadge()` value as well as the tray menu. Verification sessions and authentication links were cleaned up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unread completed tasks now display as a count badge on the macOS app icon.
  * The badge updates as tasks are viewed and remains accurate after app reloads and tray notification setting changes.
  * Development builds retain their identifying badge when there are no unread tasks.

* **Bug Fixes**
  * Improved synchronization between tray notifications and the macOS app icon badge.

* **Documentation**
  * Updated English and Chinese descriptions to clarify tray and app icon unread-task indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->