### PR TITLE
fix(wework): stabilize macOS release builds

### DIFF
--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -185,24 +185,28 @@ jobs:
             runner: macos-14
             platform: macos
             arch: arm64
+            node_arch: arm64
             cargo_target: aarch64-apple-darwin
             codex_target: aarch64-apple-darwin
           - name: macOS x64
-            runner: macos-15-intel
+            runner: macos-14
             platform: macos
             arch: x64
+            node_arch: x64
             cargo_target: x86_64-apple-darwin
             codex_target: x86_64-apple-darwin
           - name: Windows x64
             runner: windows-latest
             platform: windows
             arch: x64
+            node_arch: x64
             cargo_target: x86_64-pc-windows-msvc
             codex_target: x86_64-pc-windows-msvc
           - name: Linux x64
             runner: ubuntu-latest
             platform: linux
             arch: x64
+            node_arch: x64
             cargo_target: x86_64-unknown-linux-gnu
             codex_target: x86_64-unknown-linux-gnu
 
@@ -225,10 +229,19 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
+      - name: Install Rosetta 2
+        if: matrix.platform == 'macos' && matrix.arch == 'x64'
+        run: |
+          if ! /usr/bin/arch -x86_64 /usr/bin/true 2>/dev/null; then
+            sudo softwareupdate --install-rosetta --agree-to-license
+          fi
+          /usr/bin/arch -x86_64 /usr/bin/true
+
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
+          architecture: ${{ matrix.node_arch }}
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
@@ -352,6 +365,29 @@ jobs:
           pnpm --filter wework e2e:desktop -- \
             --parallel-segments release-package-startup,component-update,app-update-differential
           pnpm --filter wework e2e:desktop -- --segment app-update-baseline
