### PR TITLE
fix(wework): restore cross-device transcript sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,19 @@ WEGENT_SOCKET_URL=http://localhost:8000
 # Required when image or video generation uses locally uploaded references.
 ATTACHMENT_PUBLIC_BASE_URL=
 
+# S3/MinIO connection shared by attachments, deliveries, workspace archives,
+# and encrypted Wework transcript segments.
+# ATTACHMENT_S3_ENDPOINT=minio:9000
+# ATTACHMENT_S3_ACCESS_KEY=your_access_key
+# ATTACHMENT_S3_SECRET_KEY=your_secret_key
+# ATTACHMENT_S3_REGION=us-east-1
+# ATTACHMENT_S3_USE_SSL=false
+
+# Private storage and encryption settings for cross-device Wework transcripts.
+WEWORK_TRANSCRIPT_S3_BUCKET=wework-transcripts
+# Keep this stable while encrypted transcript objects are retained.
+# WEWORK_TRANSCRIPT_ENCRYPTION_SECRET=your-high-entropy-secret-here
+
 # Frontend port (default: 3000)
 WEGENT_FRONTEND_PORT=3000
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -385,6 +385,10 @@ jobs:
           TZ: Asia/Shanghai
         run: pnpm --filter wework exec vitest run --coverage --passWithNoTests --shard=${{ matrix.shard }}/2
 
+      - name: Run Wework Electron tests
+        if: matrix.shard == 1
+        run: pnpm --dir wework/electron test
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -112,6 +112,17 @@ ENABLE_API_DOCS=True
 # Required when image or video generation uses locally uploaded references.
 ATTACHMENT_PUBLIC_BASE_URL=
 
+# S3/MinIO connection shared by attachments, deliveries, workspace archives,
+# and encrypted Wework transcript segments.
+# ATTACHMENT_S3_ENDPOINT=minio:9000
+# ATTACHMENT_S3_ACCESS_KEY=your_access_key
+# ATTACHMENT_S3_SECRET_KEY=your_secret_key
+# ATTACHMENT_S3_REGION=us-east-1
+# ATTACHMENT_S3_USE_SSL=false
+
+# Private storage settings for cross-device Wework transcripts.
+WEWORK_TRANSCRIPT_S3_BUCKET=wework-transcripts
+
 # Public Socket.IO origin returned to Wework desktop clients.
 # Use wss:// in HTTPS deployments.
 WEGENT_SOCKET_URL=http://localhost:8000

--- a/backend/app/api/endpoints/wework_transcripts.py
+++ b/backend/app/api/endpoints/wework_transcripts.py
@@ -6,7 +6,9 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import StreamingResponse
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
@@ -33,8 +35,6 @@ from app.schemas.wework_transcript import (
     TranscriptListResponse,
     TranscriptResponse,
     TranscriptSegmentCommitRequest,
-    TranscriptSegmentPrepareResponse,
-    TranscriptSegmentRequest,
     TranscriptTurnResponse,
     TranscriptTurnsResponse,
 )
