### PR TITLE
fix(wework): match marketplace installations by app ID

### DIFF
--- a/wework/dsh/ui-applications/src/SmartAppsMarketplacePage.test.tsx
+++ b/wework/dsh/ui-applications/src/SmartAppsMarketplacePage.test.tsx
@@ -547,6 +547,80 @@ describe('SmartAppsMarketplacePage', () => {
     expect(screen.getByTestId('smart-app-created-item-research-desk')).not.toHaveClass('min-h-64')
   })
 
+  test.each([true, false])(
+    'keeps a market installation separate from a removed same-name import (market visible: %s)',
+    async marketVisible => {
+      const previousPublication = item({
+        id: 8,
+        accessRole: 'owner',
+        displayName: '旧测试工作台',
+        summary: '旧导入简介',
+        iconUrl: 'https://example.test/old.png',
+        tags: ['old-tag'],
+      })
+      const marketItem = item({
+        displayName: '市场工作台',
+        summary: '市场发布简介',
+        iconUrl: 'https://example.test/market.png',
+      })
+      const smartAppsApi = api(marketVisible ? [marketItem] : [])
+      vi.mocked(smartAppsApi.listOwned).mockResolvedValue({ items: [previousPublication] })
+      listInstalled.mockResolvedValue([
+        {
+          ...importedInstallation,
+          id: 'market-7',
+          source: 'market',
+          smartAppId: 7,
+          releaseId: 17,
+        },
+      ])
+
+      render(<SmartAppsMarketplacePage api={smartAppsApi} mode="owned" />)
+
+      await screen.findByText('市场安装')
+      expect(screen.getByTestId('smart-apps-owned-filter-created')).toHaveTextContent('0')
+      expect(screen.getByTestId('smart-apps-owned-filter-installed')).toHaveTextContent('1')
+      expect(screen.queryByText('旧测试工作台')).not.toBeInTheDocument()
+      expect(screen.queryByText('旧导入简介')).not.toBeInTheDocument()
+      expect(screen.queryByText('old-tag')).not.toBeInTheDocument()
+      expect(screen.queryByText('管理范围')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('smart-app-visibility-8')).not.toBeInTheDocument()
+      expect(document.querySelector(`img[src="${previousPublication.iconUrl}"]`)).toBeNull()
+      expect(
+        screen.getByText(
+          marketVisible ? marketItem.summary : importedInstallation.manifest.description
+        )
+      ).toBeInTheDocument()
+      if (marketVisible) {
+        expect(screen.getByTestId('smart-app-owned-item-7').querySelector('img')).toHaveAttribute(
+          'src',
+          marketItem.iconUrl
+        )
+      }
+      fireEvent.click(screen.getByTestId('smart-app-actions-market-7'))
+      expect(screen.queryByTestId('smart-app-manage-access-market-7')).not.toBeInTheDocument()
+    }
+  )
+
+  test('matches an owned market installation by ID ahead of another same-name publication', async () => {
+    const publication = item({ accessRole: 'owner', summary: '当前发布简介' })
+    const smartAppsApi = api([publication])
+    vi.mocked(smartAppsApi.listOwned).mockResolvedValue({
+      items: [item({ id: 8, accessRole: 'owner', summary: '旧导入简介' }), publication],
+    })
+    listInstalled.mockResolvedValue([
+      { ...importedInstallation, id: 'market-7', source: 'market', smartAppId: 7, releaseId: 17 },
+    ])
+
+    render(<SmartAppsMarketplacePage api={smartAppsApi} mode="owned" />)
+
+    const card = await screen.findByTestId('smart-app-created-item-market-7')
+    expect(card).toHaveTextContent('当前发布简介')
+    expect(card).toHaveTextContent('我创建')
+    expect(card).not.toHaveTextContent('旧导入简介')
+    expect(within(card).getByTestId('smart-app-visibility-7')).toBeInTheDocument()
+  })
+
   test('identifies a folder-linked workbench separately from an imported package', async () => {
     listInstalled.mockResolvedValue([
       {

--- a/wework/dsh/ui-applications/src/SmartAppsMarketplacePage.tsx
+++ b/wework/dsh/ui-applications/src/SmartAppsMarketplacePage.tsx
@@ -347,8 +347,10 @@ export function SmartAppsMarketplacePage({
   const installModelKey = modelKey || modelOptions[0]?.key || ''
   const ownedCards = useMemo<OwnedSmartAppCard[]>(() => {
     return activeInstallations.map(installation => {
-      const ownedItem = items.find(
-        item => item.id === installation.smartAppId || item.name === installation.manifest.name
+      const ownedItem = items.find(item =>
+        installation.smartAppId != null
+          ? item.id === installation.smartAppId
+          : item.name === installation.manifest.name
       )
       const marketItem = installation.smartAppId
         ? marketItems.find(item => item.id === installation.smartAppId)

--- a/wework/e2e/desktop/modules/smart-app-marketplace-identity.mjs
+++ b/wework/e2e/desktop/modules/smart-app-marketplace-identity.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+
+export async function verifySmartAppMarketplaceIdentity({
+  control,
+  ownerRequest,
+  installationId,
+  publicationId,
+  captureScreenshot,
+  uiTimeoutMs,
+}) {
+  const active = '[data-workspace-tab-content][aria-hidden="false"]'
+  const owned = `${active} [data-testid="smart-apps-owned-page"]`
+  const catalog = await ownerRequest('/api/smart-apps/marketplace')
+  const marketItem = catalog.items.find(
+    item => item.name === installationId && item.sourceType === 'official'
+  )
+  assert.ok(marketItem, 'Same-name official market fixture is missing')
+  assert.notEqual(marketItem.id, publicationId)
+
+  await control.command('click', `${active} [data-testid="smart-app-actions-${installationId}"]`)
+  await control.command('click', `[data-testid="smart-app-remove-local-${installationId}"]`)
+  await control.command('click', '[data-testid="smart-app-remove-local-confirm"]')
+  await control.command('waitFor', owned, {
+    text: '还没有符合条件的工作台',
+    timeoutMs: uiTimeoutMs,
+  })
+  const publications = await ownerRequest('/api/smart-apps/owned')
+  assert.ok(
+    publications.items.some(item => item.id === publicationId && item.name === installationId),
+    'Local removal must preserve the same-name cloud publication for this regression'
+  )
+
+  await control.command('click', `${active} [data-testid="smart-apps-section-marketplace"]`)
+  await control.command(
+    'waitFor',
+    `[data-testid="smart-app-marketplace-install-${marketItem.id}"]`,
+    {
+      timeoutMs: uiTimeoutMs,
+    }
+  )
+  await control.command('click', `[data-testid="smart-app-marketplace-install-${marketItem.id}"]`)
+  await control.command('waitFor', '[data-testid="harness-app-preview"]', {
+    timeoutMs: uiTimeoutMs,
+  })
+  await control.command('clickWhenEnabled', '[data-testid="harness-app-install-confirm"]', {
+    timeoutMs: uiTimeoutMs,
+  })
+  await control.command('waitFor', `[data-testid="harness-app-start-market-${marketItem.id}"]`, {
+    timeoutMs: uiTimeoutMs,
+  })
+  await control.command('click', `${active} [data-testid="smart-apps-section-owned"]`)
+  const card = `${active} [data-testid="smart-app-owned-item-${marketItem.id}"]`
+  await control.command('waitFor', card, { text: marketItem.summary, timeoutMs: uiTimeoutMs })
+  const text = await control.command('getText', card)
+  assert.ok(text.includes('市场安装'), 'Reinstallation was classified as a locally created app')
+  assert.ok(!text.includes('管理范围'), 'Market installation inherited historical owner actions')
+  const iconUrl = await control.command('getAttribute', `${card} img`, { value: 'src' })
+  assert.equal(
+    new URL(iconUrl).pathname,
+    new URL(marketItem.iconUrl).pathname,
+    'Market installation inherited the historical publication icon'
+  )
+  assert.equal(
+    Number(
+      await control.command(
+        'getElementCount',
+        `${card} [data-testid="smart-app-visibility-${publicationId}"]`
+      )
+    ),
+    0,
+    'Market installation was associated with the historical cloud publication'
+  )
+  await control.command('click', `${active} [data-testid="smart-apps-owned-filter-installed"]`)
+  await control.command('waitFor', card, { text: marketItem.summary, timeoutMs: uiTimeoutMs })
+  await captureScreenshot(control, 'harness-apps-15b-marketplace-identity.png', 'body')
+
+  await control.command(
+    'click',
+    `${active} [data-testid="smart-app-actions-market-${marketItem.id}"]`
+  )
+  await control.command('click', `[data-testid="smart-app-remove-local-market-${marketItem.id}"]`)
+  await control.command('click', '[data-testid="smart-app-remove-local-confirm"]')
+  await control.command('waitFor', owned, {
+    text: '还没有符合条件的工作台',
+    timeoutMs: uiTimeoutMs,
+  })
+}

--- a/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/harness-apps.scenario.mjs
@@ -10,6 +10,7 @@ import {
   extractSingleRootZipFixture,
   extractZipFixture,
 } from '../modules/zip-fixtures.mjs'
+import { verifySmartAppMarketplaceIdentity } from '../modules/smart-app-marketplace-identity.mjs'
 
 const INSTALLATION_ID = 'dsh-e2e-smoke'
 const IMPORTED_INSTALLATION_ID = 'dsh-e2e-smoke-imported'
@@ -1580,6 +1581,15 @@ export async function createDesktopScenario({ captureScreenshot, resultDir, uiTi
         'Removing an imported workbench left its card visible in My'
       )
       await captureScreenshot(control, 'harness-apps-15a-local-removal-semantics.png', 'body')
+
+      await verifySmartAppMarketplaceIdentity({
+        control,
+        ownerRequest,
+        installationId: INSTALLATION_ID,
+        publicationId: sharedSmartAppId,
+        captureScreenshot,
+        uiTimeoutMs,
+      })
 
       await setExperimentalFeatures(control, false, uiTimeoutMs)
       await control.command('navigate', 'body', { value: '/sites' })


### PR DESCRIPTION
Installing a marketplace app after removing a same-name local import could make My Workbenches show the old cloud publication's icon, summary, tags, and owner controls. Match installations with a smartAppId strictly by that ID; retain name matching only for local imports and linked projects without a cloud ID.

Add regression cases for same-name collisions, an unavailable market entry, and an exact owned-app ID. Extend the existing CI-covered harness-apps desktop scenario to remove the imported copy, retain its cloud publication, reinstall the same-name market app, and verify metadata, classification, filtering, and owner actions.

Validation:
- 33 page tests passed, including all three new cases; rerun after rebasing onto latest main.
- ESLint, TypeScript, Prettier, and git diff checks passed.
- Isolated real Electron: ZIP import, local-source classification, and removal passed.
- Full local desktop harness-apps E2E passed in 3m 53s before the latest-main rebase; test environments were cleaned up.
- Repository pre-push quality gate passed after rebasing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace app identity matching when installed apps share names with other publications.
  * Ensured market-installed apps display the correct summary, icon, ownership status, and available actions.
  * Prevented market installations from inheriting details or management actions from unrelated owner publications.
  * Improved filtering and installed-state behavior for marketplace apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->