### PR TITLE
fix(channels): show DingTalk card errors and reject non-Claude cloud models

### DIFF
--- a/backend/app/services/channels/dingtalk/emitter.py
+++ b/backend/app/services/channels/dingtalk/emitter.py
@@ -267,6 +267,7 @@ class StreamingResponseEmitter(ResultEmitter):
 
     MIN_UPDATE_INTERVAL = 0.8
     MAX_FINAL_CONTENT_LENGTH = 4000
+    MAX_ERROR_CONTENT_LENGTH = 300
     FINAL_TRUNCATION_SUFFIX = "\n\n…（内容已截断，请在 Wework 查看完整结果）"
     PROGRESS_STATE_SUFFIX = ":progress"
     DISPLAY_LOCK_SUFFIX = ":display-lock"
@@ -708,6 +709,21 @@ class StreamingResponseEmitter(ResultEmitter):
             )
             try:
                 if await self._ensure_card_started():
+                    # ai_fail() alone only flips the card to FAILED and leaves the
+                    # body empty, which DingTalk renders as a blank card. Write the
+                    # error into the card body first so users can see why it failed.
+                    error_text = _compact_text(error, self.MAX_ERROR_CONTENT_LENGTH)
+                    content = (
+                        f"❌ 任务执行失败：{error_text}"
+                        if error_text
+                        else "❌ 任务执行失败"
+                    )
+                    try:
+                        self._card.ai_streaming(content, append=False)
+                    except Exception:
+                        logger.exception(
+                            "[StreamingEmitter] Failed to stream error content"
+                        )
                     self._card.ai_fail()
                     self._finished = True
             except Exception:

--- a/backend/app/services/channels/handler.py
+++ b/backend/app/services/channels/handler.py
@@ -640,6 +640,30 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
 
         return None, None
 
+    async def _is_claude_compatible_override(
+        self, db: Session, user: User, model_name: str
+    ) -> Optional[bool]:
+        """Check whether an override model can run on the Claude Code executor.
+
+        Returns True/False when the model is resolvable; returns None when the
+        model is not found (e.g. custom configs) so unverifiable models are not
+        blocked.
+        """
+        from app.services.model_aggregation_service import model_aggregation_service
+
+        all_models = model_aggregation_service.list_available_models(
+            db=db,
+            current_user=user,
+            shell_type=None,
+            include_config=False,
+            scope="personal",
+            model_category_type="llm",
+        )
+        for model in all_models:
+            if model_name in {model.get("name"), model.get("displayName")}:
+                return is_claude_provider(model.get("provider"))
+        return None
+
     async def _get_device_mode_model_override(
         self, db: Session, user: User
     ) -> tuple[Optional[str], Optional[str]]:
@@ -3298,6 +3322,21 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
         override_model_name, override_model_type = await self._get_user_model_override(
             user.id
         )