@@ -171,48 +171,28 @@ def release_lease_endpoint(
 
 
 @router.post(
-    "/{transcript_id}/segments/prepare",
-    response_model=TranscriptSegmentPrepareResponse,
-    response_model_by_alias=True,
-)
-def prepare_segment_upload_endpoint(
-    transcript_id: str,
-    request: TranscriptSegmentRequest,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    upload_url, upload_fields, expires_at = _translate(
-        lambda: wework_transcript_service.prepare_segment_upload(
-            db,
-            user_id=current_user.id,
-            transcript_id=transcript_id,
-            request=request,
-        )
-    )
-    return {
-        "uploadUrl": upload_url,
-        "uploadFields": upload_fields,
-        "expiresAt": expires_at,
-    }
-
-
-@router.post(
     "/{transcript_id}/segments",
     response_model=TranscriptAppendResponse,
     response_model_by_alias=True,
 )
-def commit_segment_endpoint(
+def upload_segment_endpoint(
     transcript_id: str,
-    request: TranscriptSegmentCommitRequest,
+    metadata: str = Form(...),
+    file: UploadFile = File(...),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    try:
+        request = TranscriptSegmentCommitRequest.model_validate_json(metadata)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
     transcript, appended = _translate(
-        lambda: wework_transcript_service.commit_segment(
+        lambda: wework_transcript_service.upload_segment(
             db,
             user_id=current_user.id,
             transcript_id=transcript_id,
             request=request,
+            source=file.file,
         )
     )
     return {
@@ -291,11 +271,12 @@ def get_archive_download_endpoint(
             archive_id=archive_id,
         )
     )
-    return {
-        "downloadUrl": _translate(
-            lambda: wework_transcript_storage.download_url(archive.storage_key)
-        )
-    }
+    stream = _translate(lambda: wework_transcript_storage.stream(archive.storage_key))
+    return StreamingResponse(
+        stream,
+        media_type="application/octet-stream",
+        headers={"Content-Length": str(archive.size_bytes)},
+    )
 
 
 def _lease_response(transcript: WeworkTranscript) -> TranscriptLeaseResponse:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -259,7 +259,6 @@ class Settings(BaseSettings):
     WORKSPACE_ARCHIVE_ENABLED: bool = True
     WORKSPACE_ARCHIVE_TIMEZONE: str = "Asia/Shanghai"
     WEWORK_TRANSCRIPT_S3_BUCKET: str = "wework-transcripts"
-    WEWORK_TRANSCRIPT_DOWNLOAD_URL_EXPIRE_SECONDS: int = 900
 
     # Publish storage configuration
     PUBLISH_PRESIGNED_UPLOAD_EXPIRE_SECONDS: int = 3600

--- a/backend/app/schemas/wework_transcript.py
+++ b/backend/app/schemas/wework_transcript.py
@@ -77,14 +77,6 @@ class TranscriptLeaseResponse(BaseModel):
     current_sequence: int = Field(alias="currentSequence")
 
 
-class TranscriptSegmentPrepareResponse(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
-    upload_url: str = Field(alias="uploadUrl")
-    upload_fields: dict[str, str] = Field(alias="uploadFields")
-    expires_at: datetime = Field(alias="expiresAt")
-
-
 class TranscriptEncryptionKeyResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -110,7 +102,6 @@ class TranscriptArchiveResponse(BaseModel):
     sha256: str
     size_bytes: int = Field(alias="sizeBytes")
     format: str
-    download_url: str | None = Field(default=None, alias="downloadUrl")
     created_at: datetime = Field(alias="createdAt")
 
 

--- a/backend/app/services/wework_transcript_service.py
+++ b/backend/app/services/wework_transcript_service.py
@@ -6,7 +6,9 @@
 
 import hashlib
 import logging
+import tempfile
 from datetime import UTC, datetime, timedelta
+from typing import BinaryIO
 
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -22,7 +24,6 @@ from app.schemas.wework_transcript import (
     TranscriptLeaseReleaseRequest,
     TranscriptLeaseRequest,
     TranscriptSegmentCommitRequest,
-    TranscriptSegmentRequest,
 )
 from app.services.wework_transcript_storage import (
     WeworkTranscriptStorageError,
@@ -208,32 +209,13 @@ def release_lease(
     return transcript
 
 
-def prepare_segment_upload(
-    db: Session,
-    *,
-    user_id: int,
-    transcript_id: str,
-    request: TranscriptSegmentRequest,
-) -> tuple[str, dict[str, str], datetime]:
-    transcript = get_transcript(
-        db,
-        user_id=user_id,
-        transcript_id=transcript_id,
-        for_update=True,
-    )
-    _validate_segment_write(transcript, request)
-    return wework_transcript_storage.upload_policy(
-        _segment_object_key(user_id, transcript_id, request),
-        request.size_bytes,
-    )
-
-
-def commit_segment(
+def upload_segment(
     db: Session,
     *,
     user_id: int,
     transcript_id: str,
     request: TranscriptSegmentCommitRequest,
+    source: BinaryIO,
 ) -> tuple[WeworkTranscript, bool]:
     transcript = get_transcript(
         db,
@@ -286,22 +268,22 @@ def commit_segment(
             "A different transcript summary already exists for this turn or sequence",
         )
     _validate_segment_write(transcript, request)
-    stored_size, stored_sha256 = wework_transcript_storage.integrity(
-        object_key,
-        request.size_bytes,
-    )
-    if stored_size != request.size_bytes:
-        raise WeworkTranscriptError(
-            "segment_size_mismatch",
-            "Uploaded transcript segment size does not match its manifest",
-            status_code=422,
-        )
-    if stored_sha256 != request.sha256:
-        raise WeworkTranscriptError(
-            "segment_digest_mismatch",
-            "Uploaded transcript segment digest does not match its manifest",
-            status_code=422,
-        )
+    with tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024) as staged:
+        stored_size, stored_sha256 = _stage_segment(source, staged, request.size_bytes)
+        if stored_size != request.size_bytes:
+            raise WeworkTranscriptError(
+                "segment_size_mismatch",
+                "Uploaded transcript segment size does not match its manifest",
+                status_code=422,
+            )
+        if stored_sha256 != request.sha256:
+            raise WeworkTranscriptError(
+                "segment_digest_mismatch",
+                "Uploaded transcript segment digest does not match its manifest",
+                status_code=422,
+            )
+        staged.seek(0)
+        wework_transcript_storage.put_stream(object_key, staged, stored_size)
     db.add(
         WeworkTranscriptArchive(
             transcript_db_id=transcript.id,
@@ -329,7 +311,22 @@ def commit_segment(
     if request.title is not None:
         transcript.title = request.title
     transcript.updated_at = utcnow()
-    db.commit()
+    try:
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        try:
+            wework_transcript_storage.delete(object_key)
+        except WeworkTranscriptStorageError:
+            logger.warning(
+                "Failed to remove uncommitted Wework transcript segment",
+                extra={
+                    "transcript_db_id": transcript.id,
+                    "sequence": request.sequence,
+                },
+                exc_info=True,
+            )
+        raise
     db.refresh(transcript)
     _prune_obsolete_segments(db, transcript.id)
     return transcript, True
@@ -439,7 +436,7 @@ def _validate_fork_request(request: TranscriptLeaseRequest) -> None:
 
 def _validate_segment_write(
     transcript: WeworkTranscript,
-    request: TranscriptSegmentRequest,
+    request: TranscriptSegmentCommitRequest,
 ) -> None:
     _require_lease(transcript, request.client_id, request.fencing_token)
     if request.sequence != request.base_sequence + 1:
@@ -458,7 +455,7 @@ def _validate_segment_write(
 def _segment_object_key(
     user_id: int,
     transcript_id: str,
-    request: TranscriptSegmentRequest,
+    request: TranscriptSegmentCommitRequest,
 ) -> str:
     transcript_key = hashlib.sha256(transcript_id.encode()).hexdigest()
     kind = "snapshot" if "snapshot" in request.format else "delta"
@@ -466,6 +463,22 @@ def _segment_object_key(
         f"users/{user_id}/transcripts/{transcript_key}/"
         f"{request.sequence}-{kind}-{request.sha256}.tgz.aes256gcm"
     )
+
+
+def _stage_segment(
+    source: BinaryIO,
+    target: BinaryIO,
+    declared_size: int,
+) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    size = 0
+    while chunk := source.read(1024 * 1024):
+        size += len(chunk)
+        if size > declared_size:
+            return size, ""
+        digest.update(chunk)
+        target.write(chunk)
+    return size, digest.hexdigest()
 
 
 def _segment_matches(

--- a/backend/app/services/wework_transcript_storage.py
+++ b/backend/app/services/wework_transcript_storage.py
@@ -4,11 +4,9 @@
 
 """Private object storage for archived Wework transcripts."""
 
-import hashlib
-from datetime import UTC, datetime, timedelta
+from typing import BinaryIO, Iterator
 
 from minio import Minio
-from minio.datatypes import PostPolicy
 from urllib3 import PoolManager, Timeout
 
 from app.core.config import settings
@@ -57,63 +55,41 @@ class WeworkTranscriptStorage:
             self._client = client
         return self._client
 
-    def download_url(self, object_key: str) -> str:
+    def stream(self, object_key: str) -> Iterator[bytes]:
         try:
-            return self.client.presigned_get_object(
+            response = self.client.get_object(self.bucket, object_key)
+        except Exception as exc:
+            raise WeworkTranscriptStorageError(
+                "Failed to read transcript segment"
+            ) from exc
+        return self._stream_response(response)
+
+    @staticmethod
+    def _stream_response(response) -> Iterator[bytes]:
+        try:
+            yield from response.stream(amt=1024 * 1024)
+        finally:
+            response.close()
+            response.release_conn()
+
+    def put_stream(
+        self,
+        object_key: str,
+        stream: BinaryIO,
+        size_bytes: int,
+    ) -> None:
+        try:
+            self.client.put_object(
                 self.bucket,
                 object_key,
-                expires=timedelta(
-                    seconds=settings.WEWORK_TRANSCRIPT_DOWNLOAD_URL_EXPIRE_SECONDS
-                ),
+                stream,
+                size_bytes,
+                content_type="application/octet-stream",
             )
         except Exception as exc:
             raise WeworkTranscriptStorageError(
-                "Failed to create archived transcript download URL"
+                "Failed to store transcript segment"
             ) from exc
-
-    def upload_policy(
-        self,
-        object_key: str,
-        size_bytes: int,
-    ) -> tuple[str, dict[str, str], datetime]:
-        try:
-            expires = settings.WEWORK_TRANSCRIPT_DOWNLOAD_URL_EXPIRE_SECONDS
-            expires_at = datetime.now(UTC) + timedelta(seconds=expires)
-            policy = PostPolicy(self.bucket, expires_at)
-            policy.add_equals_condition("key", object_key)
-            policy.add_content_length_range_condition(size_bytes, size_bytes)
-            fields = self.client.presigned_post_policy(policy)
-            endpoint = settings.ATTACHMENT_S3_ENDPOINT.rstrip("/")
-            if not endpoint.startswith(("http://", "https://")):
-                scheme = "https" if settings.ATTACHMENT_S3_USE_SSL else "http"
-                endpoint = f"{scheme}://{endpoint}"
-            upload_url = f"{endpoint}/{self.bucket}"
-            return upload_url, fields, expires_at
-        except Exception as exc:
-            raise WeworkTranscriptStorageError(
-                "Failed to create transcript segment upload policy"
-            ) from exc
-
-    def integrity(self, object_key: str, max_bytes: int) -> tuple[int, str]:
-        response = None
-        try:
-            response = self.client.get_object(self.bucket, object_key)
-            digest = hashlib.sha256()
-            size = 0
-            for chunk in response.stream(amt=1024 * 1024):
-                size += len(chunk)
-                if size > max_bytes:
-                    return size, ""
-                digest.update(chunk)
-            return size, digest.hexdigest()
-        except Exception as exc:
-            raise WeworkTranscriptStorageError(
-                "Failed to verify uploaded transcript segment"
-            ) from exc
-        finally:
-            if response is not None:
-                response.close()
-                response.release_conn()
 
     def delete(self, object_key: str) -> None:
         try:

--- a/backend/tests/api/endpoints/test_wework_transcripts_api.py
+++ b/backend/tests/api/endpoints/test_wework_transcripts_api.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import UTC, datetime, timedelta
+import hashlib
+import json
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -11,6 +12,9 @@ from app.models.wework_transcript import (
     WeworkTranscriptArchive,
     WeworkTranscriptTurn,
 )
+
+SEGMENT_BODY = b"x" * 4096
+SEGMENT_SHA256 = hashlib.sha256(SEGMENT_BODY).hexdigest()
 
 
 def _headers(token: str) -> dict[str, str]:
@@ -34,8 +38,8 @@ def _segment(lease, **overrides):
         "fencingToken": lease["fencingToken"],
         "title": "Synced chat",
         "sequence": 1,
-        "sha256": "a" * 64,
-        "sizeBytes": 4096,
+        "sha256": SEGMENT_SHA256,
+        "sizeBytes": len(SEGMENT_BODY),
         "format": "codex-snapshot.v1.tgz.aes256gcm",
         "turnId": "turn-1",
         "summary": {
@@ -49,9 +53,24 @@ def _segment(lease, **overrides):
     }
 
 
-def _segment_integrity(object_key: str, _max_bytes: int) -> tuple[int, str]:
-    digest = object_key.rsplit("-", 1)[-1].split(".", 1)[0]
-    return 4096, digest
+def _upload(
+    test_client,
+    token,
+    request,
+    content: bytes = SEGMENT_BODY,
+    *,
+    normalize_manifest: bool = True,
+):
+    metadata = dict(request)
+    if normalize_manifest:
+        metadata["sha256"] = hashlib.sha256(content).hexdigest()
+        metadata["sizeBytes"] = len(content)
+    return test_client.post(
+        "/api/wework-transcripts/transcript-1/segments",
+        headers=_headers(token),
+        data={"metadata": json.dumps(metadata)},
+        files={"file": ("segment.tgz.aes256gcm", content)},
+    )
 
 
 def test_commits_native_object_metadata_and_structured_summary(
@@ -68,39 +87,20 @@ def test_commits_native_object_metadata_and_structured_summary(
     assert encryption.json()["algorithm"] == "aes-256-gcm"
     assert len(encryption.json()["key"]) == 44
     storage = wework_transcript_service.wework_transcript_storage
+    uploads = []
     monkeypatch.setattr(
         storage,
-        "upload_policy",
-        lambda key, size_bytes: (
-            f"https://storage.example/{key}",
-            {"key": key, "expected-size": str(size_bytes)},
-            datetime.now(UTC) + timedelta(minutes=5),
-        ),
+        "put_stream",
+        lambda key, stream, size: uploads.append((key, stream.read(), size)),
     )
-    monkeypatch.setattr(storage, "integrity", _segment_integrity)
     request = _segment(lease)
-    prepare = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments/prepare",
-        headers=_headers(test_token),
-        json=request,
-    )
-    assert prepare.status_code == 200
-    assert prepare.json()["uploadUrl"].startswith("https://storage.example/")
-    assert prepare.json()["uploadFields"]["expected-size"] == "4096"
-
-    commit = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments",
-        headers=_headers(test_token),
-        json=request,
-    )
+    commit = _upload(test_client, test_token, request)
     assert commit.status_code == 200
     assert commit.json() == {"currentSequence": 1, "appended": 1}
-    retry = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments",
-        headers=_headers(test_token),
-        json=request,
-    )
+    retry = _upload(test_client, test_token, request)
     assert retry.json() == {"currentSequence": 1, "appended": 0}
+    assert uploads[0][1:] == (SEGMENT_BODY, len(SEGMENT_BODY))
+    assert len(uploads) == 1
 
     transcript = test_db.query(WeworkTranscript).one()
     archive = test_db.query(WeworkTranscriptArchive).one()
@@ -109,7 +109,7 @@ def test_commits_native_object_metadata_and_structured_summary(
     assert transcript.archived_through_sequence == 1
     assert archive.from_sequence == 0
     assert archive.size_bytes == 4096
-    assert archive.storage_key.endswith(f"1-snapshot-{'a' * 64}.tgz.aes256gcm")
+    assert archive.storage_key.endswith(f"1-snapshot-{SEGMENT_SHA256}.tgz.aes256gcm")
     assert turn.sequence == 1
     assert turn.turn_id == "turn-1"
     assert turn.payload["assistantMessage"] == "Done"
@@ -132,14 +132,15 @@ def test_rejects_uploaded_segment_with_mismatched_digest(
     lease = _lease(test_client, test_token)
     monkeypatch.setattr(
         wework_transcript_service.wework_transcript_storage,
-        "integrity",
-        lambda _key, _max_bytes: (4096, "b" * 64),
+        "put_stream",
+        lambda *_args: None,
     )
 
-    response = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments",
-        headers=_headers(test_token),
-        json=_segment(lease),
+    response = _upload(
+        test_client,
+        test_token,
+        _segment(lease, sha256="b" * 64),
+        normalize_manifest=False,
     )
 
     assert response.status_code == 422
@@ -180,7 +181,7 @@ def test_prunes_segments_older_than_previous_snapshot(
     lease = _lease(test_client, test_token)
     storage = wework_transcript_service.wework_transcript_storage
     deleted_keys: list[str] = []
-    monkeypatch.setattr(storage, "integrity", _segment_integrity)
+    monkeypatch.setattr(storage, "put_stream", lambda *_args: None)
     monkeypatch.setattr(storage, "delete", deleted_keys.append)
 
     for sequence in range(1, 21):
@@ -201,11 +202,7 @@ def test_prunes_segments_older_than_previous_snapshot(
                 else "codex-delta.v1.tgz.aes256gcm"
             ),
         )
-        response = test_client.post(
-            "/api/wework-transcripts/transcript-1/segments",
-            headers=_headers(test_token),
-            json=request,
-        )
+        response = _upload(test_client, test_token, request)
         assert response.status_code == 200
 
     retained_sequences = [
@@ -228,7 +225,7 @@ def test_continues_bounded_pruning_on_delta_commits(
     lease = _lease(test_client, test_token)
     storage = wework_transcript_service.wework_transcript_storage
     deleted_keys: list[str] = []
-    monkeypatch.setattr(storage, "integrity", _segment_integrity)
+    monkeypatch.setattr(storage, "put_stream", lambda *_args: None)
     monkeypatch.setattr(storage, "delete", deleted_keys.append)
     monkeypatch.setattr(wework_transcript_service, "MAX_SEGMENTS_PRUNED_PER_COMMIT", 2)
 
@@ -236,10 +233,10 @@ def test_continues_bounded_pruning_on_delta_commits(
     for sequence in range(1, 7):
         is_snapshot = sequence in {1, 4, 5}
         deleted_before_commit = len(deleted_keys)
-        response = test_client.post(
-            "/api/wework-transcripts/transcript-1/segments",
-            headers=_headers(test_token),
-            json=_segment(
+        response = _upload(
+            test_client,
+            test_token,
+            _segment(
                 lease,
                 baseSequence=sequence - 1,
                 sequence=sequence,
@@ -274,7 +271,7 @@ def test_pruning_hides_obsolete_metadata_and_retries_object_deletion(
 
     lease = _lease(test_client, test_token)
     storage = wework_transcript_service.wework_transcript_storage
-    monkeypatch.setattr(storage, "integrity", _segment_integrity)
+    monkeypatch.setattr(storage, "put_stream", lambda *_args: None)
     failures = 1
 
     def delete(_key):
@@ -285,10 +282,10 @@ def test_pruning_hides_obsolete_metadata_and_retries_object_deletion(
 
     monkeypatch.setattr(storage, "delete", delete)
     for sequence in (1, 2, 3):
-        response = test_client.post(
-            "/api/wework-transcripts/transcript-1/segments",
-            headers=_headers(test_token),
-            json=_segment(
+        response = _upload(
+            test_client,
+            test_token,
+            _segment(
                 lease,
                 baseSequence=sequence - 1,
                 sequence=sequence,
@@ -334,17 +331,17 @@ def test_pruning_hides_metadata_when_database_delete_commit_fails(
 
     lease = _lease(test_client, test_token)
     storage = wework_transcript_service.wework_transcript_storage
-    monkeypatch.setattr(storage, "integrity", _segment_integrity)
+    monkeypatch.setattr(storage, "put_stream", lambda *_args: None)
     monkeypatch.setattr(
         storage,
         "delete",
         lambda _key: (_ for _ in ()).throw(WeworkTranscriptStorageError("defer")),
     )
     for sequence in (1, 2, 3):
-        response = test_client.post(
-            "/api/wework-transcripts/transcript-1/segments",
-            headers=_headers(test_token),
-            json=_segment(
+        response = _upload(
+            test_client,
+            test_token,
+            _segment(
                 lease,
                 baseSequence=sequence - 1,
                 sequence=sequence,
@@ -396,32 +393,33 @@ def test_pruning_hides_metadata_when_database_delete_commit_fails(
     assert test_db.query(WeworkTranscriptArchive).filter_by(id=obsolete.id).count() == 0
 
 
-def test_rejects_stale_sequence_before_upload(test_client, test_token, monkeypatch):
+def test_rejects_conflicting_segment_before_object_storage(
+    test_client, test_token, monkeypatch
+):
     from app.services import wework_transcript_service
 
     lease = _lease(test_client, test_token)
+    uploads = []
     monkeypatch.setattr(
         wework_transcript_service.wework_transcript_storage,
-        "integrity",
-        _segment_integrity,
+        "put_stream",
+        lambda *args: uploads.append(args),
     )
-    first = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments",
-        headers=_headers(test_token),
-        json=_segment(lease),
-    )
+    first = _upload(test_client, test_token, _segment(lease))
     assert first.status_code == 200
-    stale = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments/prepare",
-        headers=_headers(test_token),
-        json=_segment(
+    assert len(uploads) == 1
+    stale = _upload(
+        test_client,
+        test_token,
+        _segment(
             lease,
             sha256="b" * 64,
             format="codex-delta.v1.tgz.aes256gcm",
         ),
     )
     assert stale.status_code == 409
-    assert stale.json()["detail"]["code"] == "sequence_conflict"
+    assert stale.json()["detail"]["code"] == "segment_conflict"
+    assert len(uploads) == 1
 
 
 def test_rejects_mismatched_summary_for_committed_segment(
@@ -432,21 +430,17 @@ def test_rejects_mismatched_summary_for_committed_segment(
     lease = _lease(test_client, test_token)
     monkeypatch.setattr(
         wework_transcript_service.wework_transcript_storage,
-        "integrity",
-        _segment_integrity,
+        "put_stream",
+        lambda *_args: None,
     )
     request = _segment(lease)
-    committed = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments",
-        headers=_headers(test_token),
-        json=request,
-    )
+    committed = _upload(test_client, test_token, request)
     assert committed.status_code == 200
 
-    conflict = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments",
-        headers=_headers(test_token),
-        json={
+    conflict = _upload(
+        test_client,
+        test_token,
+        {
             **request,
             "summary": {
                 **request["summary"],
@@ -477,15 +471,11 @@ def test_reports_turn_conflict_when_turn_identity_exists_at_another_sequence(
     test_db.commit()
     monkeypatch.setattr(
         wework_transcript_service.wework_transcript_storage,
-        "integrity",
-        _segment_integrity,
+        "put_stream",
+        lambda *_args: None,
     )
 
-    conflict = test_client.post(
-        "/api/wework-transcripts/transcript-1/segments",
-        headers=_headers(test_token),
-        json=_segment(lease),
-    )
+    conflict = _upload(test_client, test_token, _segment(lease))
 
     assert conflict.status_code == 409
     assert conflict.json()["detail"]["code"] == "turn_conflict"
@@ -519,7 +509,7 @@ def test_creates_branch_without_copying_parent_objects(
     assert test_db.query(WeworkTranscriptTurn).count() == 0
 
 
-def test_download_uses_presigned_object_url(
+def test_download_streams_the_object_through_backend(
     test_client, test_token, test_db, monkeypatch
 ):
     from app.api.endpoints import wework_transcripts
@@ -539,12 +529,14 @@ def test_download_uses_presigned_object_url(
     test_db.commit()
     monkeypatch.setattr(
         wework_transcripts.wework_transcript_storage,
-        "download_url",
-        lambda key: f"https://storage.example/{key}",
+        "stream",
+        lambda _key: iter([b"encrypted", b"!!"]),
     )
     response = test_client.get(
         f"/api/wework-transcripts/transcript-1/archives/{archive.id}/download",
         headers=_headers(test_token),
     )
     assert response.status_code == 200
-    assert response.json()["downloadUrl"].startswith("https://storage.example/")
+    assert response.headers["content-type"] == "application/octet-stream"
+    assert response.headers["content-length"] == "10"
+    assert response.content == b"encrypted!!"

--- a/backend/tests/services/test_wework_transcript_storage.py
+++ b/backend/tests/services/test_wework_transcript_storage.py
@@ -4,20 +4,42 @@
 
 """Tests for archived Wework transcript object storage."""
 
-import hashlib
+from io import BytesIO
 
 from app.services.wework_transcript_storage import WeworkTranscriptStorage
+
+
+class _ObjectClient:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, str, bytes, int, str]] = []
+        self.response = None
+
+    def put_object(
+        self,
+        bucket: str,
+        object_key: str,
+        stream,
+        size_bytes: int,
+        *,
+        content_type: str,
+    ) -> None:
+        self.requests.append(
+            (bucket, object_key, stream.read(), size_bytes, content_type)
+        )
+
+    def get_object(self, bucket: str, object_key: str):
+        self.requests.append((bucket, object_key))
+        return self.response
 
 
 class _StreamingResponse:
     def __init__(self, chunks: list[bytes]) -> None:
         self.chunks = chunks
-        self.stream_amount: int | None = None
         self.closed = False
         self.released = False
 
     def stream(self, *, amt: int):
-        self.stream_amount = amt
+        assert amt == 1024 * 1024
         yield from self.chunks
 
     def close(self) -> None:
@@ -27,27 +49,8 @@ class _StreamingResponse:
         self.released = True
 
 
-class _ObjectClient:
-    def __init__(self, response: _StreamingResponse) -> None:
-        self.response = response
-        self.requests: list[tuple[str, str]] = []
-
-    def get_object(self, bucket: str, object_key: str) -> _StreamingResponse:
-        self.requests.append((bucket, object_key))
-        return self.response
-
-
-class _PolicyClient:
-    def __init__(self) -> None:
-        self.policy = None
-
-    def presigned_post_policy(self, policy):
-        self.policy = policy
-        return {"key": "user/segment.tgz.enc", "policy": "signed"}
-
-
-def test_upload_policy_requires_the_declared_object_size(monkeypatch) -> None:
-    client = _PolicyClient()
+def test_put_stream_stores_the_declared_object(monkeypatch) -> None:
+    client = _ObjectClient()
     storage = WeworkTranscriptStorage()
     storage._client = client
     monkeypatch.setattr(
@@ -55,52 +58,28 @@ def test_upload_policy_requires_the_declared_object_size(monkeypatch) -> None:
         "WEWORK_TRANSCRIPT_S3_BUCKET",
         "transcripts",
     )
-    monkeypatch.setattr(
-        "app.services.wework_transcript_storage.settings.ATTACHMENT_S3_ENDPOINT",
-        "storage.example",
-    )
-    monkeypatch.setattr(
-        "app.services.wework_transcript_storage.settings.ATTACHMENT_S3_USE_SSL",
-        True,
-    )
-
-    upload_url, fields, _expires_at = storage.upload_policy(
-        "user/segment.tgz.enc",
-        4096,
-    )
-
-    assert upload_url == "https://storage.example/transcripts"
-    assert fields["policy"] == "signed"
-    assert client.policy._conditions["eq"]["key"] == "user/segment.tgz.enc"
-    assert client.policy._lower_limit == 4096
-    assert client.policy._upper_limit == 4096
-
-
-def test_integrity_streams_object_and_releases_connection(monkeypatch) -> None:
-    response = _StreamingResponse([b"native-", b"transcript"])
-    client = _ObjectClient(response)
-    storage = WeworkTranscriptStorage()
-    storage._client = client
-    monkeypatch.setattr(
-        "app.services.wework_transcript_storage.settings."
-        "WEWORK_TRANSCRIPT_S3_BUCKET",
-        "transcripts",
-    )
-
-    size, digest = storage.integrity("user/segment.tgz.enc", 1024)
-
     content = b"native-transcript"
-    assert size == len(content)
-    assert digest == hashlib.sha256(content).hexdigest()
-    assert client.requests == [("transcripts", "user/segment.tgz.enc")]
-    assert response.stream_amount == 1024 * 1024
-    assert response.closed is True
-    assert response.released is True
+    storage.put_stream(
+        "user/segment.tgz.enc",
+        BytesIO(content),
+        len(content),
+    )
+
+    assert client.requests == [
+        (
+            "transcripts",
+            "user/segment.tgz.enc",
+            content,
+            len(content),
+            "application/octet-stream",
+        )
+    ]
 
 
-def test_integrity_stops_after_the_object_exceeds_the_limit(monkeypatch) -> None:
-    response = _StreamingResponse([b"1234", b"5678", b"ignored"])
-    client = _ObjectClient(response)
+def test_stream_reads_and_releases_the_object(monkeypatch) -> None:
+    client = _ObjectClient()
+    response = _StreamingResponse([b"native-", b"transcript"])
+    client.response = response
     storage = WeworkTranscriptStorage()
     storage._client = client
     monkeypatch.setattr(
@@ -109,9 +88,7 @@ def test_integrity_stops_after_the_object_exceeds_the_limit(monkeypatch) -> None
         "transcripts",
     )
 
-    size, digest = storage.integrity("user/oversized.tgz.enc", 6)
-
-    assert size == 8
-    assert digest == ""
+    assert b"".join(storage.stream("user/segment.tgz.enc")) == b"native-transcript"
+    assert client.requests == [("transcripts", "user/segment.tgz.enc")]
     assert response.closed is True
     assert response.released is True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,17 @@ services:
     networks:
       - wegent-network
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD:-123456}"]
+      test:
+        [
+          "CMD",
+          "mysqladmin",
+          "ping",
+          "-h",
+          "localhost",
+          "-u",
+          "root",
+          "-p${MYSQL_ROOT_PASSWORD:-123456}",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -61,7 +71,8 @@ services:
     networks:
       - wegent-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
+      test:
+        ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -69,7 +80,7 @@ services:
 
   backend:
     # build:
-      # dockerfile: docker/backend/Dockerfile
+    # dockerfile: docker/backend/Dockerfile
     image: ghcr.io/wecode-ai/wegent-backend:${WEGENT_IMAGE_TAG:-latest}
     pull_policy: ${DOCKER_PULL_POLICY:-always}
     container_name: wegent-backend
@@ -130,6 +141,13 @@ services:
       TEAM_SHARE_QUERY_PARAM: ${TEAM_SHARE_QUERY_PARAM:-teamShare}
       WEGENT_SOCKET_URL: ${WEGENT_SOCKET_URL:-http://localhost:8000}
       ATTACHMENT_PUBLIC_BASE_URL: ${ATTACHMENT_PUBLIC_BASE_URL:-}
+      ATTACHMENT_S3_ENDPOINT: ${ATTACHMENT_S3_ENDPOINT:-}
+      ATTACHMENT_S3_ACCESS_KEY: ${ATTACHMENT_S3_ACCESS_KEY:-}
+      ATTACHMENT_S3_SECRET_KEY: ${ATTACHMENT_S3_SECRET_KEY:-}
+      ATTACHMENT_S3_REGION: ${ATTACHMENT_S3_REGION:-us-east-1}
+      ATTACHMENT_S3_USE_SSL: "${ATTACHMENT_S3_USE_SSL:-true}"
+      WEWORK_TRANSCRIPT_S3_BUCKET: ${WEWORK_TRANSCRIPT_S3_BUCKET:-wework-transcripts}
+      WEWORK_TRANSCRIPT_ENCRYPTION_SECRET: ${WEWORK_TRANSCRIPT_ENCRYPTION_SECRET:-}
       # Chat Shell Configuration (uncomment to use HTTP mode)
       CHAT_SHELL_MODE: ${CHAT_SHELL_MODE:-http}
       CHAT_SHELL_URL: ${CHAT_SHELL_URL:-http://chat_shell:8100}

--- a/docs/en/wework/developer-guide/wework-transcript-sync.md
+++ b/docs/en/wework/developer-guide/wework-transcript-sync.md
@@ -19,13 +19,15 @@ The Backend uses three tables:
 | `wework_transcript_archives` | Immutable native segment sequence, object key, SHA-256, size, and format |
 | `wework_transcript_turns`    | One structured finalized-turn summary using the previous data contract   |
 
-The Executor encrypts bodies with AES-256-GCM before uploading them directly to
-the private `wework-transcripts` object bucket. The
-`wework_transcript_turns.payload` JSON retains the previous protocol's user
-messages, final assistant text, reasoning summary, completion state, and task
-ID, but not the complete tool protocol, usage, rollout JSONL, or workspace
-files. Each turn has its own row instead of appending an entire transcript into
-one field; segmented tgz objects carry full-fidelity capacity and exact restore.
+The Executor encrypts bodies with AES-256-GCM before uploading them through the
+authenticated Backend API. The Backend writes ciphertext to the private
+`wework-transcripts` object bucket; desktop clients never receive object-store
+endpoints, credentials, or presigned URLs. The `wework_transcript_turns.payload`
+JSON retains the previous protocol's user messages, final assistant text,
+reasoning summary, completion state, and task ID, but not the complete tool
+protocol, usage, rollout JSONL, or workspace files. Each turn has its own row
+instead of appending an entire transcript into one field; segmented tgz objects
+carry full-fidelity capacity and exact restore.
 
 The archive index, turn summary, and transcript head for one sequence commit in
 one MySQL transaction. A retry is idempotent only when both object metadata and
@@ -45,8 +47,11 @@ nonce for different plaintext.
 
 Each cloud sequence maps to exactly one object:
 
-- Sequence 1, every tenth sequence, and sequence 1 of a conflict branch are
-  full encrypted `codex-snapshot.v1.tgz.aes256gcm` snapshots.
+- Sequence 1, every tenth sequence, sequence 1 of a conflict branch, and the
+  first continuation after a cross-device restore are full encrypted
+  `codex-snapshot.v1.tgz.aes256gcm` snapshots. Restore rewrites the local thread
+  ID and workspace path, so a new snapshot establishes a portable byte
+  baseline.
 - Other sequences are encrypted `codex-delta.v1.tgz.aes256gcm`
   increments.
 - Every segment also carries a workspace overlay so recent files are not lost.
@@ -80,7 +85,7 @@ stateDiagram-v2
     LocalReady --> OfflinePending: Backend unavailable
     OfflinePending --> LeaseHeld: connection restored
     LeaseHeld --> SegmentBuilt: build and encrypt snapshot or rollout delta
-    SegmentBuilt --> ObjectUploaded: PUT presigned object URL
+    SegmentBuilt --> ObjectUploaded: stream ciphertext through Backend
     ObjectUploaded --> MetadataCommitted: atomically commit object index, summary, and head
     MetadataCommitted --> LocalReady: record rollout offset, clear outbox, release lease
 
@@ -90,7 +95,7 @@ stateDiagram-v2
     BranchSnapshot --> LeaseHeld: create deterministic fork transcript
 
     [*] --> RestoreRequired: transcript missing or behind locally
-    RestoreRequired --> Downloading: select latest snapshot and contiguous deltas
+    RestoreRequired --> Downloading: stream latest snapshot and contiguous deltas through Backend
     Downloading --> Staging: download and verify SHA-256
     Staging --> Bound: restore workspace, rollout, thread metadata, and dynamic tools
     Staging --> RestoreRequired: validation failed; remove staging
@@ -137,19 +142,18 @@ GitHub CI.
 
 The authenticated prefix is `/api/wework-transcripts`:
 
-| Method and path                           | Purpose                                           |
-| ----------------------------------------- | ------------------------------------------------- |
-| `GET /`                                   | List transcripts and native segment metadata      |
-| `GET /{id}`                               | Read one transcript                               |
-| `GET /{id}/turns`                         | Page through structured finalized-turn summaries  |
-| `GET /{id}/encryption-key`                | Obtain the current user's transcript cipher key   |
-| `POST /{id}/lease`                        | Create a transcript or acquire its writer lease   |
-| `PUT /{id}/lease/{token}`                 | Renew a lease                                     |
-| `POST /{id}/lease/release`                | Release a lease                                   |
-| `POST /{id}/segments/prepare`             | Validate sequence and create a size-bounded POST  |
-| `POST /{id}/segments`                     | Atomically commit object index, summary, and head |
-| `POST /{id}/archive`                      | Mark a transcript archived                        |
-| `GET /{id}/archives/{archiveId}/download` | Create a short-lived signed download URL          |
+| Method and path                           | Purpose                                            |
+| ----------------------------------------- | -------------------------------------------------- |
+| `GET /`                                   | List transcripts and native segment metadata       |
+| `GET /{id}`                               | Read one transcript                                |
+| `GET /{id}/turns`                         | Page through structured finalized-turn summaries   |
+| `GET /{id}/encryption-key`                | Obtain the current user's transcript cipher key    |
+| `POST /{id}/lease`                        | Create a transcript or acquire its writer lease    |
+| `PUT /{id}/lease/{token}`                 | Renew a lease                                      |
+| `POST /{id}/lease/release`                | Release a lease                                    |
+| `POST /{id}/segments`                     | Receive ciphertext and commit index, summary, head |
+| `POST /{id}/archive`                      | Mark a transcript archived                         |
+| `GET /{id}/archives/{archiveId}/download` | Stream ciphertext through the Backend              |
 
 Object keys contain a SHA-256 digest of the transcript ID rather than the raw
 identifier.
@@ -158,11 +162,10 @@ identifier.
 
 Object storage reuses the `ATTACHMENT_S3_*` connection settings:
 
-| Environment variable                            | Default              | Purpose                                    |
-| ----------------------------------------------- | -------------------- | ------------------------------------------ |
-| `WEWORK_TRANSCRIPT_S3_BUCKET`                   | `wework-transcripts` | Private native transcript segment bucket   |
-| `WEWORK_TRANSCRIPT_DOWNLOAD_URL_EXPIRE_SECONDS` | `900`                | Upload/download signed URL lifetime        |
-| `WEWORK_TRANSCRIPT_ENCRYPTION_SECRET`           | empty                | Stable high-entropy root for per-user keys |
+| Environment variable                  | Default              | Purpose                                    |
+| ------------------------------------- | -------------------- | ------------------------------------------ |
+| `WEWORK_TRANSCRIPT_S3_BUCKET`         | `wework-transcripts` | Private native transcript segment bucket   |
+| `WEWORK_TRANSCRIPT_ENCRYPTION_SECRET` | empty                | Stable high-entropy root for per-user keys |
 
 This design reuses the existing three transcript tables. It adds no Alembic
 migration and requires no schema change for existing deployments. If object

--- a/docs/zh/wework/developer-guide/wework-transcript-sync.md
+++ b/docs/zh/wework/developer-guide/wework-transcript-sync.md
@@ -18,11 +18,12 @@ Backend 使用三张表：
 | `wework_transcript_archives` | 不可变原生 segment 的 sequence、对象 key、SHA-256、大小和格式 |
 | `wework_transcript_turns`    | 每个已完成回合的结构化摘要，沿用旧版本的数据契约              |
 
-正文先在 Executor 中使用 AES-256-GCM 加密，再直接上传到私有
-`wework-transcripts` 对象存储。MySQL 的 `wework_transcript_turns.payload` 会按回合
-保存原有协议中的用户消息、助手最终文本、reasoning 摘要、完成状态和任务 ID，但不保存
-完整工具协议、usage、rollout JSONL 或工作区文件。摘要是一回合一行 JSON，不会把整个
-transcript 持续追加进单个字段；完整数据容量和精确恢复均由分段 tgz 对象承担。
+正文先在 Executor 中使用 AES-256-GCM 加密，再通过已认证的 Backend API 上传。Backend
+负责把密文写入私有 `wework-transcripts` 对象存储；桌面客户端不会获得对象存储地址、
+凭据或预签名 URL。MySQL 的 `wework_transcript_turns.payload` 会按回合保存原有协议中的
+用户消息、助手最终文本、reasoning 摘要、完成状态和任务 ID，但不保存完整工具协议、
+usage、rollout JSONL 或工作区文件。摘要是一回合一行 JSON，不会把整个 transcript 持续
+追加进单个字段；完整数据容量和精确恢复均由分段 tgz 对象承担。
 
 同一 sequence 的 archive 索引、turn 摘要和 transcript head 在一个 MySQL 事务中提交。
 仅当对象元数据与摘要都完全一致时，重复提交才视为幂等；任一侧缺失或不一致都会报冲突，
@@ -37,8 +38,9 @@ sequence 和格式。相同内容重试会得到相同密文，仍可通过 SHA-
 
 每个云端 sequence 恰好对应一个对象：
 
-- 第 1 个 sequence、每第 10 个 sequence 和冲突分支的第 1 个 sequence 是完整加密快照
-  `codex-snapshot.v1.tgz.aes256gcm`。
+- 第 1 个 sequence、每第 10 个 sequence、冲突分支的第 1 个 sequence，以及跨设备恢复
+  后首次继续对话的 sequence，是完整加密快照 `codex-snapshot.v1.tgz.aes256gcm`。恢复
+  会重写本机 thread ID 和工作区路径，因此必须用新快照建立新的可移植字节基线。
 - 其他 sequence 是加密增量 `codex-delta.v1.tgz.aes256gcm`。
 - 每个 segment 同时携带工作区覆盖层，避免只恢复会话却丢失最近文件。
 - 工作区打包会排除 `.git`、`node_modules`、构建产物和常见缓存目录，避免重复上传
@@ -66,7 +68,7 @@ stateDiagram-v2
     LocalReady --> OfflinePending: Backend 不可达
     OfflinePending --> LeaseHeld: 网络恢复
     LeaseHeld --> SegmentBuilt: 生成并加密快照或 rollout 增量
-    SegmentBuilt --> ObjectUploaded: PUT 预签名对象地址
+    SegmentBuilt --> ObjectUploaded: 经 Backend 流式上传密文
     ObjectUploaded --> MetadataCommitted: 同事务提交对象索引、回合摘要和 head
     MetadataCommitted --> LocalReady: 记录 rollout offset、清理 outbox、释放租约
 
@@ -76,7 +78,7 @@ stateDiagram-v2
     BranchSnapshot --> LeaseHeld: 创建确定性 fork transcript
 
     [*] --> RestoreRequired: 本机没有该 transcript 或本机落后
-    RestoreRequired --> Downloading: 选择最近快照和连续增量
+    RestoreRequired --> Downloading: 经 Backend 下载最近快照和连续增量
     Downloading --> Staging: 下载并校验 SHA-256
     Staging --> Bound: 恢复工作区、rollout、thread 元数据和动态工具
     Staging --> RestoreRequired: 任一校验失败，删除 staging
@@ -113,19 +115,18 @@ GitHub CI 的执行前提。
 
 认证前缀为 `/api/wework-transcripts`：
 
-| 方法与路径                                | 用途                                  |
-| ----------------------------------------- | ------------------------------------- |
-| `GET /`                                   | 列出 transcript 和原生 segment 元数据 |
-| `GET /{id}`                               | 读取一个 transcript                   |
-| `GET /{id}/turns`                         | 分页读取结构化回合摘要                |
-| `GET /{id}/encryption-key`                | 获取当前用户的 transcript 加解密密钥  |
-| `POST /{id}/lease`                        | 创建 transcript 或获取写租约          |
-| `PUT /{id}/lease/{token}`                 | 续租                                  |
-| `POST /{id}/lease/release`                | 释放租约                              |
-| `POST /{id}/segments/prepare`             | 校验 sequence 并生成限长预签名 POST   |
-| `POST /{id}/segments`                     | 同事务提交对象索引、回合摘要和 head   |
-| `POST /{id}/archive`                      | 标记 transcript 为 archived           |
-| `GET /{id}/archives/{archiveId}/download` | 生成短期签名下载地址                  |
+| 方法与路径                                | 用途                                    |
+| ----------------------------------------- | --------------------------------------- |
+| `GET /`                                   | 列出 transcript 和原生 segment 元数据   |
+| `GET /{id}`                               | 读取一个 transcript                     |
+| `GET /{id}/turns`                         | 分页读取结构化回合摘要                  |
+| `GET /{id}/encryption-key`                | 获取当前用户的 transcript 加解密密钥    |
+| `POST /{id}/lease`                        | 创建 transcript 或获取写租约            |
+| `PUT /{id}/lease/{token}`                 | 续租                                    |
+| `POST /{id}/lease/release`                | 释放租约                                |
+| `POST /{id}/segments`                     | 接收密文并提交对象索引、回合摘要和 head |
+| `POST /{id}/archive`                      | 标记 transcript 为 archived             |
+| `GET /{id}/archives/{archiveId}/download` | 通过 Backend 流式下载密文               |
 
 对象 key 使用 transcript ID 的 SHA-256 摘要，不暴露原始 transcript 标识。
 
@@ -133,11 +134,10 @@ GitHub CI 的执行前提。
 
 对象存储复用 `ATTACHMENT_S3_*` 连接配置：
 
-| 环境变量                                        | 默认值               | 说明                           |
-| ----------------------------------------------- | -------------------- | ------------------------------ |
-| `WEWORK_TRANSCRIPT_S3_BUCKET`                   | `wework-transcripts` | 私有原生会话 segment bucket    |
-| `WEWORK_TRANSCRIPT_DOWNLOAD_URL_EXPIRE_SECONDS` | `900`                | 上传/下载签名地址有效期        |
-| `WEWORK_TRANSCRIPT_ENCRYPTION_SECRET`           | 空                   | 派生每用户密钥的稳定高熵根密钥 |
+| 环境变量                              | 默认值               | 说明                           |
+| ------------------------------------- | -------------------- | ------------------------------ |
+| `WEWORK_TRANSCRIPT_S3_BUCKET`         | `wework-transcripts` | 私有原生会话 segment bucket    |
+| `WEWORK_TRANSCRIPT_ENCRYPTION_SECRET` | 空                   | 派生每用户密钥的稳定高熵根密钥 |
 
 本方案直接复用已有的三张 transcript 表，不新增 Alembic migration，也不要求已有部署
 调整数据库结构。对象存储不可用时，segment 不会提交到 MySQL，outbox 继续保留定位

--- a/executor/src/runtime_work/handler/tests.rs
+++ b/executor/src/runtime_work/handler/tests.rs
@@ -3922,6 +3922,56 @@ fn transcript_sync_requires_restore_before_native_thread_exists() {
     let _ = fs::remove_file(index_path);
 }
 
+#[test]
+fn transcript_sync_rekeys_the_local_task_when_a_conflicting_turn_forks() {
+    let index_path = temp_runtime_work_index_path("transcript-sync-fork");
+    let mut handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+    handler.store = RuntimeWorkStore::new(index_path.clone());
+    let mut link = RuntimeTaskLink::new_pending(
+        "parent-transcript".to_owned(),
+        "/tmp/project".to_owned(),
+        "Local conflicting branch".to_owned(),
+    );
+    link.thread_id = Some("local-thread".to_owned());
+    link.runtime_handle["cloudTranscript"] = json!({
+        "transcriptId": "parent-transcript",
+        "importedThrough": 3,
+        "rolloutBytes": 120,
+    });
+    handler.upsert_local_task(link);
+
+    let result = handler
+        .acknowledge_transcript_turn(json!({
+            "taskId": "parent-transcript",
+            "transcriptId": "fork-transcript",
+            "parentTranscriptId": "parent-transcript",
+            "sequence": 1,
+            "rolloutEnd": 240,
+        }))
+        .expect("fork acknowledgement should move the local task");
+
+    assert_eq!(result["taskId"], "fork-transcript");
+    assert_eq!(result["available"], true);
+    assert!(handler.local_task_link("parent-transcript").is_none());
+    let branch = handler
+        .local_task_link("fork-transcript")
+        .expect("forked local task should use the branch transcript ID");
+    assert_eq!(branch.thread_id.as_deref(), Some("local-thread"));
+    assert_eq!(
+        branch.runtime_handle["cloudTranscript"]["transcriptId"],
+        "fork-transcript"
+    );
+    assert_eq!(
+        branch.runtime_handle["cloudTranscript"]["importedThrough"],
+        1
+    );
+    assert_eq!(
+        branch.runtime_handle["cloudTranscript"]["requiresSnapshot"],
+        false
+    );
+    let _ = fs::remove_file(index_path);
+}
+
 #[tokio::test]
 async fn transcript_rejects_conflicting_cursors_before_task_lookup() {
     let handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");

--- a/executor/src/runtime_work/handler/transcript_sync.rs
+++ b/executor/src/runtime_work/handler/transcript_sync.rs
@@ -98,7 +98,8 @@ impl RuntimeWorkRpcHandler {
         let snapshot = payload
             .get("snapshot")
             .and_then(Value::as_bool)
-            .unwrap_or(false);
+            .unwrap_or(false)
+            || requires_snapshot(&link);
         let encryption_key = string_field(&payload, "encryptionKey")
             .or_else(|| string_field(&payload, "encryption_key"))
             .ok_or_else(|| {
@@ -243,21 +244,34 @@ impl RuntimeWorkRpcHandler {
         let rollout_end = alias_u64(&payload, "rolloutEnd", "rollout_end")?;
         let parent_id = string_field(&payload, "parentTranscriptId")
             .or_else(|| string_field(&payload, "parent_transcript_id"));
-        let updated = self.store.update_task(&task_id, |link| {
+        let should_rekey = self.local_task_link(&task_id).is_some_and(|link| {
+            task_id != transcript_id
+                && parent_id.as_deref() == cloud_transcript_id(&link).as_deref()
+        });
+        let update = |link: &mut RuntimeTaskLink| {
             let current_id = cloud_transcript_id(link);
             if current_id.as_deref() == Some(transcript_id.as_str())
                 || current_id.is_none()
                 || parent_id.as_deref() == current_id.as_deref()
             {
-                set_cloud_transcript(link, &transcript_id, sequence, rollout_end);
+                set_cloud_transcript(link, &transcript_id, sequence, rollout_end, false);
                 link.updated_at = now_ms();
             }
-        });
+        };
+        let updated = if should_rekey {
+            self.store.rekey_task(&task_id, &transcript_id, update)
+        } else {
+            self.store.update_task(&task_id, update)
+        };
         let Some(link) = updated else {
             return Ok(status(&task_id, &transcript_id, false, 0, "task_missing"));
         };
+        if should_rekey {
+            emit_runtime_work_changed(&self.event_tx, &self.device_id, &task_id);
+            emit_runtime_work_changed(&self.event_tx, &self.device_id, &transcript_id);
+        }
         Ok(status(
-            &task_id,
+            &link.local_task_id,
             &transcript_id,
             transcript_matches(&link, &transcript_id),
             imported_through(&link),
@@ -282,6 +296,7 @@ fn restored_task_link(
         transcript_id,
         restored.sequence,
         restored.rollout_end,
+        true,
     );
     link
 }
@@ -352,11 +367,20 @@ fn synchronized_rollout_bytes(link: &RuntimeTaskLink) -> u64 {
         .unwrap_or(0)
 }
 
+fn requires_snapshot(link: &RuntimeTaskLink) -> bool {
+    link.runtime_handle
+        .get(CLOUD_TRANSCRIPT_HANDLE_KEY)
+        .and_then(|value| value.get("requiresSnapshot"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
 fn set_cloud_transcript(
     link: &mut RuntimeTaskLink,
     transcript_id: &str,
     sequence: u64,
     rollout_bytes: u64,
+    requires_snapshot: bool,
 ) {
     if !link.runtime_handle.is_object() {
         link.runtime_handle = json!({});
@@ -365,6 +389,7 @@ fn set_cloud_transcript(
         "transcriptId": transcript_id,
         "importedThrough": sequence,
         "rolloutBytes": rollout_bytes,
+        "requiresSnapshot": requires_snapshot,
     });
 }
 
@@ -372,7 +397,10 @@ fn set_cloud_transcript(
 mod tests {
     use std::path::PathBuf;
 
-    use super::{cloud_transcript_id, imported_through, restored_task_link, RestoredTranscript};
+    use super::{
+        cloud_transcript_id, imported_through, requires_snapshot, restored_task_link,
+        RestoredTranscript,
+    };
 
     #[test]
     fn restore_preserves_the_requested_local_task_identity() {
@@ -392,5 +420,6 @@ mod tests {
             Some("cloud-transcript")
         );
         assert_eq!(imported_through(&link), 4);
+        assert!(requires_snapshot(&link));
     }
 }

--- a/executor/src/runtime_work/store.rs
+++ b/executor/src/runtime_work/store.rs
@@ -406,6 +406,27 @@ impl RuntimeWorkStore {
         self.update_task_with_persistence(local_task_id, updater, true)
     }
 
+    pub fn rekey_task(
+        &self,
+        local_task_id: &str,
+        new_local_task_id: &str,
+        updater: impl FnOnce(&mut RuntimeTaskLink),
+    ) -> Option<RuntimeTaskLink> {
+        self.refresh_index_from_disk_if_changed();
+        let mut index = self.index.lock().ok()?;
+        if local_task_id != new_local_task_id && index.tasks.contains_key(new_local_task_id) {
+            return None;
+        }
+        let mut task = index.tasks.remove(local_task_id)?;
+        updater(&mut task);
+        task.local_task_id = new_local_task_id.to_owned();
+        let updated = task.clone();
+        index.tasks.insert(new_local_task_id.to_owned(), task);
+        drop(index);
+        self.persist_current_index();
+        Some(updated)
+    }
+
     fn update_task_with_persistence(
         &self,
         local_task_id: &str,

--- a/wework/dsh/executor-runtime/index.js
+++ b/wework/dsh/executor-runtime/index.js
@@ -24,6 +24,7 @@ export async function apply(ctx) {
       console.error('[wework-executor-runtime] transcript subscriber failed', error)
     },
     readTurn: (turn, options) => exportExecutorTranscript(client, turn, options),
+    summarizeTurn: turn => readExecutorTurn(client, turn),
   })
   const projector = new ExecutorSessionProjector(ctx.sessions, {
     onTurnCompleted: turn => transcriptSource.publish(turn),
@@ -80,7 +81,9 @@ export function createTranscriptTarget(client) {
 }
 
 export async function exportExecutorTranscript(client, turn, options = {}) {
-  const summarized = await readExecutorTurn(client, turn)
+  const summarized = options.summary
+    ? { ...turn, payload: options.summary }
+    : await readExecutorTurn(client, turn)
   const exported = await client.request('runtime.tasks.transcript.export', {
     transcriptId: turn.transcriptId,
     taskId: turn.taskId,
@@ -96,6 +99,7 @@ export async function readExecutorTurn(client, turn) {
   let beforeCursor
   const pages = []
   const observedCursors = new Set()
+  let taskAvailable = false
   for (;;) {
     const transcript = await client.request('runtime.tasks.transcript', {
       taskId: turn.taskId,
@@ -103,6 +107,7 @@ export async function readExecutorTurn(client, turn) {
       ...(beforeCursor ? { beforeCursor } : {}),
     })
     const turns = Array.isArray(transcript?.turns) ? transcript.turns : []
+    taskAvailable ||= executorTranscriptTaskAvailable(transcript, turns)
     pages.push(turns)
     const matched = turn.executorTurnId
       ? turns.find(candidate => candidate?.id === turn.executorTurnId)
@@ -121,8 +126,20 @@ export async function readExecutorTurn(client, turn) {
     const matched = orderedTurns[turn.sequence - 1]
     if (matched) return { ...turn, payload: executorTurnPayload(matched) }
   }
-  throw new Error(
+  const code = taskAvailable ? 'transcript_turn_missing' : 'transcript_task_missing'
+  throw new ExecutorRuntimeError(
+    code,
     `Executor transcript turn is unavailable: ${turn.taskId}#${turn.executorTurnId ?? turn.sequence}`
+  )
+}
+
+function executorTranscriptTaskAvailable(transcript, turns) {
+  if (turns.length > 0) return true
+  if (typeof transcript?.workspacePath === 'string' && transcript.workspacePath.trim()) return true
+  return (
+    typeof transcript?.runtime === 'string' &&
+    transcript.runtime.trim() !== '' &&
+    transcript.runtime !== 'runtime'
   )
 }
 

--- a/wework/dsh/executor-runtime/index.test.mjs
+++ b/wework/dsh/executor-runtime/index.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { createTranscriptTarget, exportExecutorTranscript } from './index.js'
+import { createTranscriptTarget, exportExecutorTranscript, readExecutorTurn } from './index.js'
 
 const TEST_ENCRYPTION_KEY = Buffer.alloc(32, 7).toString('base64')
 
@@ -120,4 +120,30 @@ test('routes restore and acknowledgement through native transcript RPCs', async 
       },
     },
   ])
+})
+
+test('distinguishes a deleted task from a missing turn in an existing task', async () => {
+  await assert.rejects(
+    readExecutorTurn(
+      {
+        async request() {
+          return { taskId: 'deleted-task', runtime: 'runtime', workspacePath: '', turns: [] }
+        },
+      },
+      { taskId: 'deleted-task', executorTurnId: 'turn-1' }
+    ),
+    error => error.code === 'transcript_task_missing'
+  )
+
+  await assert.rejects(
+    readExecutorTurn(
+      {
+        async request() {
+          return { taskId: 'active-task', runtime: 'Codex', workspacePath: '/workspace', turns: [] }
+        },
+      },
+      { taskId: 'active-task', executorTurnId: 'turn-1' }
+    ),
+    error => error.code === 'transcript_turn_missing'
+  )
 })

--- a/wework/dsh/executor-runtime/transcript-source.js
+++ b/wework/dsh/executor-runtime/transcript-source.js
@@ -2,6 +2,7 @@ export class TranscriptSource {
   constructor(options = {}) {
     this.onError = options.onError ?? (() => {})
     this.readTurn = options.readTurn
+    this.summarizeTurn = options.summarizeTurn
     this.turns = new Map()
     this.listeners = new Set()
   }
@@ -25,6 +26,13 @@ export class TranscriptSource {
       throw new Error('Transcript source does not support persisted turn reads')
     }
     return this.readTurn(structuredClone(turn), structuredClone(options))
+  }
+
+  summarize(turn) {
+    if (typeof this.summarizeTurn !== 'function') {
+      throw new Error('Transcript source does not support turn summaries')
+    }
+    return this.summarizeTurn(structuredClone(turn))
   }
 
   notify(listener, turn) {

--- a/wework/dsh/transcript-sync/client.js
+++ b/wework/dsh/transcript-sync/client.js
@@ -12,6 +12,8 @@ window.__ModuleLoader__.load({
         enabled: service.configuration.get(CONFIGURATION_ID)?.enabled !== false,
         error: null,
         pending: false,
+        status: null,
+        statusPending: false,
       }
       const listeners = new Set()
       const publish = patch => {
@@ -27,8 +29,36 @@ window.__ModuleLoader__.load({
         async reconcile() {
           try {
             await backend.request('setEnabled', { enabled: snapshot.enabled })
+            await this.refreshStatus()
           } catch (error) {
             publish({ error: error instanceof Error ? error.message : String(error) })
+          }
+        },
+        async refreshStatus() {
+          if (snapshot.statusPending) return
+          publish({ statusPending: true })
+          try {
+            const status = await backend.request('getStatus', {})
+            publish({ status, statusPending: false })
+          } catch (error) {
+            publish({
+              error: error instanceof Error ? error.message : String(error),
+              statusPending: false,
+            })
+          }
+        },
+        async retry() {
+          if (snapshot.statusPending) return
+          publish({ error: null, statusPending: true })
+          try {
+            const status = await backend.request('flush', {})
+            publish({ status, statusPending: false })
+          } catch (error) {
+            publish({
+              error: error instanceof Error ? error.message : String(error),
+              statusPending: false,
+            })
+            await this.refreshStatus()
           }
         },
         async setEnabled(enabled) {
@@ -38,6 +68,7 @@ window.__ModuleLoader__.load({
             await backend.request('setEnabled', { enabled })
             service.configuration.update(CONFIGURATION_ID, { enabled })
             publish({ enabled, pending: false })
+            await this.refreshStatus()
           } catch (error) {
             publish({
               error: error instanceof Error ? error.message : String(error),
@@ -50,7 +81,15 @@ window.__ModuleLoader__.load({
 
     function SyncSettingsSection({ service, store }) {
       const [snapshot, setSnapshot] = useState(store.getSnapshot())
-      useEffect(() => store.subscribe(setSnapshot), [store])
+      useEffect(() => {
+        const unsubscribe = store.subscribe(setSnapshot)
+        void store.refreshStatus()
+        const timer = setInterval(() => void store.refreshStatus(), 5000)
+        return () => {
+          clearInterval(timer)
+          unsubscribe()
+        }
+      }, [store])
       const label = service.localization.translate({
         en: 'Synchronize conversations and settings across devices',
         'zh-CN': '跨设备同步会话和配置',
@@ -59,9 +98,7 @@ window.__ModuleLoader__.load({
         en: 'When disabled, Wework keeps working locally and does not upload or download cloud data.',
         'zh-CN': '关闭后 Wework 仍可在本机正常工作，但不会上传或下载云端数据。',
       })
-      const status = snapshot.enabled
-        ? service.localization.translate({ en: 'Synchronization enabled', 'zh-CN': '同步已开启' })
-        : service.localization.translate({ en: 'Synchronization disabled', 'zh-CN': '同步已关闭' })
+      const syncStatus = synchronizationStatus(snapshot, service)
 
       return createElement(
         'section',
@@ -109,24 +146,156 @@ window.__ModuleLoader__.load({
                 'data-testid': 'transcript-sync-enabled-status',
                 style: { color: 'rgb(var(--color-text-muted))' },
               },
-              snapshot.pending
-                ? service.localization.translate({ en: 'Saving…', 'zh-CN': '正在保存…' })
-                : status
-            ),
-            snapshot.error
-              ? createElement(
-                  'span',
-                  {
-                    'data-testid': 'transcript-sync-settings-error',
-                    role: 'alert',
-                    style: { color: 'rgb(var(--color-error))' },
-                  },
-                  snapshot.error
-                )
-              : null
+              snapshot.pending || snapshot.statusPending
+                ? service.localization.translate({ en: 'Updating…', 'zh-CN': '正在更新…' })
+                : syncStatus.label
+            )
           )
+        ),
+        createElement(
+          'div',
+          {
+            style: {
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '4px',
+              marginLeft: '28px',
+              marginTop: '8px',
+            },
+          },
+          snapshot.status
+            ? createElement(
+                'span',
+                {
+                  'data-testid': 'transcript-sync-runtime-status',
+                  style: {
+                    color: syncStatus.color,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '2px',
+                  },
+                },
+                createElement(
+                  'span',
+                  null,
+                  service.localization.translate({
+                    en: `${snapshot.status.pendingTurns} turns waiting to upload`,
+                    'zh-CN': `待上传 ${snapshot.status.pendingTurns} 轮`,
+                  })
+                ),
+                createElement(
+                  'span',
+                  null,
+                  service.localization.translate({
+                    en: `${snapshot.status.transcripts} cloud conversations discovered`,
+                    'zh-CN': `已发现 ${snapshot.status.transcripts} 个云端会话`,
+                  })
+                ),
+                createElement(
+                  'span',
+                  null,
+                  service.localization.translate({
+                    en: `Last successful sync: ${formatTimestamp(snapshot.status.lastSuccessAt, 'Never')}`,
+                    'zh-CN': `最近成功：${formatTimestamp(snapshot.status.lastSuccessAt, '暂无')}`,
+                  })
+                )
+              )
+            : null,
+          snapshot.status?.lastError
+            ? createElement(
+                'span',
+                {
+                  'data-testid': 'transcript-sync-runtime-error',
+                  role: 'alert',
+                  style: { color: 'rgb(var(--color-error))' },
+                },
+                snapshot.status.lastError
+              )
+            : null,
+          snapshot.enabled
+            ? createElement(
+                'button',
+                {
+                  'data-testid': 'transcript-sync-retry-button',
+                  disabled: snapshot.statusPending,
+                  onClick: () => void store.retry(),
+                  style: {
+                    alignSelf: 'flex-start',
+                    background: 'transparent',
+                    border: '1px solid rgb(var(--color-border))',
+                    borderRadius: '6px',
+                    color: 'rgb(var(--color-text-primary))',
+                    cursor: snapshot.statusPending ? 'default' : 'pointer',
+                    padding: '6px 10px',
+                  },
+                  type: 'button',
+                },
+                service.localization.translate({ en: 'Retry now', 'zh-CN': '立即重试' })
+              )
+            : null,
+          snapshot.error
+            ? createElement(
+                'span',
+                {
+                  'data-testid': 'transcript-sync-settings-error',
+                  role: 'alert',
+                  style: { color: 'rgb(var(--color-error))' },
+                },
+                snapshot.error
+              )
+            : null
         )
       )
+    }
+
+    function synchronizationStatus(snapshot, service) {
+      if (!snapshot.enabled) {
+        return {
+          color: 'rgb(var(--color-text-muted))',
+          label: service.localization.translate({
+            en: 'Synchronization disabled',
+            'zh-CN': '同步已关闭',
+          }),
+        }
+      }
+      if (snapshot.status?.syncing) {
+        return {
+          color: 'rgb(var(--color-text-muted))',
+          label: service.localization.translate({ en: 'Synchronizing…', 'zh-CN': '正在同步…' }),
+        }
+      }
+      if (snapshot.status?.lastError) {
+        return {
+          color: 'rgb(var(--color-error))',
+          label: service.localization.translate({
+            en: 'Synchronization failed',
+            'zh-CN': '同步失败',
+          }),
+        }
+      }
+      if (snapshot.status?.pendingTurns > 0) {
+        return {
+          color: 'rgb(var(--color-text-muted))',
+          label: service.localization.translate({
+            en: 'Waiting to synchronize',
+            'zh-CN': '等待同步',
+          }),
+        }
+      }
+      return {
+        color: 'rgb(var(--color-text-muted))',
+        label: service.localization.translate({
+          en: 'Synchronization is up to date',
+          'zh-CN': '同步正常',
+        }),
+      }
+    }
+
+    function formatTimestamp(value, fallback) {
+      if (typeof value !== 'string' || !value) return fallback
+      const date = new Date(value)
+      if (Number.isNaN(date.getTime())) return fallback
+      return date.toLocaleString()
     }
 
     return {

--- a/wework/dsh/transcript-sync/client.js
+++ b/wework/dsh/transcript-sync/client.js
@@ -14,6 +14,7 @@ window.__ModuleLoader__.load({
         pending: false,
         status: null,
         statusPending: false,
+        statusRefreshing: false,
       }
       const listeners = new Set()
       const publish = patch => {
@@ -34,29 +35,34 @@ window.__ModuleLoader__.load({
             publish({ error: error instanceof Error ? error.message : String(error) })
           }
         },
-        async refreshStatus() {
-          if (snapshot.statusPending) return
-          publish({ statusPending: true })
+        async refreshStatus({ showPending = false } = {}) {
+          if (snapshot.statusRefreshing) return
+          publish({
+            statusRefreshing: true,
+            ...(showPending ? { statusPending: true } : {}),
+          })
           try {
             const status = await backend.request('getStatus', {})
-            publish({ status, statusPending: false })
+            publish({ status, statusPending: false, statusRefreshing: false })
           } catch (error) {
             publish({
               error: error instanceof Error ? error.message : String(error),
               statusPending: false,
+              statusRefreshing: false,
             })
           }
         },
         async retry() {
-          if (snapshot.statusPending) return
-          publish({ error: null, statusPending: true })
+          if (snapshot.statusRefreshing) return
+          publish({ error: null, statusPending: true, statusRefreshing: true })
           try {
             const status = await backend.request('flush', {})
-            publish({ status, statusPending: false })
+            publish({ status, statusPending: false, statusRefreshing: false })
           } catch (error) {
             publish({
               error: error instanceof Error ? error.message : String(error),
               statusPending: false,
+              statusRefreshing: false,
             })
             await this.refreshStatus()
           }
@@ -68,7 +74,7 @@ window.__ModuleLoader__.load({
             await backend.request('setEnabled', { enabled })
             service.configuration.update(CONFIGURATION_ID, { enabled })
             publish({ enabled, pending: false })
-            await this.refreshStatus()
+            await this.refreshStatus({ showPending: true })
           } catch (error) {
             publish({
               error: error instanceof Error ? error.message : String(error),
@@ -217,7 +223,7 @@ window.__ModuleLoader__.load({
                 'button',
                 {
                   'data-testid': 'transcript-sync-retry-button',
-                  disabled: snapshot.statusPending,
+                  disabled: snapshot.statusRefreshing,
                   onClick: () => void store.retry(),
                   style: {
                     alignSelf: 'flex-start',
@@ -225,7 +231,7 @@ window.__ModuleLoader__.load({
                     border: '1px solid rgb(var(--color-border))',
                     borderRadius: '6px',
                     color: 'rgb(var(--color-text-primary))',
-                    cursor: snapshot.statusPending ? 'default' : 'pointer',
+                    cursor: snapshot.statusRefreshing ? 'default' : 'pointer',
                     padding: '6px 10px',
                   },
                   type: 'button',

--- a/wework/dsh/transcript-sync/client.test.mjs
+++ b/wework/dsh/transcript-sync/client.test.mjs
@@ -129,6 +129,15 @@ test('registers a default-enabled cloud sync setting and applies changes to the 
   assert.ok(pageRegistration)
   assert.equal(registrations.find(entry => entry.descriptor)?.descriptor.page, 'connections')
   const wrapper = pageRegistration.component({})
+  const statusSnapshots = []
+  const unsubscribeStatus = wrapper.props.store.subscribe(snapshot => {
+    statusSnapshots.push(snapshot)
+  })
+  await wrapper.props.store.refreshStatus()
+  unsubscribeStatus()
+  assert.ok(statusSnapshots.some(snapshot => snapshot.statusRefreshing))
+  assert.ok(statusSnapshots.every(snapshot => !snapshot.statusPending))
+
   const page = wrapper.type(wrapper.props)
   const checkbox = findElement(
     page,

--- a/wework/dsh/transcript-sync/client.test.mjs
+++ b/wework/dsh/transcript-sync/client.test.mjs
@@ -63,6 +63,30 @@ test('registers a default-enabled cloud sync setting and applies changes to the 
           return {
             async request(method, params) {
               backendRequests.push({ method, params })
+              if (method === 'getStatus') {
+                return {
+                  configured: true,
+                  enabled: true,
+                  pendingTurns: 1,
+                  transcripts: 28,
+                  syncing: false,
+                  lastError: 'Not Found',
+                  lastAttemptAt: '2026-09-09T17:41:48.000Z',
+                  lastSuccessAt: null,
+                }
+              }
+              if (method === 'flush') {
+                return {
+                  configured: true,
+                  enabled: true,
+                  pendingTurns: 0,
+                  transcripts: 29,
+                  syncing: false,
+                  lastError: null,
+                  lastAttemptAt: '2026-09-09T17:45:00.000Z',
+                  lastSuccessAt: '2026-09-09T17:45:01.000Z',
+                }
+              }
               return { enabled: params.enabled }
             },
           }
@@ -96,7 +120,7 @@ test('registers a default-enabled cloud sync setting and applies changes to the 
   }
 
   plugin.apply(ctx)
-  await Promise.resolve()
+  await new Promise(resolve => setImmediate(resolve))
 
   assert.equal(configurationDefinition.defaults.enabled, true)
   assert.equal(backendRequests[0].method, 'setEnabled')
@@ -112,11 +136,28 @@ test('registers a default-enabled cloud sync setting and applies changes to the 
   )
   assert.ok(checkbox)
   assert.equal(checkbox.props.checked, true)
+  const runtimeStatus = findElement(
+    page,
+    node => node.props?.['data-testid'] === 'transcript-sync-runtime-status'
+  )
+  assert.ok(runtimeStatus)
+  assert.ok(
+    findElement(page, node => node.props?.['data-testid'] === 'transcript-sync-runtime-error')
+  )
+  const retry = findElement(
+    page,
+    node => node.props?.['data-testid'] === 'transcript-sync-retry-button'
+  )
+  assert.ok(retry)
+  retry.props.onClick()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(backendRequests.at(-1).method, 'flush')
 
   checkbox.props.onChange({ target: { checked: false } })
   await new Promise(resolve => setImmediate(resolve))
 
   assert.equal(configured.enabled, false)
-  assert.equal(backendRequests.at(-1).method, 'setEnabled')
-  assert.equal(backendRequests.at(-1).params.enabled, false)
+  assert.equal(backendRequests.at(-2).method, 'setEnabled')
+  assert.equal(backendRequests.at(-2).params.enabled, false)
+  assert.equal(backendRequests.at(-1).method, 'getStatus')
 })

--- a/wework/dsh/transcript-sync/index.js
+++ b/wework/dsh/transcript-sync/index.js
@@ -1,7 +1,4 @@
-import { createWriteStream, openAsBlob } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rename, rm, unlink, writeFile } from 'node:fs/promises'
-import { Readable, Transform } from 'node:stream'
-import { pipeline } from 'node:stream/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
@@ -19,7 +16,6 @@ export const inject = [
 const PACKAGE_NAME = '@wegent/dsh-transcript-sync'
 const SNAPSHOT_INTERVAL = 10
 const MAX_ENCRYPTED_SEGMENT_BYTES = 256 * 1024 * 1024 + 33
-const OBJECT_TRANSFER_TIMEOUT_MS = 10 * 60 * 1000
 const PREFERENCES_UNIT = 'portable_preferences'
 const PREFERENCES_FIELDS = [
   'appearanceMode',
@@ -59,10 +55,16 @@ export async function apply(ctx) {
     state,
     target: ctx.weworkTranscriptTarget,
   })
+  const service = sync.service()
   ctx.weworkPluginRuntime.register(ctx, {
     id: name,
     methods: {
       getSettings: () => ({ enabled: sync.enabled }),
+      getStatus: () => service.status(),
+      flush: async () => {
+        await service.flush()
+        return service.status()
+      },
       setEnabled: ({ enabled }) => sync.setEnabled(enabled),
     },
   })
@@ -72,7 +74,7 @@ export async function apply(ctx) {
     })
   })
   ctx.effect(() => {
-    const unprovide = ctx.reflect.provide('weworkTranscriptSync', sync.service())
+    const unprovide = ctx.reflect.provide('weworkTranscriptSync', service)
     return () => {
       unsubscribe()
       unprovide()
@@ -96,6 +98,7 @@ export class WeworkSync {
     pollIntervalMs = 5000,
   }) {
     this.apiBaseUrl = apiBaseUrl
+    this.environmentApiBaseUrl = apiBaseUrl
     this.clientId = clientId
     this.desktop = desktop
     this.outbox = outbox
@@ -108,6 +111,8 @@ export class WeworkSync {
     this.processing = null
     this.timer = null
     this.lastError = null
+    this.lastAttemptAt = null
+    this.lastSuccessAt = null
     this.failureCount = 0
   }
 
@@ -131,7 +136,10 @@ export class WeworkSync {
         enabled: this.enabled,
         pendingTurns: this.outbox.count(),
         transcripts: Object.keys(this.state.value.transcripts).length,
+        syncing: Boolean(this.processing),
         lastError: this.lastError,
+        lastAttemptAt: this.lastAttemptAt,
+        lastSuccessAt: this.lastSuccessAt,
       }),
       list: () => structuredClone(Object.values(this.state.value.transcripts)),
       flush: () => this.flush(),
@@ -167,18 +175,32 @@ export class WeworkSync {
     if (!this.enabled) return Promise.resolve()
     if (this.processing) return this.processing
     const operation = async () => {
+      this.lastAttemptAt = new Date().toISOString()
       if (!this.enabled) return
       if (!(await this.ensureApiBaseUrl())) return
-      if (!this.enabled) return
-      await this.flushPending()
-      if (!this.enabled) return
-      await this.pullTranscripts()
-      if (!this.enabled) return
-      await this.syncPreferences()
+      const failures = []
+      for (const phase of [
+        () => this.flushPending(),
+        () => this.pullTranscripts(),
+        () => this.syncPreferences(),
+      ]) {
+        if (!this.enabled) return
+        try {
+          await phase()
+        } catch (error) {
+          failures.push(error)
+        }
+      }
+      if (failures.length === 1) throw failures[0]
+      if (failures.length > 1) {
+        throw new AggregateError(failures, 'Wework cloud synchronization phases failed')
+      }
     }
     this.processing = operation()
       .then(result => {
         this.failureCount = 0
+        this.lastError = null
+        this.lastSuccessAt = new Date().toISOString()
         return result
       })
       .catch(error => {
@@ -195,66 +217,106 @@ export class WeworkSync {
   }
 
   async flushPending() {
-    let pending
-    while (this.enabled && (pending = this.outbox.first())) {
-      const turn = pending
-      const lease = await this.request(
-        `/wework-transcripts/${encodeURIComponent(turn.transcriptId)}/lease`,
-        'POST',
-        {
-          clientId: this.clientId,
-          ttlSeconds: 300,
-          title: turn.title || '',
-          ...(turn.parentTranscriptId
-            ? {
-                parentTranscriptId: turn.parentTranscriptId,
-                forkedAtSequence: turn.forkedAtSequence,
-              }
-            : {}),
-        }
-      )
-      if (lease.currentSequence !== turn.baseSequence) {
-        const delivered = await this.reconcilePendingSegment(turn)
-        await this.releaseLease(turn, lease)
-        if (delivered) {
-          await this.acknowledgeNativeTurn(delivered)
-          this.outbox.acknowledge(turn)
+    const failures = []
+    for (const sessionId of this.outbox.sessionIds()) {
+      try {
+        await this.flushPendingSession(sessionId)
+      } catch (error) {
+        if (error?.code === 'transcript_task_missing') {
+          const discarded = this.outbox.discardSession(sessionId)
+          console.warn('[wework-transcript-sync] discarded orphaned transcript session', {
+            sessionId,
+            discarded,
+          })
           continue
         }
-        this.forkPendingTurn(turn)
-        continue
-      }
-      const snapshot = turn.cloudSequence === 1 || turn.cloudSequence % SNAPSHOT_INTERVAL === 0
-      const encryption = await this.transcriptEncryption(turn.transcriptId)
-      let segment
-      let released = false
-      try {
-        segment = await this.source.read(turn, {
-          baseSequence: turn.cloudSequence - 1,
-          sequence: turn.cloudSequence,
-          snapshot,
-          encryptionKey: encryption.key,
-        })
-        await this.uploadPendingSegment(turn, segment, lease)
-      } catch (error) {
-        await this.releaseLease(turn, lease)
-        released = true
-        if (isSequenceConflict(error)) {
-          this.forkPendingTurn(turn)
+        if (error?.code === 'transcript_turn_missing') {
+          failures.push(error)
+          console.error('[wework-transcript-sync] transcript session is blocked', {
+            sessionId,
+            error,
+          })
           continue
         }
         throw error
-      } finally {
-        if (segment?.path) {
-          await unlink(segment.path).catch(error => {
-            if (error?.code !== 'ENOENT') throw error
-          })
-        }
       }
-      if (!released) await this.releaseLease(turn, lease)
-      await this.acknowledgeNativeTurn({ ...turn, rolloutEnd: segment.rolloutEnd })
-      this.outbox.acknowledge(turn)
     }
+    if (failures.length === 1) throw failures[0]
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Some transcript sessions could not be exported')
+    }
+  }
+
+  async flushPendingSession(sessionId) {
+    let pending
+    while (this.enabled && (pending = this.outbox.firstForSession(sessionId))) {
+      await this.flushPendingTurn(pending)
+    }
+  }
+
+  async flushPendingTurn(turn) {
+    const summarized = await this.source.summarize(turn)
+    const lease = await this.acquireLease(turn)
+    if (lease.currentSequence !== turn.baseSequence) {
+      await this.reconcileOrForkPendingTurn(turn, lease)
+      return
+    }
+    const snapshot = turn.cloudSequence === 1 || turn.cloudSequence % SNAPSHOT_INTERVAL === 0
+    const encryption = await this.transcriptEncryption(turn.transcriptId)
+    let segment
+    let released = false
+    try {
+      segment = await this.source.read(turn, {
+        baseSequence: turn.cloudSequence - 1,
+        sequence: turn.cloudSequence,
+        snapshot,
+        encryptionKey: encryption.key,
+        summary: summarized.payload,
+      })
+      await this.uploadPendingSegment(turn, segment, lease)
+    } catch (error) {
+      await this.releaseLease(turn, lease)
+      released = true
+      if (isSequenceConflict(error)) {
+        this.forkPendingTurn(turn)
+        return
+      }
+      throw error
+    } finally {
+      await removeSegmentFile(segment)
+    }
+    if (!released) await this.releaseLease(turn, lease)
+    await this.acknowledgeNativeTurn({ ...turn, rolloutEnd: segment.rolloutEnd })
+    this.outbox.acknowledge(turn)
+  }
+
+  acquireLease(turn) {
+    return this.request(
+      `/wework-transcripts/${encodeURIComponent(turn.transcriptId)}/lease`,
+      'POST',
+      {
+        clientId: this.clientId,
+        ttlSeconds: 300,
+        title: turn.title || '',
+        ...(turn.parentTranscriptId
+          ? {
+              parentTranscriptId: turn.parentTranscriptId,
+              forkedAtSequence: turn.forkedAtSequence,
+            }
+          : {}),
+      }
+    )
+  }
+
+  async reconcileOrForkPendingTurn(turn, lease) {
+    const delivered = await this.reconcilePendingSegment(turn)
+    await this.releaseLease(turn, lease)
+    if (!delivered) {
+      this.forkPendingTurn(turn)
+      return
+    }
+    await this.acknowledgeNativeTurn(delivered)
+    this.outbox.acknowledge(turn)
   }
 
   async acknowledgeNativeTurn(turn) {
@@ -278,28 +340,6 @@ export class WeworkSync {
       sizeBytes: segment.sizeBytes,
       format: segment.format,
     }
-    const prepared = await this.request(
-      `/wework-transcripts/${encodeURIComponent(turn.transcriptId)}/segments/prepare`,
-      'POST',
-      descriptor
-    )
-    const uploadBody = new FormData()
-    for (const [name, value] of Object.entries(prepared.uploadFields)) {
-      uploadBody.append(name, value)
-    }
-    uploadBody.append(
-      'file',
-      await openAsBlob(segment.path, { type: 'application/octet-stream' }),
-      'segment.tgz.aes256gcm'
-    )
-    const response = await fetch(prepared.uploadUrl, {
-      method: 'POST',
-      body: uploadBody,
-      signal: AbortSignal.timeout(OBJECT_TRANSFER_TIMEOUT_MS),
-    })
-    if (!response.ok) {
-      throw new Error(`Transcript object upload failed (${response.status})`)
-    }
     await this.request(
       `/wework-transcripts/${encodeURIComponent(turn.transcriptId)}/segments`,
       'POST',
@@ -307,6 +347,13 @@ export class WeworkSync {
         ...descriptor,
         turnId: turn.turnId,
         summary: segmentSummary(turn, segment),
+      },
+      {
+        file: {
+          path: segment.path,
+          name: 'segment.tgz.aes256gcm',
+          contentType: 'application/octet-stream',
+        },
       }
     )
   }
@@ -393,6 +440,7 @@ export class WeworkSync {
         downloadedThrough: current?.downloadedThrough ?? 0,
         downloadedArchiveIds: current?.downloadedArchiveIds ?? [],
       }
+      if (this.outbox.hasPendingTranscript(transcript.transcriptId)) continue
       const targetStatus = await this.target.status(transcript)
       if (!targetStatus?.available) continue
       let after = targetStatus.importedThrough ?? 0
@@ -412,11 +460,16 @@ export class WeworkSync {
               ) {
                 throw new Error('Transcript archive has an invalid encrypted size')
               }
-              const download = await this.request(
-                `/wework-transcripts/${encodeURIComponent(transcript.transcriptId)}/archives/${archive.id}/download`
-              )
               const path = join(directory, `${archive.toSequence}.tgz.aes256gcm`)
-              await downloadFile(download.downloadUrl, path)
+              await this.request(
+                `/wework-transcripts/${encodeURIComponent(transcript.transcriptId)}/archives/${archive.id}/download`,
+                'GET',
+                undefined,
+                {
+                  downloadPath: path,
+                  downloadSizeBytes: archive.sizeBytes,
+                }
+              )
               segments.push({
                 path,
                 sha256: archive.sha256,
@@ -491,7 +544,7 @@ export class WeworkSync {
     }
   }
 
-  async request(path, method = 'GET', body) {
+  async request(path, method = 'GET', body, transfer = {}) {
     if (!this.enabled) throw new Error('Transcript synchronization is disabled')
     if (!this.apiBaseUrl) throw new Error('Cloud backend is not configured')
     const response = await this.desktop.weworkSync.request({
@@ -499,6 +552,7 @@ export class WeworkSync {
       path,
       method,
       ...(body === undefined ? {} : { body }),
+      ...transfer,
     })
     if (response.status < 200 || response.status >= 300) {
       const detail = response.body?.detail
@@ -513,9 +567,9 @@ export class WeworkSync {
   }
 
   async ensureApiBaseUrl() {
-    if (this.apiBaseUrl) return true
-    const preferences = await this.desktop.preferences.get()
-    this.apiBaseUrl = resolveCloudConnectionApiBaseUrl(preferences.cloudConnection)
+    const preferences = await this.desktop.preferences?.get?.()
+    this.apiBaseUrl =
+      resolveCloudConnectionApiBaseUrl(preferences?.cloudConnection) ?? this.environmentApiBaseUrl
     if (!this.apiBaseUrl) {
       this.lastError = null
       return false
@@ -654,6 +708,13 @@ function isSequenceConflict(error) {
   )
 }
 
+async function removeSegmentFile(segment) {
+  if (!segment?.path) return
+  await unlink(segment.path).catch(error => {
+    if (error?.code !== 'ENOENT') throw error
+  })
+}
+
 function restorableSegments(archives, currentSequence) {
   const ordered = archives
     .filter(archive => archive.toSequence <= currentSequence)
@@ -667,25 +728,4 @@ function restorableSegments(archives, currentSequence) {
     expected += 1
   }
   return selected.at(-1)?.toSequence === currentSequence ? selected : []
-}
-
-async function downloadFile(url, path) {
-  const response = await fetch(url, {
-    signal: AbortSignal.timeout(OBJECT_TRANSFER_TIMEOUT_MS),
-  })
-  if (!response.ok || !response.body) {
-    throw new Error(`Transcript object download failed (${response.status})`)
-  }
-  let downloadedBytes = 0
-  const limit = new Transform({
-    transform(chunk, _encoding, callback) {
-      downloadedBytes += chunk.length
-      if (downloadedBytes > MAX_ENCRYPTED_SEGMENT_BYTES) {
-        callback(new Error('Transcript object exceeds the encrypted size limit'))
-        return
-      }
-      callback(null, chunk)
-    },
-  })
-  await pipeline(Readable.fromWeb(response.body), limit, createWriteStream(path, { mode: 0o600 }))
 }

--- a/wework/dsh/transcript-sync/index.js
+++ b/wework/dsh/transcript-sync/index.js
@@ -176,15 +176,15 @@ export class WeworkSync {
     if (this.processing) return this.processing
     const operation = async () => {
       this.lastAttemptAt = new Date().toISOString()
-      if (!this.enabled) return
-      if (!(await this.ensureApiBaseUrl())) return
+      if (!this.enabled) return false
+      if (!(await this.ensureApiBaseUrl())) return false
       const failures = []
       for (const phase of [
         () => this.flushPending(),
         () => this.pullTranscripts(),
         () => this.syncPreferences(),
       ]) {
-        if (!this.enabled) return
+        if (!this.enabled) break
         try {
           await phase()
         } catch (error) {
@@ -195,13 +195,14 @@ export class WeworkSync {
       if (failures.length > 1) {
         throw new AggregateError(failures, 'Wework cloud synchronization phases failed')
       }
+      return this.enabled
     }
     this.processing = operation()
-      .then(result => {
+      .then(completed => {
+        if (!completed) return
         this.failureCount = 0
         this.lastError = null
         this.lastSuccessAt = new Date().toISOString()
-        return result
       })
       .catch(error => {
         this.failureCount += 1

--- a/wework/dsh/transcript-sync/index.test.mjs
+++ b/wework/dsh/transcript-sync/index.test.mjs
@@ -465,6 +465,36 @@ test('continues download and preference phases after an upload phase failure', a
   assert.deepEqual(phases, ['upload', 'download', 'preferences'])
 })
 
+test('preserves a failed sync result when synchronization is disabled between phases', async () => {
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'client-1',
+    outbox: new MemorySyncOutbox(),
+    source: await segmentSource(),
+    state: state(),
+    target: {},
+    desktop: {},
+  })
+  sync.failureCount = 2
+  sync.flushPending = async () => {
+    sync.enabled = false
+    throw new Error('upload failed before disable')
+  }
+  sync.pullTranscripts = async () => {
+    assert.fail('Download must not run after synchronization is disabled')
+  }
+  sync.syncPreferences = async () => {
+    assert.fail('Preferences must not run after synchronization is disabled')
+  }
+
+  await assert.rejects(sync.flush(), /upload failed before disable/u)
+
+  const status = sync.service().status()
+  assert.equal(status.lastError, 'upload failed before disable')
+  assert.equal(status.lastSuccessAt, null)
+  assert.equal(sync.failureCount, 3)
+})
+
 test('clears the previous synchronization error after a successful retry', async () => {
   const sync = new WeworkSync({
     apiBaseUrl: 'https://cloud.example.com/api',

--- a/wework/dsh/transcript-sync/index.test.mjs
+++ b/wework/dsh/transcript-sync/index.test.mjs
@@ -32,6 +32,17 @@ async function segmentSource() {
   const directory = await mkdtemp(join(tmpdir(), 'segment-source-'))
   return {
     calls: [],
+    async summarize(locator) {
+      return {
+        ...locator,
+        payload: {
+          userMessages: [{ id: 'user-1', text: 'Continue' }],
+          assistantMessage: 'Done',
+          reasoning: 'Checked',
+          completion: { kind: 'completed' },
+        },
+      }
+    },
     async read(locator, options) {
       this.calls.push({ locator: structuredClone(locator), options })
       const path = join(directory, `${locator.turnId}.tgz`)
@@ -45,12 +56,7 @@ async function segmentSource() {
           ? 'codex-snapshot.v1.tgz.aes256gcm'
           : 'codex-delta.v1.tgz.aes256gcm',
         rolloutEnd: 2048,
-        summary: {
-          userMessages: [{ id: 'user-1', text: 'Continue' }],
-          assistantMessage: 'Done',
-          reasoning: 'Checked',
-          completion: { kind: 'completed' },
-        },
+        summary: options.summary,
       }
     },
   }
@@ -74,191 +80,185 @@ test('resolves backend API and strips device-local preferences', () => {
   )
 })
 
+test('prefers the active cloud connection over the environment backend', async () => {
+  const sync = new WeworkSync({
+    apiBaseUrl: 'http://127.0.0.1:9100/api',
+    clientId: 'client-1',
+    outbox: new MemorySyncOutbox(),
+    source: await segmentSource(),
+    state: state(),
+    target: {},
+    desktop: {
+      preferences: {
+        async get() {
+          return {
+            cloudConnection: {
+              apiBaseUrl: 'https://preview.example.com/api',
+            },
+          }
+        },
+      },
+    },
+  })
+
+  assert.equal(await sync.ensureApiBaseUrl(), true)
+  assert.equal(sync.apiBaseUrl, 'https://preview.example.com/api')
+})
+
 test('uploads a native snapshot and persists only its locator', async () => {
   const requests = []
-  const uploads = []
   const source = await segmentSource()
   const outbox = new MemorySyncOutbox()
   const acknowledgements = []
-  const originalFetch = globalThis.fetch
-  globalThis.fetch = async (_url, options) => {
-    assert.ok(options.signal instanceof AbortSignal)
-    uploads.push({
-      method: options.method,
-      key: options.body.get('key'),
-      content: await options.body.get('file').text(),
-    })
-    return new Response(null, { status: 200 })
-  }
-  try {
-    const sync = new WeworkSync({
-      apiBaseUrl: 'https://cloud.example.com/api',
-      clientId: 'client-1',
-      outbox,
-      source,
-      state: state(),
-      target: {
-        async acknowledge(value) {
-          acknowledgements.push(value)
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'client-1',
+    outbox,
+    source,
+    state: state(),
+    target: {
+      async acknowledge(value) {
+        acknowledgements.push(value)
+      },
+    },
+    desktop: {
+      weworkSync: {
+        async request(request) {
+          if (request.file) {
+            request.fileContent = await readFile(request.file.path, 'utf8')
+          }
+          requests.push(request)
+          if (request.path.endsWith('/lease')) {
+            return { status: 200, body: { fencingToken: 7, currentSequence: 0 } }
+          }
+          if (request.path.endsWith('/encryption-key')) {
+            return {
+              status: 200,
+              body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
+            }
+          }
+          return { status: 200, body: { currentSequence: 1, appended: 1 } }
         },
       },
-      desktop: {
-        weworkSync: {
-          async request(request) {
-            requests.push(request)
-            if (request.path.endsWith('/lease')) {
-              return { status: 200, body: { fencingToken: 7, currentSequence: 0 } }
-            }
-            if (request.path.endsWith('/encryption-key')) {
-              return {
-                status: 200,
-                body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
-              }
-            }
-            if (request.path.endsWith('/segments/prepare')) {
-              return {
-                status: 200,
-                body: {
-                  uploadUrl: 'https://storage/upload',
-                  uploadFields: { key: 'transcripts/segment' },
-                },
-              }
-            }
-            return { status: 200, body: { currentSequence: 1, appended: 1 } }
-          },
-        },
-      },
-    })
-    await sync.enqueue(turn())
-    assert.equal(Object.hasOwn(outbox.first(), 'payload'), false)
-    await sync.flushPending()
-    assert.equal(outbox.count(), 0)
-    assert.deepEqual(uploads, [
-      {
-        method: 'POST',
-        key: 'transcripts/segment',
-        content: 'native-codex-state',
-      },
-    ])
-    assert.equal(source.calls.at(-1).options.snapshot, true)
-    assert.equal(acknowledgements[0].rolloutEnd, 2048)
-    assert.ok(requests.some(request => request.path.endsWith('/segments/prepare')))
-    const prepare = requests.find(request => request.path.endsWith('/segments/prepare'))
-    const commit = requests.find(request => request.path.endsWith('/segments'))
-    assert.equal(Object.hasOwn(prepare.body, 'summary'), false)
-    assert.equal(commit.body.turnId, 'turn-1')
-    assert.deepEqual(commit.body.summary, {
-      userMessages: [{ id: 'user-1', text: 'Continue' }],
-      assistantMessage: 'Done',
-      reasoning: 'Checked',
-      completion: { kind: 'completed' },
-      taskId: 'task-1',
-    })
-  } finally {
-    globalThis.fetch = originalFetch
-  }
+    },
+  })
+  await sync.enqueue(turn())
+  assert.equal(Object.hasOwn(outbox.first(), 'payload'), false)
+  await sync.flushPending()
+  assert.equal(outbox.count(), 0)
+  assert.equal(source.calls.at(-1).options.snapshot, true)
+  assert.equal(acknowledgements[0].rolloutEnd, 2048)
+  assert.equal(
+    requests.some(request => request.path.endsWith('/segments/prepare')),
+    false
+  )
+  const upload = requests.find(request => request.path.endsWith('/segments'))
+  assert.equal(upload.body.turnId, 'turn-1')
+  assert.deepEqual(upload.body.summary, {
+    userMessages: [{ id: 'user-1', text: 'Continue' }],
+    assistantMessage: 'Done',
+    reasoning: 'Checked',
+    completion: { kind: 'completed' },
+    taskId: 'task-1',
+  })
+  assert.equal(upload.file.name, 'segment.tgz.aes256gcm')
+  assert.equal(upload.file.contentType, 'application/octet-stream')
+  assert.equal(upload.fileContent, 'native-codex-state')
 })
 
 test('restores the latest snapshot and contiguous native deltas', async () => {
   const restored = []
-  const downloadSignals = []
-  const originalFetch = globalThis.fetch
-  globalThis.fetch = async (url, options) => {
-    downloadSignals.push(options.signal)
-    return new Response(`object:${url}`, { status: 200 })
-  }
-  try {
-    const sync = new WeworkSync({
-      apiBaseUrl: 'https://cloud.example.com/api',
-      clientId: 'client-2',
-      outbox: new MemorySyncOutbox(),
-      source: await segmentSource(),
-      state: state(),
-      target: {
-        async status() {
-          return { available: true, importedThrough: 0 }
-        },
-        async restore(transcript, segments, options) {
-          restored.push({
-            transcript,
-            options,
-            segments: await Promise.all(
-              segments.map(async segment => ({
-                ...segment,
-                body: await readFile(segment.path, 'utf8'),
-              }))
-            ),
-          })
-          return { available: true, importedThrough: 2 }
+  const downloadPaths = []
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'client-2',
+    outbox: new MemorySyncOutbox(),
+    source: await segmentSource(),
+    state: state(),
+    target: {
+      async status() {
+        return { available: true, importedThrough: 0 }
+      },
+      async restore(transcript, segments, options) {
+        restored.push({
+          transcript,
+          options,
+          segments: await Promise.all(
+            segments.map(async segment => ({
+              ...segment,
+              body: await readFile(segment.path, 'utf8'),
+            }))
+          ),
+        })
+        return { available: true, importedThrough: 2 }
+      },
+    },
+    desktop: {
+      weworkSync: {
+        async request(request) {
+          if (request.path === '/wework-transcripts?includeArchived=true') {
+            return {
+              status: 200,
+              body: {
+                items: [
+                  {
+                    transcriptId: 'shared',
+                    currentSequence: 2,
+                    archives: [
+                      {
+                        id: 0,
+                        fromSequence: 0,
+                        toSequence: 0,
+                        sha256: '0'.repeat(64),
+                        sizeBytes: 32,
+                        format: 'jsonl.zst',
+                      },
+                      {
+                        id: 1,
+                        fromSequence: 0,
+                        toSequence: 1,
+                        sha256: 'a'.repeat(64),
+                        sizeBytes: 32,
+                        format: 'codex-snapshot.v1.tgz.aes256gcm',
+                      },
+                      {
+                        id: 2,
+                        fromSequence: 2,
+                        toSequence: 2,
+                        sha256: 'b'.repeat(64),
+                        sizeBytes: 32,
+                        format: 'codex-delta.v1.tgz.aes256gcm',
+                      },
+                    ],
+                  },
+                ],
+              },
+            }
+          }
+          if (request.path.endsWith('/encryption-key')) {
+            return {
+              status: 200,
+              body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
+            }
+          }
+          const id = request.path.match(/archives\/(\d+)\/download/u)?.[1]
+          assert.ok(request.downloadPath)
+          downloadPaths.push(request.downloadPath)
+          await writeFile(request.downloadPath, `object:${id}`)
+          return { status: 200, body: { path: request.downloadPath } }
         },
       },
-      desktop: {
-        weworkSync: {
-          async request(request) {
-            if (request.path === '/wework-transcripts?includeArchived=true') {
-              return {
-                status: 200,
-                body: {
-                  items: [
-                    {
-                      transcriptId: 'shared',
-                      currentSequence: 2,
-                      archives: [
-                        {
-                          id: 0,
-                          fromSequence: 0,
-                          toSequence: 0,
-                          sha256: '0'.repeat(64),
-                          sizeBytes: 32,
-                          format: 'jsonl.zst',
-                        },
-                        {
-                          id: 1,
-                          fromSequence: 0,
-                          toSequence: 1,
-                          sha256: 'a'.repeat(64),
-                          sizeBytes: 32,
-                          format: 'codex-snapshot.v1.tgz.aes256gcm',
-                        },
-                        {
-                          id: 2,
-                          fromSequence: 2,
-                          toSequence: 2,
-                          sha256: 'b'.repeat(64),
-                          sizeBytes: 32,
-                          format: 'codex-delta.v1.tgz.aes256gcm',
-                        },
-                      ],
-                    },
-                  ],
-                },
-              }
-            }
-            if (request.path.endsWith('/encryption-key')) {
-              return {
-                status: 200,
-                body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
-              }
-            }
-            const id = request.path.match(/archives\/(\d+)\/download/u)?.[1]
-            return { status: 200, body: { downloadUrl: `https://storage/${id}` } }
-          },
-        },
-      },
-    })
-    await sync.pullTranscripts()
-    assert.equal(restored.length, 1)
-    assert.deepEqual(
-      restored[0].segments.map(segment => segment.sequence),
-      [1, 2]
-    )
-    assert.equal(restored[0].segments[1].body, 'object:https://storage/2')
-    assert.equal(restored[0].options.encryptionKey, TEST_ENCRYPTION_KEY)
-    assert.equal(downloadSignals.length, 2)
-    assert.ok(downloadSignals.every(signal => signal instanceof AbortSignal))
-  } finally {
-    globalThis.fetch = originalFetch
-  }
+    },
+  })
+  await sync.pullTranscripts()
+  assert.equal(restored.length, 1)
+  assert.deepEqual(
+    restored[0].segments.map(segment => segment.sequence),
+    [1, 2]
+  )
+  assert.equal(restored[0].segments[1].body, 'object:2')
+  assert.equal(restored[0].options.encryptionKey, TEST_ENCRYPTION_KEY)
+  assert.equal(downloadPaths.length, 2)
 })
 
 test('branches deterministically when the cloud causal head changed', async () => {
@@ -273,61 +273,293 @@ test('branches deterministically when the cloud causal head changed', async () =
   })
   const outbox = new MemorySyncOutbox([pending])
   const leases = []
-  const originalFetch = globalThis.fetch
-  globalThis.fetch = async (_url, options) => {
-    for await (const _chunk of options.body) {
-      // Consume the stream before the temporary segment is removed.
-    }
-    return new Response(null, { status: 200 })
-  }
-  try {
-    const sync = new WeworkSync({
-      apiBaseUrl: 'https://cloud.example.com/api',
-      clientId: 'device-b',
-      outbox,
-      source,
-      state: state(),
-      target: { async acknowledge() {} },
-      desktop: {
-        weworkSync: {
-          async request(request) {
-            if (request.path.endsWith('/lease')) {
-              leases.push(request)
-              return {
-                status: 200,
-                body: {
-                  fencingToken: 9,
-                  currentSequence: request.path.includes('/shared/') ? 2 : 0,
-                },
-              }
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'device-b',
+    outbox,
+    source,
+    state: state(),
+    target: { async acknowledge() {} },
+    desktop: {
+      weworkSync: {
+        async request(request) {
+          if (request.path.endsWith('/lease')) {
+            leases.push(request)
+            return {
+              status: 200,
+              body: {
+                fencingToken: 9,
+                currentSequence: request.path.includes('/shared/') ? 2 : 0,
+              },
             }
-            if (request.path.endsWith('/encryption-key')) {
-              return {
-                status: 200,
-                body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
-              }
+          }
+          if (request.path.endsWith('/encryption-key')) {
+            return {
+              status: 200,
+              body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
             }
-            if (request.path.endsWith('/segments/prepare')) {
-              return {
-                status: 200,
-                body: {
-                  uploadUrl: 'https://storage/upload',
-                  uploadFields: { key: 'transcripts/segment' },
-                },
-              }
-            }
-            return { status: 200, body: {} }
-          },
+          }
+          return { status: 200, body: {} }
         },
       },
-    })
-    await sync.flushPending()
-    assert.equal(outbox.count(), 0)
-    const branchLease = leases.find(request => request.path.includes('/fork-'))
-    assert.equal(branchLease.body.parentTranscriptId, 'shared')
-    assert.equal(branchLease.body.forkedAtSequence, 1)
-    assert.equal(source.calls.at(-1).options.snapshot, true)
-  } finally {
-    globalThis.fetch = originalFetch
+    },
+  })
+  await sync.flushPending()
+  assert.equal(outbox.count(), 0)
+  const branchLease = leases.find(request => request.path.includes('/fork-'))
+  assert.equal(branchLease.body.parentTranscriptId, 'shared')
+  assert.equal(branchLease.body.forkedAtSequence, 1)
+  assert.equal(source.calls.at(-1).options.snapshot, true)
+})
+
+test('discards an orphaned session and continues uploading healthy sessions', async () => {
+  const source = await segmentSource()
+  const summarize = source.summarize.bind(source)
+  source.summarize = async locator => {
+    if (locator.sessionId === 'orphaned-session') {
+      throw Object.assign(new Error('runtime task is unavailable'), {
+        code: 'transcript_task_missing',
+      })
+    }
+    return summarize(locator)
   }
+  const outbox = new MemorySyncOutbox([
+    turn({
+      transcriptId: 'orphaned',
+      taskId: 'orphaned',
+      turnId: 'orphaned-turn-1',
+      sessionId: 'orphaned-session',
+    }),
+    turn({
+      transcriptId: 'orphaned',
+      taskId: 'orphaned',
+      sequence: 2,
+      turnId: 'orphaned-turn-2',
+      sessionId: 'orphaned-session',
+      baseSequence: 1,
+    }),
+    turn({
+      transcriptId: 'healthy',
+      taskId: 'healthy',
+      turnId: 'healthy-turn',
+      sessionId: 'healthy-session',
+    }),
+  ])
+  const requests = []
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'client-1',
+    outbox,
+    source,
+    state: state(),
+    target: { async acknowledge() {} },
+    desktop: {
+      weworkSync: {
+        async request(request) {
+          requests.push(request)
+          if (request.path.endsWith('/lease')) {
+            return { status: 200, body: { fencingToken: 1, currentSequence: 0 } }
+          }
+          if (request.path.endsWith('/encryption-key')) {
+            return {
+              status: 200,
+              body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
+            }
+          }
+          return { status: 200, body: {} }
+        },
+      },
+    },
+  })
+
+  await sync.flushPending()
+
+  assert.equal(outbox.count(), 0)
+  assert.equal(
+    requests.some(request => request.path.includes('/orphaned/')),
+    false
+  )
+  assert.ok(requests.some(request => request.path.includes('/healthy/')))
+})
+
+test('isolates a missing turn while other sessions continue uploading', async () => {
+  const source = await segmentSource()
+  const summarize = source.summarize.bind(source)
+  source.summarize = async locator => {
+    if (locator.sessionId === 'blocked-session') {
+      throw Object.assign(new Error('executor turn is unavailable'), {
+        code: 'transcript_turn_missing',
+      })
+    }
+    return summarize(locator)
+  }
+  const blocked = turn({
+    transcriptId: 'blocked',
+    taskId: 'blocked',
+    turnId: 'blocked-turn',
+    sessionId: 'blocked-session',
+  })
+  const outbox = new MemorySyncOutbox([
+    blocked,
+    turn({
+      transcriptId: 'healthy',
+      taskId: 'healthy',
+      turnId: 'healthy-turn',
+      sessionId: 'healthy-session',
+    }),
+  ])
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'client-1',
+    outbox,
+    source,
+    state: state(),
+    target: { async acknowledge() {} },
+    desktop: {
+      weworkSync: {
+        async request(request) {
+          if (request.path.endsWith('/lease')) {
+            return { status: 200, body: { fencingToken: 1, currentSequence: 0 } }
+          }
+          if (request.path.endsWith('/encryption-key')) {
+            return {
+              status: 200,
+              body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
+            }
+          }
+          return { status: 200, body: {} }
+        },
+      },
+    },
+  })
+
+  await assert.rejects(sync.flushPending(), error => error.code === 'transcript_turn_missing')
+
+  assert.equal(outbox.count(), 1)
+  assert.equal(outbox.first().turnId, blocked.turnId)
+})
+
+test('continues download and preference phases after an upload phase failure', async () => {
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'client-1',
+    outbox: new MemorySyncOutbox(),
+    source: await segmentSource(),
+    state: state(),
+    target: {},
+    desktop: {},
+  })
+  const phases = []
+  sync.flushPending = async () => {
+    phases.push('upload')
+    throw new Error('upload failed')
+  }
+  sync.pullTranscripts = async () => {
+    phases.push('download')
+  }
+  sync.syncPreferences = async () => {
+    phases.push('preferences')
+  }
+
+  await assert.rejects(sync.flush(), /upload failed/u)
+  assert.deepEqual(phases, ['upload', 'download', 'preferences'])
+})
+
+test('clears the previous synchronization error after a successful retry', async () => {
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'client-1',
+    outbox: new MemorySyncOutbox(),
+    source: await segmentSource(),
+    state: state(),
+    target: {},
+    desktop: {},
+  })
+  let fail = true
+  sync.flushPending = async () => {
+    if (fail) throw new Error('temporary upload failure')
+  }
+  sync.pullTranscripts = async () => {}
+  sync.syncPreferences = async () => {}
+
+  await assert.rejects(sync.flush(), /temporary upload failure/u)
+  assert.equal(sync.service().status().lastError, 'temporary upload failure')
+
+  fail = false
+  await sync.flush()
+
+  const status = sync.service().status()
+  assert.equal(status.lastError, null)
+  assert.equal(typeof status.lastSuccessAt, 'string')
+})
+
+test('does not restore over a transcript with an unresolved local turn', async () => {
+  const outbox = new MemorySyncOutbox([
+    turn({
+      transcriptId: 'shared',
+      taskId: 'local-task',
+      sequence: 2,
+      turnId: 'local-conflict',
+      baseSequence: 1,
+      cloudSequence: 2,
+    }),
+  ])
+  const restored = []
+  const inspected = []
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'device-b',
+    outbox,
+    source: await segmentSource(),
+    state: state(),
+    target: {
+      async status(transcript) {
+        inspected.push(transcript.transcriptId)
+        return { available: true, importedThrough: 1 }
+      },
+      async restore(transcript) {
+        restored.push(transcript.transcriptId)
+        return { available: true, importedThrough: transcript.currentSequence }
+      },
+    },
+    desktop: {
+      weworkSync: {
+        async request(request) {
+          assert.equal(request.path, '/wework-transcripts?includeArchived=true')
+          return {
+            status: 200,
+            body: {
+              items: [
+                {
+                  transcriptId: 'shared',
+                  currentSequence: 2,
+                  archives: [
+                    {
+                      id: 2,
+                      fromSequence: 0,
+                      toSequence: 2,
+                      sha256: 'a'.repeat(64),
+                      sizeBytes: 32,
+                      format: 'codex-snapshot.v1.tgz.aes256gcm',
+                    },
+                  ],
+                },
+                {
+                  transcriptId: 'unrelated',
+                  currentSequence: 0,
+                  archives: [],
+                },
+              ],
+            },
+          }
+        },
+      },
+    },
+  })
+
+  await sync.pullTranscripts()
+
+  assert.deepEqual(inspected, ['unrelated'])
+  assert.deepEqual(restored, [])
+  assert.equal(sync.state.value.transcripts.shared.currentSequence, 2)
 })

--- a/wework/dsh/transcript-sync/outbox.js
+++ b/wework/dsh/transcript-sync/outbox.js
@@ -106,11 +106,41 @@ export class SqliteSyncOutbox {
       ORDER BY created_at, session_id, local_sequence
       LIMIT 1
     `)
+    this.selectSessions = this.database.prepare(`
+      SELECT session_id
+      FROM pending_turns
+      GROUP BY session_id
+      ORDER BY MIN(created_at), session_id
+    `)
+    this.selectSessionFirst = this.database.prepare(`
+      SELECT
+        turn_id,
+        transcript_id,
+        local_sequence,
+        session_id,
+        task_id,
+        executor_turn_id,
+        title,
+        base_sequence,
+        cloud_sequence,
+        parent_transcript_id,
+        forked_at_sequence
+      FROM pending_turns
+      WHERE session_id = ?
+      ORDER BY local_sequence
+      LIMIT 1
+    `)
     this.selectSessionPending = this.database.prepare(`
       SELECT turn_id
       FROM pending_turns
       WHERE session_id = ?
       ORDER BY local_sequence
+    `)
+    this.selectTranscriptPending = this.database.prepare(`
+      SELECT 1
+      FROM pending_turns
+      WHERE transcript_id = ?
+      LIMIT 1
     `)
     this.updateForkRoute = this.database.prepare(`
       UPDATE session_routes
@@ -133,6 +163,12 @@ export class SqliteSyncOutbox {
       WHERE turn_id = ?
     `)
     this.remove = this.database.prepare('DELETE FROM pending_turns WHERE turn_id = ?')
+    this.removeSessionPending = this.database.prepare(
+      'DELETE FROM pending_turns WHERE session_id = ?'
+    )
+    this.removeSessionRoute = this.database.prepare(
+      'DELETE FROM session_routes WHERE session_id = ?'
+    )
     this.selectCount = this.database.prepare('SELECT COUNT(*) AS count FROM pending_turns')
     this.selectAll = this.database.prepare(`
       SELECT
@@ -187,6 +223,18 @@ export class SqliteSyncOutbox {
     return rowToTurn(this.selectFirst.get())
   }
 
+  sessionIds() {
+    return this.selectSessions.all().map(row => row.session_id)
+  }
+
+  firstForSession(sessionId) {
+    return rowToTurn(this.selectSessionFirst.get(sessionId))
+  }
+
+  hasPendingTranscript(transcriptId) {
+    return Boolean(this.selectTranscriptPending.get(transcriptId))
+  }
+
   fork(turn, transcriptId) {
     const pending = this.selectSessionPending.all(turn.sessionId)
     const start = pending.findIndex(item => item.turn_id === turn.turnId)
@@ -217,6 +265,15 @@ export class SqliteSyncOutbox {
       this.advanceRoute.run(turn.cloudSequence, Date.now(), turn.sessionId)
       this.remove.run(turn.turnId)
     })
+  }
+
+  discardSession(sessionId) {
+    let discarded = 0
+    this.transaction(() => {
+      discarded = Number(this.removeSessionPending.run(sessionId).changes)
+      this.removeSessionRoute.run(sessionId)
+    })
+    return discarded
   }
 
   count() {
@@ -293,6 +350,21 @@ export class MemorySyncOutbox {
     return this.turns[0] ? structuredClone(this.turns[0]) : null
   }
 
+  sessionIds() {
+    return [...new Set(this.turns.map(turn => turn.sessionId))]
+  }
+
+  firstForSession(sessionId) {
+    const turn = this.turns
+      .filter(item => item.sessionId === sessionId)
+      .sort((left, right) => left.sequence - right.sequence)[0]
+    return turn ? structuredClone(turn) : null
+  }
+
+  hasPendingTranscript(transcriptId) {
+    return this.turns.some(turn => turn.transcriptId === transcriptId)
+  }
+
   fork(turn, transcriptId) {
     const sessionTurns = this.turns
       .filter(item => item.sessionId === turn.sessionId)
@@ -321,6 +393,14 @@ export class MemorySyncOutbox {
     if (route) route.acknowledgedSequence = Math.max(route.acknowledgedSequence, turn.cloudSequence)
     const index = this.turns.findIndex(item => item.turnId === turn.turnId)
     if (index >= 0) this.turns.splice(index, 1)
+  }
+
+  discardSession(sessionId) {
+    const retained = this.turns.filter(item => item.sessionId !== sessionId)
+    const discarded = this.turns.length - retained.length
+    this.turns = retained
+    this.routes.delete(sessionId)
+    return discarded
   }
 
   count() {

--- a/wework/dsh/transcript-sync/outbox.js
+++ b/wework/dsh/transcript-sync/outbox.js
@@ -35,6 +35,8 @@ export class SqliteSyncOutbox {
       );
       CREATE INDEX IF NOT EXISTS pending_turns_delivery_order
         ON pending_turns (created_at, session_id, local_sequence);
+      CREATE INDEX IF NOT EXISTS pending_turns_transcript
+        ON pending_turns (transcript_id);
     `)
     const pendingColumns = this.database
       .prepare('PRAGMA table_info(pending_turns)')

--- a/wework/dsh/transcript-sync/outbox.test.mjs
+++ b/wework/dsh/transcript-sync/outbox.test.mjs
@@ -123,6 +123,58 @@ test('persists an automatic branch route for later turns across restart', async 
   reopened.close()
 })
 
+test('discards every pending turn and route for an orphaned session', async t => {
+  const directory = await mkdtemp(join(tmpdir(), 'wework-sync-outbox-'))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const path = join(directory, 'outbox.sqlite3')
+  const outbox = new SqliteSyncOutbox(path)
+
+  outbox.enqueue({
+    transcriptId: 'orphaned-transcript',
+    taskId: 'orphaned-task',
+    title: 'Orphaned',
+    sequence: 1,
+    turnId: 'orphaned-turn-1',
+    sessionId: 'orphaned-session',
+  })
+  outbox.enqueue({
+    transcriptId: 'orphaned-transcript',
+    taskId: 'orphaned-task',
+    title: 'Orphaned',
+    sequence: 2,
+    turnId: 'orphaned-turn-2',
+    sessionId: 'orphaned-session',
+  })
+  outbox.enqueue({
+    transcriptId: 'retained-transcript',
+    taskId: 'retained-task',
+    title: 'Retained',
+    sequence: 1,
+    turnId: 'retained-turn-1',
+    sessionId: 'retained-session',
+  })
+
+  assert.deepEqual(outbox.sessionIds(), ['orphaned-session', 'retained-session'])
+  assert.equal(outbox.firstForSession('orphaned-session').turnId, 'orphaned-turn-1')
+  assert.equal(outbox.hasPendingTranscript('orphaned-transcript'), true)
+  assert.equal(outbox.hasPendingTranscript('missing-transcript'), false)
+  assert.equal(outbox.discardSession('orphaned-session'), 2)
+  assert.equal(outbox.hasPendingTranscript('orphaned-transcript'), false)
+  assert.equal(outbox.count(), 1)
+  assert.equal(outbox.first().turnId, 'retained-turn-1')
+
+  outbox.enqueue({
+    transcriptId: 'orphaned-transcript',
+    taskId: 'orphaned-task',
+    title: 'Recreated',
+    sequence: 3,
+    turnId: 'orphaned-turn-3',
+    sessionId: 'orphaned-session',
+  })
+  assert.equal(outbox.firstForSession('orphaned-session').cloudSequence, 1)
+  outbox.close()
+})
+
 test('upgrades an existing locator outbox without copying transcript bodies', async t => {
   const directory = await mkdtemp(join(tmpdir(), 'wework-sync-outbox-'))
   t.after(() => rm(directory, { recursive: true, force: true }))

--- a/wework/dsh/transcript-sync/outbox.test.mjs
+++ b/wework/dsh/transcript-sync/outbox.test.mjs
@@ -158,6 +158,10 @@ test('discards every pending turn and route for an orphaned session', async t =>
   assert.equal(outbox.firstForSession('orphaned-session').turnId, 'orphaned-turn-1')
   assert.equal(outbox.hasPendingTranscript('orphaned-transcript'), true)
   assert.equal(outbox.hasPendingTranscript('missing-transcript'), false)
+  const queryPlan = outbox.database
+    .prepare('EXPLAIN QUERY PLAN SELECT 1 FROM pending_turns WHERE transcript_id = ? LIMIT 1')
+    .get('orphaned-transcript')
+  assert.match(queryPlan.detail, /pending_turns_transcript/u)
   assert.equal(outbox.discardSession('orphaned-session'), 2)
   assert.equal(outbox.hasPendingTranscript('orphaned-transcript'), false)
   assert.equal(outbox.count(), 1)

--- a/wework/e2e/desktop/scenarios/transcript-sync.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/transcript-sync.scenario.mjs
@@ -19,6 +19,12 @@ const RESTORED_PROMPT = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_RESTORED_DEVICE'
 const RESTORED_COMPLETION = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_RESTORED_DEVICE_COMPLETE'
 const THIRD_PROMPT = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_DISABLED_QUEUE'
 const THIRD_COMPLETION = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_DISABLED_QUEUE_COMPLETE'
+const REMOTE_PROMPT = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_REMOTE_CONFLICT'
+const REMOTE_COMPLETION = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_REMOTE_CONFLICT_COMPLETE'
+const NEW_CHAT_PROMPT = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_NEW_CHAT'
+const NEW_CHAT_COMPLETION = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_NEW_CHAT_COMPLETE'
+const OTHER_PROJECT_PROMPT = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_OTHER_PROJECT'
+const OTHER_PROJECT_COMPLETION = 'WEWORK_DESKTOP_E2E_NATIVE_TRANSCRIPT_OTHER_PROJECT_COMPLETE'
 const RESTORED_WORKSPACE_MARKER = 'restored-from-encrypted-cloud-segments'
 const SYNC_POLL_INTERVAL_MS = 5_000
 const TEST_ENCRYPTION_KEY = Buffer.alloc(32, 7).toString('base64')
@@ -72,17 +78,28 @@ async function rawBody(request) {
   return Buffer.concat(chunks)
 }
 
-async function multipartFile(request) {
+async function multipartUpload(request) {
   const contentType = String(request.headers['content-type'] || '')
   const boundary = contentType.match(/boundary=([^;]+)/u)?.[1]
   assert.ok(boundary, 'Transcript upload must include a multipart boundary')
   const body = await rawBody(request)
+  const metadataHeader = body.indexOf(Buffer.from('name="metadata"'))
+  assert.notEqual(metadataHeader, -1, 'Transcript multipart upload must include metadata')
+  const metadataStart = body.indexOf(Buffer.from('\r\n\r\n'), metadataHeader) + 4
+  const metadataEnd = body.indexOf(Buffer.from(`\r\n--${boundary}`), metadataStart)
+  assert.ok(
+    metadataStart >= 4 && metadataEnd > metadataStart,
+    'Transcript metadata part is malformed'
+  )
   const fileHeader = body.indexOf(Buffer.from('name="file"'))
   assert.notEqual(fileHeader, -1, 'Transcript multipart upload must include the file field')
   const contentStart = body.indexOf(Buffer.from('\r\n\r\n'), fileHeader) + 4
   const contentEnd = body.indexOf(Buffer.from(`\r\n--${boundary}`), contentStart)
   assert.ok(contentStart >= 4 && contentEnd > contentStart, 'Transcript file part is malformed')
-  return body.subarray(contentStart, contentEnd)
+  return {
+    metadata: JSON.parse(body.subarray(metadataStart, metadataEnd).toString('utf8')),
+    file: body.subarray(contentStart, contentEnd),
+  }
 }
 
 function seedCloudCredential(electronUserDataDirectory, apiBaseUrl) {
@@ -168,13 +185,12 @@ export function createDesktopScenario({
 
   const transcripts = new Map()
   const objects = new Map()
-  const prepared = new Map()
   const requestLog = []
   const modelRequests = []
   let activeTranscriptId = null
   let preferenceValue = null
   let fencingToken = 0
-  let lease = null
+  const leases = new Map()
   let firstCommitResponseDropped = false
   let restartDesktopApp = null
   let modelSequence = 0
@@ -243,6 +259,16 @@ export function createDesktopScenario({
       if (request.method === 'POST' && leaseMatch) {
         const transcriptId = decodeURIComponent(leaseMatch[1])
         const body = await requestBody(request)
+        const currentLease = leases.get(transcriptId)
+        if (currentLease && currentLease.clientId !== body.clientId) {
+          json(response, 409, {
+            detail: {
+              code: 'lease_held',
+              message: 'Wework transcript is being edited on another device',
+            },
+          })
+          return true
+        }
         activeTranscriptId ??= transcriptId
         const transcript = transcripts.get(transcriptId) ?? {
           title: body.title ?? transcriptId,
@@ -254,7 +280,7 @@ export function createDesktopScenario({
         }
         transcripts.set(transcriptId, transcript)
         fencingToken += 1
-        lease = { clientId: body.clientId, fencingToken }
+        leases.set(transcriptId, { clientId: body.clientId, fencingToken })
         json(response, 200, {
           transcriptId,
           clientId: body.clientId,
@@ -264,47 +290,26 @@ export function createDesktopScenario({
         })
         return true
       }
-      const prepareMatch = url.pathname.match(
-        /^\/api\/wework-transcripts\/([^/]+)\/segments\/prepare$/u
-      )
-      if (request.method === 'POST' && prepareMatch) {
-        const transcriptId = decodeURIComponent(prepareMatch[1])
-        const body = await requestBody(request)
-        const transcript = transcripts.get(transcriptId)
-        assert.equal(body.baseSequence, transcript.currentSequence)
-        assert.deepEqual({ clientId: body.clientId, fencingToken: body.fencingToken }, lease)
-        const objectId = `${transcriptId}-${body.sequence}-${body.sha256}`
-        prepared.set(objectId, structuredClone(body))
-        json(response, 200, {
-          uploadUrl: `${origin}/transcript-objects/${encodeURIComponent(objectId)}`,
-          uploadFields: { key: objectId, policy: 'desktop-e2e-size-bounded' },
-          expiresAt: '2026-09-08T01:00:00.000Z',
-        })
-        return true
-      }
-      const objectMatch = url.pathname.match(/^\/transcript-objects\/([^/]+)$/u)
-      if (request.method === 'POST' && objectMatch) {
-        objects.set(decodeURIComponent(objectMatch[1]), await multipartFile(request))
-        response.writeHead(200)
-        response.end()
-        return true
-      }
-      if (request.method === 'GET' && objectMatch) {
-        const object = objects.get(decodeURIComponent(objectMatch[1]))
-        response.writeHead(200, { 'content-type': 'application/octet-stream' })
-        response.end(object)
-        return true
-      }
       const commitMatch = url.pathname.match(/^\/api\/wework-transcripts\/([^/]+)\/segments$/u)
       if (request.method === 'POST' && commitMatch) {
         const transcriptId = decodeURIComponent(commitMatch[1])
-        const body = await requestBody(request)
+        assert.equal(
+          request.headers.authorization,
+          'bearer wework-desktop-e2e-cloud-token',
+          'Transcript upload must be authenticated through Backend'
+        )
+        const upload = await multipartUpload(request)
+        const body = upload.metadata
         const transcript = transcripts.get(transcriptId)
+        assert.equal(body.baseSequence, transcript.currentSequence)
+        assert.deepEqual(
+          { clientId: body.clientId, fencingToken: body.fencingToken },
+          leases.get(transcriptId)
+        )
         const objectId = `${transcriptId}-${body.sequence}-${body.sha256}`
-        const object = objects.get(objectId)
-        assert.ok(object, 'Segment metadata committed before object upload')
-        assert.equal(object.byteLength, body.sizeBytes)
-        assert.equal(createHash('sha256').update(object).digest('hex'), body.sha256)
+        assert.equal(upload.file.byteLength, body.sizeBytes)
+        assert.equal(createHash('sha256').update(upload.file).digest('hex'), body.sha256)
+        objects.set(objectId, upload.file)
         const existing = transcript.archives.find(archive => archive.toSequence === body.sequence)
         const existingTurn = transcript.turns.find(turn => turn.sequence === body.sequence)
         assert.equal(typeof body.turnId, 'string')
@@ -362,9 +367,13 @@ export function createDesktopScenario({
         /^\/api\/wework-transcripts\/([^/]+)\/lease\/release$/u
       )
       if (request.method === 'POST' && releaseMatch) {
+        const transcriptId = decodeURIComponent(releaseMatch[1])
         const body = await requestBody(request)
-        assert.deepEqual({ clientId: body.clientId, fencingToken: body.fencingToken }, lease)
-        lease = null
+        assert.deepEqual(
+          { clientId: body.clientId, fencingToken: body.fencingToken },
+          leases.get(transcriptId)
+        )
+        leases.delete(transcriptId)
         json(response, 200, { released: true })
         return true
       }
@@ -374,24 +383,33 @@ export function createDesktopScenario({
       if (request.method === 'GET' && downloadMatch) {
         const transcript = transcripts.get(decodeURIComponent(downloadMatch[1]))
         const archive = transcript.archives.find(item => item.id === Number(downloadMatch[2]))
-        json(response, 200, {
-          downloadUrl: `${origin}/transcript-objects/${encodeURIComponent(archive.objectId)}`,
+        const object = objects.get(archive.objectId)
+        response.writeHead(200, {
+          'content-type': 'application/octet-stream',
+          'content-length': String(object.byteLength),
         })
+        response.end(object)
         return true
       }
       if (request.method === 'POST' && ['/responses', '/v1/responses'].includes(url.pathname)) {
         const body = await requestBody(request)
         modelRequests.push(structuredClone(body))
         const serialized = JSON.stringify(body)
-        const completion = serialized.includes(THIRD_PROMPT)
-          ? THIRD_COMPLETION
-          : serialized.includes(RESTORED_PROMPT)
-            ? RESTORED_COMPLETION
-            : serialized.includes(SECOND_PROMPT)
-              ? SECOND_COMPLETION
-              : serialized.includes(FIRST_PROMPT)
-                ? FIRST_COMPLETION
-                : null
+        const completion = serialized.includes(OTHER_PROJECT_PROMPT)
+          ? OTHER_PROJECT_COMPLETION
+          : serialized.includes(NEW_CHAT_PROMPT)
+            ? NEW_CHAT_COMPLETION
+            : serialized.includes(REMOTE_PROMPT)
+              ? REMOTE_COMPLETION
+              : serialized.includes(THIRD_PROMPT)
+                ? THIRD_COMPLETION
+                : serialized.includes(RESTORED_PROMPT)
+                  ? RESTORED_COMPLETION
+                  : serialized.includes(SECOND_PROMPT)
+                    ? SECOND_COMPLETION
+                    : serialized.includes(FIRST_PROMPT)
+                      ? FIRST_COMPLETION
+                      : null
         if (!completion) return false
         modelSequence += 1
         response.writeHead(200, { 'content-type': 'text/event-stream; charset=utf-8' })
@@ -434,7 +452,7 @@ export function createDesktopScenario({
       await restartDesktopApp()
       await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
       await waitFor(
-        () => lease === null && sqliteOutboxCount(deviceAOutboxPath) === 0,
+        () => leases.size === 0 && sqliteOutboxCount(deviceAOutboxPath) === 0,
         uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
         'Restart did not reconcile the already committed native snapshot'
       )
@@ -456,7 +474,7 @@ export function createDesktopScenario({
         () =>
           activeTranscript().currentSequence === 2 &&
           sqliteOutboxCount(deviceAOutboxPath) === 0 &&
-          lease === null,
+          leases.size === 0,
         uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
         'Second turn did not upload a native rollout delta'
       )
@@ -564,6 +582,7 @@ export function createDesktopScenario({
         'Restored device did not continue and upload the next native delta'
       )
       assert.equal(activeTranscript().turns[2].payload.assistantMessage, RESTORED_COMPLETION)
+      assert.equal(activeTranscript().archives[2].format, 'codex-snapshot.v1.tgz.aes256gcm')
       const restoredRequest = modelRequests.find(request =>
         JSON.stringify(request).includes(RESTORED_PROMPT)
       )
@@ -579,7 +598,7 @@ export function createDesktopScenario({
       await control.command('click', '[data-testid="settings-menu-button"]')
       await control.command('click', '[data-testid="settings-nav-connections"]')
       await control.command('waitFor', '[data-testid="transcript-sync-enabled-status"]', {
-        text: '同步已开启',
+        text: '同步正常',
         timeoutMs: uiTimeoutMs,
       })
       await control.command('click', '[data-testid="transcript-sync-enabled-checkbox"]')
@@ -616,33 +635,231 @@ export function createDesktopScenario({
         'body'
       )
 
-      await control.command('click', '[data-testid="transcript-sync-enabled-checkbox"]')
-      await control.command('waitFor', '[data-testid="transcript-sync-enabled-status"]', {
-        text: '同步已开启',
+      const deviceCRoot = join(resultDir, 'simulated-device-c')
+      const deviceCHome = join(deviceCRoot, 'home')
+      const deviceCExecutorHome = join(deviceCRoot, 'executor-home')
+      const deviceCCodexSqliteHome = join(deviceCRoot, 'codex-sqlite')
+      const deviceCUserDataDirectory = join(deviceCRoot, 'electron-user-data')
+      await restartDesktopApp({
+        afterStop: async () => {
+          await Promise.all([
+            mkdir(deviceCHome, { recursive: true }),
+            mkdir(deviceCCodexSqliteHome, { recursive: true }),
+          ])
+          await writeFile(join(deviceCHome, '.zshrc'), '# Wework simulated device C shell\n')
+          seedCloudCredential(deviceCUserDataDirectory, apiBaseUrl)
+        },
+        appEnvironmentOverrides: {
+          CODEX_SQLITE_HOME: deviceCCodexSqliteHome,
+          HOME: deviceCHome,
+          WEGENT_STANDALONE_WORKSPACE_ROOT: join(deviceCHome, 'Documents', 'Codex'),
+          WEGENT_CODEX_HOME: join(deviceCExecutorHome, 'codex'),
+          WEGENT_EXECUTOR_HOME: deviceCExecutorHome,
+          WEGENT_EXECUTOR_LOG_FILE: 'executor-device-c.log',
+          WEWORK_APP_CONFIG_DIR: join(deviceCHome, 'app-config'),
+          WEWORK_USER_DATA_DIR: deviceCUserDataDirectory,
+        },
+        expectNewDeviceIdentity: true,
+      })
+      await control.command('waitFor', '[data-testid="telemetry-consent-overlay"]', {
         timeoutMs: uiTimeoutMs,
       })
-      await control.command('click', '[data-testid="settings-back-button"]')
+      await control.command('clickWhenEnabled', '[data-testid="telemetry-consent-decline"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await waitFor(
+        async () => {
+          try {
+            const index = JSON.parse(
+              await readFile(join(deviceCExecutorHome, 'runtime-work', 'index.json'), 'utf8')
+            )
+            return (
+              index.tasks?.[transcriptId]?.runtime_handle?.cloudTranscript?.importedThrough === 3
+            )
+          } catch (error) {
+            if (error?.code === 'ENOENT') return false
+            throw error
+          }
+        },
+        uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
+        'The second active device did not restore the shared transcript before diverging'
+      )
+      await control.command('click', `[data-testid="runtime-local-task-row-${transcriptId}"]`)
+      await control.command('fill', ACTIVE_COMPOSER_SELECTOR, { value: REMOTE_PROMPT })
+      await control.command('press', ACTIVE_COMPOSER_SELECTOR, { key: 'Enter' })
+      await control.command('waitFor', '[data-testid="message-assistant"]', {
+        text: REMOTE_COMPLETION,
+        timeoutMs: uiTimeoutMs,
+      })
       await waitFor(
         () =>
-          activeTranscript().currentSequence === 4 && sqliteOutboxCount(deviceBOutboxPath) === 0,
+          activeTranscript().currentSequence === 4 &&
+          activeTranscript().turns[3].payload.assistantMessage === REMOTE_COMPLETION &&
+          leases.size === 0,
         uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
-        'Re-enabled sync did not upload the queued native delta'
+        'The remote device did not advance the shared transcript'
       )
-      const persisted = JSON.parse(await readFile(deviceBStatePath, 'utf8'))
-      assert.equal(Object.hasOwn(persisted.transcripts[activeTranscriptId], 'turns'), false)
-      assert.equal(activeTranscript().turns[3].payload.assistantMessage, THIRD_COMPLETION)
-      assert.ok((await readFile(deviceAStatePath, 'utf8')).includes(activeTranscriptId))
-      await control.command('waitFor', ACTIVE_WORKBENCH_SELECTOR, { timeoutMs: uiTimeoutMs })
+
+      await restartDesktopApp({
+        appEnvironmentOverrides: {
+          CODEX_SQLITE_HOME: deviceBCodexSqliteHome,
+          HOME: deviceBHome,
+          WEGENT_STANDALONE_WORKSPACE_ROOT: join(deviceBHome, 'Documents', 'Codex'),
+          WEGENT_CODEX_HOME: join(deviceBExecutorHome, 'codex'),
+          WEGENT_EXECUTOR_HOME: deviceBExecutorHome,
+          WEGENT_EXECUTOR_LOG_FILE: 'executor-device-b.log',
+          WEWORK_APP_CONFIG_DIR: join(deviceBHome, 'app-config'),
+          WEWORK_USER_DATA_DIR: deviceBUserDataDirectory,
+        },
+        expectNewDeviceIdentity: true,
+      })
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
       await control.command('click', '[data-testid="settings-button"]')
       await control.command('click', '[data-testid="settings-menu-button"]')
       await control.command('click', '[data-testid="settings-nav-connections"]')
       await control.command('waitFor', '[data-testid="transcript-sync-enabled-status"]', {
-        text: '同步已开启',
+        text: '同步已关闭',
+        timeoutMs: uiTimeoutMs,
+      })
+      leases.set(transcriptId, {
+        clientId: 'simulated-external-writer',
+        fencingToken: ++fencingToken,
+      })
+      await control.command('click', '[data-testid="transcript-sync-enabled-checkbox"]')
+      await control.command('waitFor', '[data-testid="transcript-sync-enabled-status"]', {
+        text: '同步失败',
+        timeoutMs: uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
+      })
+      await control.command('waitFor', '[data-testid="transcript-sync-runtime-error"]', {
+        text: 'another device',
+        timeoutMs: uiTimeoutMs,
+      })
+      assert.equal(sqliteOutboxCount(deviceBOutboxPath), 1)
+      leases.delete(transcriptId)
+      await control.command('click', '[data-testid="transcript-sync-retry-button"]')
+      const forkEntry = await waitFor(
+        () =>
+          [...transcripts].find(
+            ([id, transcript]) =>
+              id !== transcriptId &&
+              transcript.parentTranscriptId === transcriptId &&
+              transcript.forkedAtSequence === 3 &&
+              transcript.currentSequence === 1
+          ),
+        uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
+        'The conflicting local continuation was not preserved as a branch'
+      )
+      const [forkTranscriptId, forkTranscript] = forkEntry
+      assert.equal(forkTranscript.turns[0].payload.assistantMessage, THIRD_COMPLETION)
+      assert.equal(activeTranscript().turns[3].payload.assistantMessage, REMOTE_COMPLETION)
+      assert.equal(sqliteOutboxCount(deviceBOutboxPath), 0)
+      await waitFor(
+        async () => {
+          const index = JSON.parse(
+            await readFile(join(deviceBExecutorHome, 'runtime-work', 'index.json'), 'utf8')
+          )
+          return index.tasks?.[forkTranscriptId] && index.tasks?.[transcriptId]
+        },
+        uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
+        'The fork and original transcript did not become two independent local conversations'
+      )
+      await control.command('waitFor', '[data-testid="transcript-sync-enabled-status"]', {
+        text: '同步正常',
         timeoutMs: uiTimeoutMs,
       })
       await captureScreenshot(
         control,
-        'transcript-sync-06-device-b-sync-reenabled-flushed.png',
+        'transcript-sync-06-conflict-preserved-as-branch.png',
+        'body'
+      )
+
+      await control.command('click', '[data-testid="settings-back-button"]')
+      const newChatProjectPath = join(resultDir, 'transcript-sync-new-chat-project')
+      await mkdir(newChatProjectPath, { recursive: true })
+      await createSingleRootLocalProject(
+        control,
+        newChatProjectPath,
+        'transcript-sync-new-chat-project',
+        uiTimeoutMs
+      )
+      const beforeNewChatIds = new Set(transcripts.keys())
+      await control.command('click', '[data-testid="new-chat-button"]')
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await control.command('fill', ACTIVE_COMPOSER_SELECTOR, { value: NEW_CHAT_PROMPT })
+      await control.command('press', ACTIVE_COMPOSER_SELECTOR, { key: 'Enter' })
+      await control.command('waitFor', '[data-testid="message-assistant"]', {
+        text: NEW_CHAT_COMPLETION,
+        timeoutMs: uiTimeoutMs,
+      })
+      const newChatEntry = await waitFor(
+        () =>
+          [...transcripts].find(
+            ([id, transcript]) =>
+              !beforeNewChatIds.has(id) &&
+              transcript.parentTranscriptId === null &&
+              transcript.currentSequence === 1
+          ),
+        uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
+        'A new conversation did not create an independent cloud transcript'
+      )
+      const [newChatTranscriptId, newChatTranscript] = newChatEntry
+      assert.equal(newChatTranscript.turns[0].payload.assistantMessage, NEW_CHAT_COMPLETION)
+      assert.notEqual(newChatTranscriptId, transcriptId)
+      assert.notEqual(newChatTranscriptId, forkTranscriptId)
+
+      const otherProjectPath = join(resultDir, 'transcript-sync-other-project')
+      const beforeOtherProjectIds = new Set(transcripts.keys())
+      await mkdir(otherProjectPath, { recursive: true })
+      await createSingleRootLocalProject(
+        control,
+        otherProjectPath,
+        'transcript-sync-other-project',
+        uiTimeoutMs
+      )
+      await control.command('waitFor', ACTIVE_COMPOSER_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await control.command('fill', ACTIVE_COMPOSER_SELECTOR, { value: OTHER_PROJECT_PROMPT })
+      await control.command('press', ACTIVE_COMPOSER_SELECTOR, { key: 'Enter' })
+      await control.command('waitFor', '[data-testid="message-assistant"]', {
+        text: OTHER_PROJECT_COMPLETION,
+        timeoutMs: uiTimeoutMs,
+      })
+      const otherProjectEntry = await waitFor(
+        () =>
+          [...transcripts].find(
+            ([id, transcript]) =>
+              !beforeOtherProjectIds.has(id) &&
+              transcript.parentTranscriptId === null &&
+              transcript.currentSequence === 1
+          ),
+        uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
+        'A conversation in another project did not create an independent cloud transcript'
+      )
+      const [otherProjectTranscriptId, otherProjectTranscript] = otherProjectEntry
+      assert.equal(
+        otherProjectTranscript.turns[0].payload.assistantMessage,
+        OTHER_PROJECT_COMPLETION
+      )
+      const finalIndex = JSON.parse(
+        await readFile(join(deviceBExecutorHome, 'runtime-work', 'index.json'), 'utf8')
+      )
+      assert.equal(finalIndex.tasks[otherProjectTranscriptId].workspace_path, otherProjectPath)
+      assert.equal(activeTranscript().currentSequence, 4)
+      assert.equal(forkTranscript.currentSequence, 1)
+      assert.equal(newChatTranscript.currentSequence, 1)
+
+      const persisted = JSON.parse(await readFile(deviceBStatePath, 'utf8'))
+      assert.equal(Object.hasOwn(persisted.transcripts[activeTranscriptId], 'turns'), false)
+      assert.ok((await readFile(deviceAStatePath, 'utf8')).includes(activeTranscriptId))
+      assert.equal(
+        requestLog.some(value => value.includes('/transcript-objects/')),
+        false,
+        'Desktop transcript sync must not contact object storage directly'
+      )
+      await control.command('waitFor', ACTIVE_WORKBENCH_SELECTOR, { timeoutMs: uiTimeoutMs })
+      await captureScreenshot(
+        control,
+        'transcript-sync-07-new-chat-and-project-isolation.png',
         'body'
       )
     },

--- a/wework/electron/src/host/electron-capabilities.ts
+++ b/wework/electron/src/host/electron-capabilities.ts
@@ -51,6 +51,7 @@ import type { DesktopHostEventBroker } from './desktop-host-events.js'
 import type { SecureValueStore } from './secure-value-store.js'
 import type { BrowserAnnotationController } from './browser-annotation-controller.js'
 import { RotatingLog } from '../runtime/rotating-log.js'
+import type { WeworkSyncRequest } from './wework-sync-request.js'
 
 export { captureWebContentsDataUrl } from './web-contents-capture.js'
 
@@ -105,12 +106,7 @@ export interface ElectronDesktopServices {
   openScheme: (url: string) => void
   takePendingWorkspaceOpenRequests?: () => Array<{ path: string; label?: string }>
   updatePreferences?: (patch: Record<string, unknown>) => Promise<Record<string, unknown>>
-  weworkSyncRequest?: (request: {
-    apiBaseUrl: string
-    path: string
-    method: 'GET' | 'POST' | 'PUT'
-    body?: unknown
-  }) => Promise<unknown>
+  weworkSyncRequest?: (request: WeworkSyncRequest) => Promise<unknown>
 }
 
 interface ElectronNotificationHandle {
@@ -688,11 +684,27 @@ export function createElectronCapabilityRouter(
     }
     const method = optionalStringParam(params, 'method') ?? 'GET'
     if (!['GET', 'POST', 'PUT'].includes(method)) invalidParam('method')
+    const file = Object.hasOwn(params, 'file') ? recordParam(params, 'file') : null
     return desktopServices.weworkSyncRequest({
       apiBaseUrl: stringParam(params, 'apiBaseUrl'),
       path: stringParam(params, 'path'),
       method: method as 'GET' | 'POST' | 'PUT',
       ...(Object.hasOwn(params, 'body') ? { body: params.body } : {}),
+      ...(Object.hasOwn(params, 'downloadPath')
+        ? { downloadPath: stringParam(params, 'downloadPath') }
+        : {}),
+      ...(Object.hasOwn(params, 'downloadSizeBytes')
+        ? { downloadSizeBytes: requiredIntegerParam(params, 'downloadSizeBytes') }
+        : {}),
+      ...(file
+        ? {
+            file: {
+              path: stringParam(file, 'path'),
+              name: stringParam(file, 'name'),
+              contentType: stringParam(file, 'contentType'),
+            },
+          }
+        : {}),
     })
   })
   registerRendererStorageCapabilities(router, rendererStorage)

--- a/wework/electron/src/host/wework-sync-request.test.ts
+++ b/wework/electron/src/host/wework-sync-request.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from 'vitest'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
+  createWeworkSyncFetchInit,
   createWeworkSyncRequestSignal,
   normalizeWeworkSyncApiBaseUrl,
   normalizeWeworkSyncPath,
+  readWeworkSyncResponse,
   WEWORK_SYNC_REQUEST_TIMEOUT_MS,
 } from './wework-sync-request.js'
 
@@ -47,5 +52,58 @@ describe('Wework sync request normalization', () => {
       signal.addEventListener('abort', () => resolve(), { once: true })
     })
     expect(signal.aborted).toBe(true)
+  })
+
+  test('builds authenticated multipart uploads to the backend', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-sync-upload-'))
+    const path = join(directory, 'segment.enc')
+    await writeFile(path, 'encrypted transcript')
+
+    const request = await createWeworkSyncFetchInit(
+      {
+        apiBaseUrl: 'https://cloud.example.com/api',
+        path: '/wework-transcripts/task-1/segments',
+        method: 'POST',
+        body: { sequence: 1 },
+        file: {
+          path,
+          name: 'segment.tgz.aes256gcm',
+          contentType: 'application/octet-stream',
+        },
+      },
+      'Bearer token'
+    )
+
+    expect(request.headers).toEqual({ authorization: 'Bearer token' })
+    expect(request.body).toBeInstanceOf(FormData)
+    const form = request.body as FormData
+    expect(form.get('metadata')).toBe('{"sequence":1}')
+    expect(await (form.get('file') as File).text()).toBe('encrypted transcript')
+  })
+
+  test('streams authenticated backend downloads to a local file', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-sync-download-'))
+    const path = join(directory, 'segment.enc')
+
+    const body = await readWeworkSyncResponse(
+      new Response('encrypted transcript', {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      }),
+      path,
+      Buffer.byteLength('encrypted transcript')
+    )
+
+    expect(body).toEqual({ path })
+    expect(await readFile(path, 'utf8')).toBe('encrypted transcript')
+  })
+
+  test('rejects backend downloads that exceed their declared size', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'wework-sync-download-'))
+    const path = join(directory, 'segment.enc')
+
+    await expect(readWeworkSyncResponse(new Response('oversized'), path, 4)).rejects.toThrow(
+      'exceeds its declared size'
+    )
   })
 })

--- a/wework/electron/src/host/wework-sync-request.test.ts
+++ b/wework/electron/src/host/wework-sync-request.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  createWeworkSyncDownloadTimeout,
   createWeworkSyncFetchInit,
   createWeworkSyncRequestSignal,
   normalizeWeworkSyncApiBaseUrl,
@@ -40,9 +41,18 @@ describe('Wework sync request normalization', () => {
     expect(normalizeWeworkSyncApiBaseUrl('https://cloud.example.com/api/?ignored=1#hash')).toBe(
       'https://cloud.example.com/api'
     )
+    expect(normalizeWeworkSyncApiBaseUrl('http://127.0.0.1:8000/api')).toBe(
+      'http://127.0.0.1:8000/api'
+    )
+    expect(normalizeWeworkSyncApiBaseUrl('http://localhost:8000/api')).toBe(
+      'http://localhost:8000/api'
+    )
     expect(() =>
       normalizeWeworkSyncApiBaseUrl('https://user:secret@cloud.example.com/api')
     ).toThrow('Invalid Wework sync API URL')
+    expect(() => normalizeWeworkSyncApiBaseUrl('http://cloud.example.com/api')).toThrow(
+      'Invalid Wework sync API URL'
+    )
   })
 
   test('bounds an unavailable backend request without blocking the desktop', async () => {
@@ -52,6 +62,26 @@ describe('Wework sync request normalization', () => {
       signal.addEventListener('abort', () => resolve(), { once: true })
     })
     expect(signal.aborted).toBe(true)
+  })
+
+  test('renews and clears the download inactivity timeout', () => {
+    vi.useFakeTimers()
+    try {
+      const timeout = createWeworkSyncDownloadTimeout(30)
+      vi.advanceTimersByTime(20)
+      timeout.refresh()
+      vi.advanceTimersByTime(20)
+      expect(timeout.signal.aborted).toBe(false)
+      vi.advanceTimersByTime(10)
+      expect(timeout.signal.aborted).toBe(true)
+
+      const completed = createWeworkSyncDownloadTimeout(1)
+      completed.clear()
+      vi.advanceTimersByTime(1)
+      expect(completed.signal.aborted).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('builds authenticated multipart uploads to the backend', async () => {
@@ -84,6 +114,7 @@ describe('Wework sync request normalization', () => {
   test('streams authenticated backend downloads to a local file', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'wework-sync-download-'))
     const path = join(directory, 'segment.enc')
+    let progressEvents = 0
 
     const body = await readWeworkSyncResponse(
       new Response('encrypted transcript', {
@@ -91,11 +122,15 @@ describe('Wework sync request normalization', () => {
         headers: { 'content-type': 'application/octet-stream' },
       }),
       path,
-      Buffer.byteLength('encrypted transcript')
+      Buffer.byteLength('encrypted transcript'),
+      () => {
+        progressEvents += 1
+      }
     )
 
     expect(body).toEqual({ path })
     expect(await readFile(path, 'utf8')).toBe('encrypted transcript')
+    expect(progressEvents).toBeGreaterThanOrEqual(2)
   })
 
   test('rejects backend downloads that exceed their declared size', async () => {

--- a/wework/electron/src/host/wework-sync-request.ts
+++ b/wework/electron/src/host/wework-sync-request.ts
@@ -4,6 +4,7 @@ import { Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 
 const REQUEST_ORIGIN = 'https://wework-sync.local'
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]', 'localhost'])
 export const WEWORK_SYNC_REQUEST_TIMEOUT_MS = 30_000
 
 export interface WeworkSyncRequest {
@@ -23,7 +24,8 @@ export interface WeworkSyncRequest {
 export async function readWeworkSyncResponse(
   response: Response,
   downloadPath?: string,
-  downloadSizeBytes?: number
+  downloadSizeBytes?: number,
+  onDownloadProgress?: () => void
 ): Promise<unknown> {
   if (downloadPath && response.ok) {
     if (!response.body) {
@@ -38,6 +40,7 @@ export async function readWeworkSyncResponse(
     }
     const expectedSizeBytes = downloadSizeBytes
     let receivedBytes = 0
+    onDownloadProgress?.()
     const sizeLimit = new Transform({
       transform(chunk, _encoding, callback) {
         receivedBytes += chunk.length
@@ -50,6 +53,7 @@ export async function readWeworkSyncResponse(
           )
           return
         }
+        onDownloadProgress?.()
         callback(null, chunk)
       },
       flush(callback) {
@@ -87,9 +91,31 @@ export function createWeworkSyncRequestSignal(
   return AbortSignal.timeout(timeoutMs)
 }
 
+export function createWeworkSyncDownloadTimeout(timeoutMs = WEWORK_SYNC_REQUEST_TIMEOUT_MS): {
+  signal: AbortSignal
+  refresh: () => void
+  clear: () => void
+} {
+  const controller = new AbortController()
+  let timer: NodeJS.Timeout | null = null
+  const clear = () => {
+    if (timer) clearTimeout(timer)
+    timer = null
+  }
+  const refresh = () => {
+    clear()
+    timer = setTimeout(() => controller.abort(), timeoutMs)
+    timer.unref()
+  }
+  refresh()
+  return { signal: controller.signal, refresh, clear }
+}
+
 export function normalizeWeworkSyncApiBaseUrl(value: string): string {
   const url = new URL(value.trim())
-  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) {
+  const secureTransport =
+    url.protocol === 'https:' || (url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname))
+  if (!secureTransport || url.username || url.password) {
     throw new CloudCredentialError('request_failed', 'Invalid Wework sync API URL')
   }
   url.pathname = url.pathname.replace(/\/+$/, '')
@@ -116,7 +142,8 @@ export function normalizeWeworkSyncPath(value: string): string {
 
 export async function createWeworkSyncFetchInit(
   request: WeworkSyncRequest,
-  authorization: string
+  authorization: string,
+  signal?: AbortSignal
 ): Promise<RequestInit> {
   if (request.file) {
     if (request.body === undefined) {
@@ -131,14 +158,14 @@ export async function createWeworkSyncFetchInit(
     )
     return {
       method: request.method,
-      signal: createWeworkSyncRequestSignal(10 * 60 * 1000),
+      signal: signal ?? createWeworkSyncRequestSignal(10 * 60 * 1000),
       headers: { authorization },
       body: form,
     }
   }
   return {
     method: request.method,
-    signal: createWeworkSyncRequestSignal(),
+    signal: signal ?? createWeworkSyncRequestSignal(),
     headers: {
       authorization,
       ...(request.body === undefined ? {} : { 'content-type': 'application/json' }),

--- a/wework/electron/src/host/wework-sync-request.ts
+++ b/wework/electron/src/host/wework-sync-request.ts
@@ -1,7 +1,85 @@
 import { CloudCredentialError } from './cloud-credential-service.js'
+import { createWriteStream, openAsBlob } from 'node:fs'
+import { Readable, Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 
 const REQUEST_ORIGIN = 'https://wework-sync.local'
 export const WEWORK_SYNC_REQUEST_TIMEOUT_MS = 30_000
+
+export interface WeworkSyncRequest {
+  apiBaseUrl: string
+  path: string
+  method: 'GET' | 'POST' | 'PUT'
+  body?: unknown
+  downloadPath?: string
+  downloadSizeBytes?: number
+  file?: {
+    path: string
+    name: string
+    contentType: string
+  }
+}
+
+export async function readWeworkSyncResponse(
+  response: Response,
+  downloadPath?: string,
+  downloadSizeBytes?: number
+): Promise<unknown> {
+  if (downloadPath && response.ok) {
+    if (!response.body) {
+      throw new CloudCredentialError('request_failed', 'Wework sync download body is missing')
+    }
+    if (
+      typeof downloadSizeBytes !== 'number' ||
+      !Number.isSafeInteger(downloadSizeBytes) ||
+      downloadSizeBytes < 1
+    ) {
+      throw new CloudCredentialError('request_failed', 'Wework sync download size is invalid')
+    }
+    const expectedSizeBytes = downloadSizeBytes
+    let receivedBytes = 0
+    const sizeLimit = new Transform({
+      transform(chunk, _encoding, callback) {
+        receivedBytes += chunk.length
+        if (receivedBytes > expectedSizeBytes) {
+          callback(
+            new CloudCredentialError(
+              'request_failed',
+              'Wework sync download exceeds its declared size'
+            )
+          )
+          return
+        }
+        callback(null, chunk)
+      },
+      flush(callback) {
+        if (receivedBytes !== expectedSizeBytes) {
+          callback(
+            new CloudCredentialError(
+              'request_failed',
+              'Wework sync download does not match its declared size'
+            )
+          )
+          return
+        }
+        callback()
+      },
+    })
+    await pipeline(
+      Readable.from(response.body as AsyncIterable<Uint8Array>),
+      sizeLimit,
+      createWriteStream(downloadPath, { mode: 0o600 })
+    )
+    return { path: downloadPath }
+  }
+  const text = await response.text()
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
 
 export function createWeworkSyncRequestSignal(
   timeoutMs = WEWORK_SYNC_REQUEST_TIMEOUT_MS
@@ -34,6 +112,39 @@ export function normalizeWeworkSyncPath(value: string): string {
     throw pathNotAllowed()
   }
   return `${url.pathname}${url.search}`
+}
+
+export async function createWeworkSyncFetchInit(
+  request: WeworkSyncRequest,
+  authorization: string
+): Promise<RequestInit> {
+  if (request.file) {
+    if (request.body === undefined) {
+      throw new CloudCredentialError('request_failed', 'Wework sync upload metadata is missing')
+    }
+    const form = new FormData()
+    form.append('metadata', JSON.stringify(request.body))
+    form.append(
+      'file',
+      await openAsBlob(request.file.path, { type: request.file.contentType }),
+      request.file.name
+    )
+    return {
+      method: request.method,
+      signal: createWeworkSyncRequestSignal(10 * 60 * 1000),
+      headers: { authorization },
+      body: form,
+    }
+  }
+  return {
+    method: request.method,
+    signal: createWeworkSyncRequestSignal(),
+    headers: {
+      authorization,
+      ...(request.body === undefined ? {} : { 'content-type': 'application/json' }),
+    },
+    ...(request.body === undefined ? {} : { body: JSON.stringify(request.body) }),
+  }
 }
 
 function pathNotAllowed(): CloudCredentialError {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -121,6 +121,7 @@ import { SecureValueStore } from './host/secure-value-store.js'
 import { resolveDevelopmentDockIdentity } from './host/development-dock-identity.js'
 import { isEffectivePackagedApplication } from './host/application-packaging-mode.js'
 import {
+  createWeworkSyncDownloadTimeout,
   createWeworkSyncFetchInit,
   normalizeWeworkSyncApiBaseUrl,
   normalizeWeworkSyncPath,
@@ -1430,19 +1431,26 @@ async function configureDesktopRuntime(): Promise<void> {
             const apiBaseUrl = normalizeWeworkSyncApiBaseUrl(request.apiBaseUrl)
             const path = normalizeWeworkSyncPath(request.path)
             const credential = await requiredCloudCredentials().refreshAccessToken(apiBaseUrl)
-            const response = await fetch(
-              `${apiBaseUrl}${path}`,
-              await createWeworkSyncFetchInit(
-                request,
-                `${credential.tokenType} ${credential.accessToken}`
+            const downloadTimeout = request.downloadPath ? createWeworkSyncDownloadTimeout() : null
+            try {
+              const response = await fetch(
+                `${apiBaseUrl}${path}`,
+                await createWeworkSyncFetchInit(
+                  request,
+                  `${credential.tokenType} ${credential.accessToken}`,
+                  downloadTimeout?.signal
+                )
               )
-            )
-            const body = await readWeworkSyncResponse(
-              response,
-              request.downloadPath,
-              request.downloadSizeBytes
-            )
-            return { status: response.status, body }
+              const body = await readWeworkSyncResponse(
+                response,
+                request.downloadPath,
+                request.downloadSizeBytes,
+                downloadTimeout?.refresh
+              )
+              return { status: response.status, body }
+            } finally {
+              downloadTimeout?.clear()
+            }
           },
         },
         {

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -121,9 +121,10 @@ import { SecureValueStore } from './host/secure-value-store.js'
 import { resolveDevelopmentDockIdentity } from './host/development-dock-identity.js'
 import { isEffectivePackagedApplication } from './host/application-packaging-mode.js'
 import {
-  createWeworkSyncRequestSignal,
+  createWeworkSyncFetchInit,
   normalizeWeworkSyncApiBaseUrl,
   normalizeWeworkSyncPath,
+  readWeworkSyncResponse,
 } from './host/wework-sync-request.js'
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -1429,24 +1430,18 @@ async function configureDesktopRuntime(): Promise<void> {
             const apiBaseUrl = normalizeWeworkSyncApiBaseUrl(request.apiBaseUrl)
             const path = normalizeWeworkSyncPath(request.path)
             const credential = await requiredCloudCredentials().refreshAccessToken(apiBaseUrl)
-            const response = await fetch(`${apiBaseUrl}${path}`, {
-              method: request.method,
-              signal: createWeworkSyncRequestSignal(),
-              headers: {
-                authorization: `${credential.tokenType} ${credential.accessToken}`,
-                ...(request.body === undefined ? {} : { 'content-type': 'application/json' }),
-              },
-              ...(request.body === undefined ? {} : { body: JSON.stringify(request.body) }),
-            })
-            const text = await response.text()
-            let body: unknown = null
-            if (text) {
-              try {
-                body = JSON.parse(text)
-              } catch {
-                body = text
-              }
-            }
+            const response = await fetch(
+              `${apiBaseUrl}${path}`,
+              await createWeworkSyncFetchInit(
+                request,
+                `${credential.tokenType} ${credential.accessToken}`
+              )
+            )
+            const body = await readWeworkSyncResponse(
+              response,
+              request.downloadPath,
+              request.downloadSizeBytes
+            )
             return { status: response.status, body }
           },
         },

--- a/wework/scripts/run-vitest.mjs
+++ b/wework/scripts/run-vitest.mjs
@@ -8,6 +8,7 @@ import { wrapWindowsScriptCommand } from './child-process-command.mjs'
 const rawArgs = process.argv.slice(2)
 const requestedArgs = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const electronRoot = join(root, 'electron')
 const integrationTestFiles = ['scripts/dev-executor-reload.integration.mjs']
 const nodeTestFiles = discoverNodeTestFiles()
 const requestedIntegrationTests = requestedArgs.filter(argument =>
@@ -16,10 +17,14 @@ const requestedIntegrationTests = requestedArgs.filter(argument =>
 const requestedNodeTests = requestedArgs.filter(argument =>
   nodeTestFiles.includes(normalizeArgumentPath(argument))
 )
+const requestedElectronTests = requestedArgs.filter(argument =>
+  normalizeArgumentPath(argument).startsWith('electron/')
+)
 const vitestArgs = requestedArgs.filter(
   argument =>
     !integrationTestFiles.includes(normalizeArgumentPath(argument)) &&
-    !nodeTestFiles.includes(normalizeArgumentPath(argument))
+    !nodeTestFiles.includes(normalizeArgumentPath(argument)) &&
+    !requestedElectronTests.includes(argument)
 )
 
 if (requestedArgs.length === 0) {
@@ -30,6 +35,17 @@ if (requestedArgs.length === 0) {
 
 if (requestedArgs.length === 0 || vitestArgs.length > 0) {
   run('vitest', ['run', ...vitestArgs])
+}
+
+if (requestedArgs.length === 0) {
+  run('pnpm', ['--dir', 'electron', 'test'])
+} else if (requestedElectronTests.length > 0) {
+  run('pnpm', [
+    '--dir',
+    'electron',
+    'test',
+    ...requestedElectronTests.map(argument => relative(electronRoot, resolve(root, argument))),
+  ])
 }
 
 if (requestedArgs.length === 0) {

--- a/wework/vite.config.ts
+++ b/wework/vite.config.ts
@@ -219,6 +219,7 @@ export default defineConfig({
       ...configDefaults.exclude,
       'dsh/**/*.test.mjs',
       'e2e/**',
+      'electron/**',
       'scripts/electron-e2e-launch-arguments.test.mjs',
       'scripts/harness-runtime-metadata.test.mjs',
       'test-results/**',


### PR DESCRIPTION
## Summary

- proxy encrypted transcript archive uploads and downloads through Backend, removing direct desktop-to-object-storage transfers
- preserve divergent local turns by skipping destructive restore while an outbox item is pending, and atomically adopt forked transcript IDs after lease conflicts
- force a fresh snapshot after cross-device restore so rewritten local rollout files cannot produce invalid byte-offset deltas
- isolate new-chat and project-scoped transcript state, and expose sync health, retry, and enable/disable controls in Wework settings
- document the required transcript bucket configuration and deployment flow

## Verification

- Backend focused tests: 14 passed
- DSH transcript/executor tests: 19 passed
- Executor transcript-sync tests: 3 passed
- Electron package tests: 577 passed
- Wework TypeScript, Electron TypeScript, ESLint, Prettier, Black, isort, cargo fmt, cargo clippy, Python syntax, settings config, and Alembic head checks passed
- Real Electron transcript-sync E2E passed: initial snapshot, dropped-response reconciliation, delta upload, second-device restore and continuation, disabled queue/retry, remote follow-up restore, lease-conflict branch, new-chat isolation, and project isolation
- Independent real Electron UI verification passed for sync status, disable/enable, and manual retry

E2E evidence: wework/test-results/desktop-e2e/2026-09-09T19-22-12-641Z-53070 (local, intentionally not committed)
AI verification evidence: wework/test-results/ai-verify/2026-09-09T19-31-29-538Z-65940 (local, intentionally not committed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WeWork transcript uploads and downloads now use authenticated backend transfers instead of direct storage links.
  * Added transcript sync status details, retry actions, and background refresh indicators.
  * Added automatic recovery and branching when transcripts change across devices.
  * Downloads can stream directly to local files with size validation and progress updates.
  * Added S3/MinIO configuration options for attachments and transcript storage.

* **Bug Fixes**
  * Improved handling of missing tasks, conflicting turns, failed uploads, and retry cleanup.
  * Added clearer synchronization error reporting and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->