+
+      - name: Prune formal release verification diagnostics
+        if: failure() && matrix.platform == 'macos' && matrix.arch == 'arm64'
+        run: .github/scripts/prune-wework-desktop-e2e-diagnostics.sh
+
+      - name: Upload formal release verification diagnostics
+        if: failure() && matrix.platform == 'macos' && matrix.arch == 'arm64'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: wework-formal-release-e2e-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            wework/test-results/desktop-e2e/
+            !wework/test-results/desktop-e2e/**/executor-home/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/harness-runtime/**
+            !wework/test-results/desktop-e2e/**/node-runtime/**
+            !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
+          if-no-files-found: ignore
+          retention-days: 7
+          compression-level: 0
 
       - name: Prepare desktop release assets
         shell: bash

--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -8,12 +8,19 @@ The Wework desktop application uses Electron. Formal builds and releases are
 handled by `.github/workflows/wework-app.yml`, which produces Electron
 installers for macOS, Windows, and Linux.
 
-macOS x64 releases use the `macos-15-intel` runner; arm64 releases use `macos-14`.
-Before installing dependencies, the workflow checks that the Node.js architecture
-matches the target. Harness Runtime native dependencies follow the running Node.js
-architecture, so selecting an Electron Builder target alone cannot cross-build the
-complete runtime. If the architectures differ, correct the runner and rebuild;
-do not reuse artifacts built for the wrong architecture or rerun only publication.
+Both macOS arm64 and x64 releases use the Apple Silicon `macos-14` runner. The
+x64 build verifies Rosetta 2 and then installs x64 Node.js through
+`actions/setup-node`. Before installing dependencies, the workflow checks that
+the running Node.js architecture matches the target. Harness Runtime native
+dependencies follow the running Node.js architecture, so selecting an Electron
+Builder target alone cannot cross-build the complete runtime. If the
+architectures differ, correct the Node.js architecture and rebuild; do not
+reuse artifacts built for the wrong architecture or rerun only publication.
+
+When formal macOS arm64 package verification fails, the workflow prunes large
+temporary runtime directories and uploads desktop E2E diagnostics retained for
+seven days. Use those logs to establish the root cause instead of hiding a
+failure through reruns or weaker E2E assertions.
 
 ## Version and artifacts
 

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -8,11 +8,16 @@ Wework 桌面应用使用 Electron。正式构建和发布由
 `.github/workflows/wework-app.yml` 负责；该工作流同时生成 macOS、Windows 和
 Linux 的 Electron 安装包。
 
-macOS x64 发布使用 `macos-15-intel` runner，arm64 发布使用 `macos-14`。
-安装依赖前，工作流校验 Node.js 架构与目标架构一致；Harness Runtime 的原生
-依赖按运行中的 Node.js 架构准备，仅指定 Electron Builder 的目标架构不足以
-交叉构建完整运行环境。架构不匹配时应修正 runner 并重新构建，不能复用错误架构
-的产物或仅重跑发布步骤。
+macOS arm64 和 x64 发布都使用 Apple Silicon `macos-14` runner。x64 构建先
+校验 Rosetta 2，再通过 `actions/setup-node` 安装 x64 Node.js；安装依赖前，
+工作流校验运行中的 Node.js 架构与目标架构一致。Harness Runtime 的原生依赖按
+运行中的 Node.js 架构准备，仅指定 Electron Builder 的目标架构不足以交叉构建
+完整运行环境。架构不匹配时应修正 Node.js 架构并重新构建，不能复用错误架构的
+产物或仅重跑发布步骤。
+
+正式 macOS arm64 包验证失败时，工作流会清理体积较大的临时运行时目录，并上传
+保留七天的桌面 E2E 诊断产物。必须先用这些日志定位根因，不能通过重跑或放宽
+E2E 断言隐藏失败。
 
 ## 版本与产物
 

--- a/wework/electron/scripts/notarize-macos.cjs
+++ b/wework/electron/scripts/notarize-macos.cjs
@@ -110,7 +110,7 @@ function s3AccelerationArgs(value) {
 
 function isTransientNotaryFailure(error) {
   const message = error instanceof Error ? error.message : String(error)
-  return /abortedUpload|deadlineExceeded|timed? ?out|connection (?:reset|lost)|NSURLErrorDomain.*-100[15]/i.test(
+  return /abortedUpload|deadlineExceeded|timed? ?out|connection (?:reset|lost)|NSURLErrorDomain.*-100[159]/i.test(
     message
   )
 }

--- a/wework/electron/src/notarize-macos.test.ts
+++ b/wework/electron/src/notarize-macos.test.ts
@@ -74,6 +74,11 @@ test('retries only transient notarization transport failures', () => {
   expect(isTransientNotaryFailure(new Error('HTTPClientError.deadlineExceeded'))).toBe(true)
   expect(isTransientNotaryFailure(new Error('abortedUpload after connection reset'))).toBe(true)
   expect(
+    isTransientNotaryFailure(
+      new Error('NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline."')
+    )
+  ).toBe(true)
+  expect(
     isTransientNotaryFailure(new Error('Apple notarization failed with status: Invalid'))
   ).toBe(false)
 })

--- a/wework/src/test/bundled-plugin-resources.test.ts
+++ b/wework/src/test/bundled-plugin-resources.test.ts
@@ -337,16 +337,19 @@ describe('bundled plugin resources', () => {
 
     expect(workflow).toMatch(/name: macOS arm64\s+runner: macos-14\s+platform: macos\s+arch: arm64/)
     expect(workflow).toMatch(
-      /name: macOS x64\s+runner: macos-15-intel\s+platform: macos\s+arch: x64/
+      /name: macOS x64\s+runner: macos-14\s+platform: macos\s+arch: x64\s+node_arch: x64/
     )
+    expect(workflow).toContain('- name: Install Rosetta 2')
+    expect(workflow).toContain('architecture: ${{ matrix.node_arch }}')
     expect(workflow.indexOf('- name: Verify native build architecture')).toBeGreaterThan(
       workflow.indexOf('- name: Set up Node.js')
     )
     expect(workflow.indexOf('- name: Verify native build architecture')).toBeLessThan(
       workflow.indexOf('- name: Install workspace dependencies')
     )
-    expect(workflow).not.toContain('Install Rosetta 2')
-    expect(workflow).not.toContain('node_arch')
+    expect(workflow).toContain('- name: Upload formal release verification diagnostics')
+    expect(workflow).toContain('if: failure() && matrix.platform ==')
+    expect(workflow).toContain('wework/test-results/desktop-e2e/')
     expect(workflow).toContain('WEWORK_ELECTRON_DEPENDENCIES_READY: "true"')
     expect(workflow).toContain('WEWORK_E2E_PARALLEL_CHECKPOINTS: "3"')
     expect(workflow).toContain(


### PR DESCRIPTION
## Summary

- build macOS x64 releases on Apple Silicon with Rosetta and an explicit x64 Node runtime
- retry Apple notarization when NSURLErrorDomain reports offline connectivity (-1009)
- upload pruned formal-release E2E diagnostics when the arm64 verification fails
- document and enforce the release architecture contract

## Evidence

The failed beta.3 release spent about 22 minutes compiling the x64 executor on the Intel runner, while historical Apple Silicon x64 cross-builds completed that phase in roughly 5–7 minutes. Its final error was NSURLErrorDomain Code=-1009, which the existing transient retry matcher did not include. The arm64 package built successfully but failed in app-update-differential without retained diagnostics, so this change preserves the E2E assertion and uploads evidence on failure.

## Verification

- `pnpm --filter wework test src/test/bundled-plugin-resources.test.ts`
- `pnpm --dir wework/electron test -- src/notarize-macos.test.ts` (97 files, 574 tests)
- Prettier check for all changed files
- `actionlint -shellcheck= .github/workflows/wework-app.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - macOS notarization now automatically retries additional transient network failures, including timeouts and offline connection errors.

- **Release Improvements**
  - macOS x64 releases now build with the correct Node.js architecture and Rosetta 2 support.
  - Failed macOS arm64 package verification now preserves diagnostic artifacts for troubleshooting, retained for seven days.

- **Documentation**
  - Updated English and Chinese macOS release guidance to reflect architecture handling, Rosetta 2 requirements, and available verification diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->