### PR TITLE
fix(wework): remove release script package dependency

### DIFF
--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -3110,7 +3110,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
         )
         from app.services.wework_api.events import publish_runtime_event
 
-        await publish_runtime_event(user_id, logical_device_id, payload)
+        await publish_runtime_event(user_id, device_id, payload)
         await self._local_task_responses.forward_runtime_event_to_channels(
             device_id=device_id,
             payload=payload["payload"],

--- a/wework/scripts/collect-harness-runtime-release-assets.mjs
+++ b/wework/scripts/collect-harness-runtime-release-assets.mjs
@@ -1,9 +1,9 @@
 import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { extract } from 'tar'
 
 const CORE_COMPONENT_PATTERN = /^WeworkComponent_coreDsh_.+\.tar\.gz$/
 
@@ -25,7 +25,13 @@ export async function collectHarnessRuntimeReleaseAssets(inputDirectory, outputD
 async function collectComponentArchive(archive, output) {
   const temporary = await mkdtemp(join(tmpdir(), 'wework-harness-runtime-release-'))
   try {
-    await extract({ cwd: temporary, file: archive, strict: true })
+    const extraction = spawnSync('tar', ['-xzf', archive, '-C', temporary], {
+      stdio: 'inherit',
+    })
+    if (extraction.error) throw extraction.error
+    if (extraction.status !== 0) {
+      throw new Error(`Failed to extract Harness Runtime component: ${archive}`)
+    }
     const catalog = JSON.parse(await readFile(join(temporary, 'runtimes.json'), 'utf8'))
     if (!Array.isArray(catalog.runtimes) || catalog.runtimes.length === 0) {
       throw new Error(`Harness Runtime catalog is invalid: ${archive}`)


### PR DESCRIPTION
## Summary
- remove the publish-time dependency on the workspace `tar` package
- extract Harness Runtime component archives with the native `tar` command already available on release runners
- preserve descriptor checksum, size, and immutable asset validation
- fix the merge-time Backend runtime-event regression exposed by the full merge-queue suite

## Root cause
The publish job intentionally does not install workspace dependencies. `collect-harness-runtime-release-assets.mjs` introduced an import from the `wework` devDependency `tar`, so the rolling-channel step failed with `ERR_MODULE_NOT_FOUND` after formal release assets had already been published.

The first merge-queue attempt also exposed a semantic conflict already present on `main`: one change renamed `_forward_runtime_event` from `logical_device_id` to `device_id`, while a concurrent Wework API change added a publisher call using the old name. That caused 18 deterministic Backend failures. The publisher now uses the canonical `device_id` parameter.

## Verification
- `pnpm --filter wework test scripts/collect-harness-runtime-release-assets.test.mjs`
- `pnpm --filter wework test src/test/bundled-plugin-resources.test.ts`
- `pnpm --filter wework exec prettier --check scripts/collect-harness-runtime-release-assets.mjs`
- `cd backend && uv run pytest tests/api/ws/test_wework_runtime_namespace.py` (31 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extraction of component release archives.
  - Added clearer handling for archive extraction failures, including startup errors and unsuccessful extraction attempts.
  - Fixed runtime event forwarding so events are associated with the correct device identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->