+
+        # Cloud executor runs Claude Code, which only accepts Claude models.
+        # Reject an incompatible override up front; otherwise the task fails deep
+        # inside the executor with a card that shows no content.
+        if override_model_name:
+            compatible = await self._is_claude_compatible_override(
+                db, user, override_model_name
+            )
+            if compatible is False:
+                return (
+                    f"⚠️ 当前模型 **{override_model_name}** 不支持云端执行模式\n\n"
+                    "云端执行基于 Claude Code，仅支持 Claude 模型。\n"
+                    "请使用 `/models` 切换到 Claude 模型，"
+                    "或使用 `/use chat` 切回对话模式"
+                )
 
         params = TaskCreationParams(
             message=display_text,

--- a/backend/tests/services/channels/dingtalk/test_emitter.py
+++ b/backend/tests/services/channels/dingtalk/test_emitter.py
@@ -354,6 +354,23 @@ async def test_interactive_block_points_user_back_to_wework(emitter, card_factor
 
 
 @pytest.mark.asyncio
+async def test_error_writes_content_before_marking_failed(emitter, card_factory):
+    """A failed task must render the error text instead of a blank card."""
+    await emitter.emit_start(task_id="task-1", subtask_id=1)
+    await emitter.emit_error(
+        task_id="task-1",
+        subtask_id=1,
+        error="There is an issue with the selected model (gpt-5.1)",
+    )
+
+    card = card_factory[0]
+    assert card.failed is True
+    assert card.updates
+    assert card.updates[-1].startswith("❌ 任务执行失败")
+    assert "gpt-5.1" in card.updates[-1]
+
+
+@pytest.mark.asyncio
 async def test_answer_stream_and_terminal_result_replace_progress(
     emitter, card_factory
 ):

--- a/backend/tests/services/channels/telegram_channel/test_handler.py
+++ b/backend/tests/services/channels/telegram_channel/test_handler.py
@@ -687,6 +687,75 @@ class TestTelegramChannelHandler:
         _assert_message_source(create_task_mock)
 
     @pytest.mark.asyncio
+    async def test_create_and_process_cloud_task_rejects_non_claude_model(
+        self, handler
+    ):
+        """Cloud executor (Claude Code) must reject a non-Claude override model."""
+        message_context = _message_context()
+        user = SimpleNamespace(id=1)
+        team = SimpleNamespace(id=100)
+        db = MagicMock()
+
+        with (
+            patch.object(
+                handler,
+                "_get_user_model_override",
+                new=AsyncMock(return_value=("openai-gpt-5.1(overseas)", None)),
+            ),
+            patch.object(
+                handler,
+                "_is_claude_compatible_override",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "app.services.chat.storage.task_manager.create_task_and_subtasks",
+                new=AsyncMock(),
+            ) as create_task_mock,
+        ):
+            result = await handler._create_and_process_cloud_task(
+                db=db,
+                user=user,
+                team=team,
+                message_context=message_context,
+            )
+
+        assert result is not None
+        assert "不支持云端执行模式" in result
+        create_task_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_is_claude_compatible_override_matches_model_list(self, handler):
+        """The override compatibility check follows the model list provider."""
+        user = SimpleNamespace(id=1)
+        db = MagicMock()
+        models = [
+            {"name": "openai-gpt", "displayName": "GPT", "provider": "openai"},
+            {"name": "wecode-claude-x", "displayName": "ClaudeX", "provider": "claude"},
+        ]
+        with patch(
+            "app.services.model_aggregation_service.model_aggregation_service"
+            ".list_available_models",
+            return_value=models,
+        ):
+            assert (
+                await handler._is_claude_compatible_override(db, user, "openai-gpt")
+                is False
+            )
+            assert (
+                await handler._is_claude_compatible_override(db, user, "GPT") is False
+            )
+            assert (
+                await handler._is_claude_compatible_override(
+                    db, user, "wecode-claude-x"
+                )
+                is True
+            )
+            assert (
+                await handler._is_claude_compatible_override(db, user, "unknown-model")
+                is None
+            )
+
+    @pytest.mark.asyncio
     async def test_broadcast_user_message_to_web_includes_display_metadata(
         self, handler
     ):


### PR DESCRIPTION
## 背景

钉钉群里 @ 机器人后，返回结果显示为一张空白的「交互卡片消息」。排查（WORK-21）确认链路：群消息 → 用户账号偏好 `default_execution_target=cloud` → 云端 executor（Claude Code）+ 通道默认模型为 openai 协议模型 → claude CLI 报 `selected model` 错误 → 任务 FAILED → `emit_error` 只调 `ai_fail()` 不写正文 → 群里空白卡片。

## 修复内容

1. **DingTalk emitter 失败兜底**（`dingtalk/emitter.py`）：`emit_error` 先把错误文案写进卡片正文（`ai_streaming`）再 `ai_fail()`，失败任务不再是空白卡片。

2. **cloud 模式模型兼容性校验**（`channels/handler.py`）：云 executor 跑的是 Claude Code，仅支持 Claude 协议模型。现在创建云端任务前会校验模型覆盖（用户 `/models` 选择或通道 `defaultModelName`）是否为 Claude 系（复用 `is_claude_provider`，与设备模式一致）；不兼容时直接回复可操作的提示，不再把任务送进 executor 才失败。

3. **单测**：`test_emitter.py` 覆盖失败写正文；`telegram_channel/test_handler.py` 覆盖 cloud 模式拒绝非 Claude 模型 + 兼容性检查本身。

注：`set_chat_mode` 清除显式选择导致 `/use chat` 被 Web 偏好覆盖的问题，已由 #3343 修复，不在本 PR 范围。

## 测试

- `uv run pytest tests/services/channels/` — 238 passed