### PR TITLE
fix(wework): build macOS x64 releases on Intel runners

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -188,7 +188,7 @@ jobs:
             cargo_target: aarch64-apple-darwin
             codex_target: aarch64-apple-darwin
           - name: macOS x64
-            runner: macos-14
+            runner: macos-15-intel
             platform: macos
             arch: x64
             cargo_target: x86_64-apple-darwin
@@ -233,6 +233,17 @@ jobs:
           cache-dependency-path: |
             pnpm-lock.yaml
             wework/electron/pnpm-lock.yaml
+
+      - name: Verify native build architecture
+        env:
+          WEWORK_RELEASE_ARCH: ${{ matrix.arch }}
+        run: |
+          node -e '
+            const expected = process.env.WEWORK_RELEASE_ARCH
+            if (process.arch !== expected) {
+              throw new Error("Release target " + expected + " requires native Node.js; runner uses " + process.arch)
+            }
+          '
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -8,6 +8,13 @@ The Wework desktop application uses Electron. Formal builds and releases are
 handled by `.github/workflows/wework-app.yml`, which produces Electron
 installers for macOS, Windows, and Linux.
 
+macOS x64 releases use the `macos-15-intel` runner; arm64 releases use `macos-14`.
+Before installing dependencies, the workflow checks that the Node.js architecture
+matches the target. Harness Runtime native dependencies follow the running Node.js
+architecture, so selecting an Electron Builder target alone cannot cross-build the
+complete runtime. If the architectures differ, correct the runner and rebuild;
+do not reuse artifacts built for the wrong architecture or rerun only publication.
+
 ## Version and artifacts
 
 The release version is written to `wework/package.json` and

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -8,6 +8,12 @@ Wework 桌面应用使用 Electron。正式构建和发布由
 `.github/workflows/wework-app.yml` 负责；该工作流同时生成 macOS、Windows 和
 Linux 的 Electron 安装包。
 
+macOS x64 发布使用 `macos-15-intel` runner，arm64 发布使用 `macos-14`。
+安装依赖前，工作流校验 Node.js 架构与目标架构一致；Harness Runtime 的原生
+依赖按运行中的 Node.js 架构准备，仅指定 Electron Builder 的目标架构不足以
+交叉构建完整运行环境。架构不匹配时应修正 runner 并重新构建，不能复用错误架构
+的产物或仅重跑发布步骤。
+
 ## 版本与产物
 
 发布版本同时写入 `wework/package.json` 和 `wework/electron/package.json`。正式

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -335,8 +335,16 @@ describe('bundled plugin resources', () => {
       'utf8'
     )
 
-    expect(workflow).toContain('macos-14')
-    expect(workflow).not.toContain('macos-15-intel')
+    expect(workflow).toMatch(/name: macOS arm64\s+runner: macos-14\s+platform: macos\s+arch: arm64/)
+    expect(workflow).toMatch(
+      /name: macOS x64\s+runner: macos-15-intel\s+platform: macos\s+arch: x64/
+    )
+    expect(workflow.indexOf('- name: Verify native build architecture')).toBeGreaterThan(
+      workflow.indexOf('- name: Set up Node.js')
+    )
+    expect(workflow.indexOf('- name: Verify native build architecture')).toBeLessThan(
+      workflow.indexOf('- name: Install workspace dependencies')
+    )
     expect(workflow).not.toContain('Install Rosetta 2')
     expect(workflow).not.toContain('node_arch')
     expect(workflow).toContain('WEWORK_ELECTRON_DEPENDENCIES_READY: "true"')


### PR DESCRIPTION
## Problem and change

The macOS x64 job in release run [34351911807](https://github.com/wecode-ai/Wegent/actions/runs/34351911807/job/102467294146) ran on `macos-14-arm64` with arm64 Node.js. It built arm64 Harness Runtime native dependencies despite the x64 Electron target. Publication then rejected conflicting immutable macOS arm64 runtime archives.

Use `macos-15-intel` for macOS x64 releases and reject a Node.js architecture mismatch before installing dependencies. Document the native-build requirement and the need to rebuild incorrect artifacts in both release guides.

## Validation

- Architecture guard executed: matching architecture succeeds; mismatched architecture fails with the expected diagnostic.
- Prettier and `git diff --check` pass.
- Actionlint passes with only the existing SC2129 signing-step style warning excluded.
- Repository pre-push quality gate passes; no application code or E2E scenarios changed.

A new beta build from the merged workflow is required; retrying only the failed publication job reuses the incorrect artifacts.

The existing workflow unit test prohibited Intel runners. Updated it to assert the native runner for each macOS architecture and require the architecture guard between Node setup and dependency installation. All 7 tests in `src/test/bundled-plugin-resources.test.ts` pass locally, along with ESLint and Prettier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release reliability by ensuring builds use runners matching the target architecture.
  * Added validation to detect architecture mismatches before dependencies are installed, preventing incompatible release artifacts.

* **Documentation**
  * Updated macOS release guidance with the correct runner mappings for Intel and Apple silicon builds.
  * Added recovery guidance for resolving architecture mismatches through a clean rebuild.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->