### PR TITLE
feat(wework): extend Plugin Creator with account authentication

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -74,7 +74,7 @@ classify_path() {
       changed[wegent_cli]=true
       changed[platform_e2e]=true
       ;;
-    executor/* | sdk/plugin-auth/* | sdk/plugin-auth-go/* | sdk/dws-auth/* | sdk/plugin-build/*)
+    executor/* | sdk/plugin-auth/* | sdk/plugin-auth-go/* | sdk/dws-auth/* | sdk/plugin-build/* | sdk/plugin-creator/*)
       changed[executor]=true
       changed[platform_e2e]=true
       changed[wework_e2e]=true

--- a/.github/scripts/classify-wework-desktop-e2e.sh
+++ b/.github/scripts/classify-wework-desktop-e2e.sh
@@ -64,6 +64,7 @@ core_segments=(
 )
 plugin_segments=(
   core-dsh-ui-plugin-composition
+  plugin-marketplace-lifecycle
   plugin-lifecycle
   skill-mention-rendering
   sites-plugin-auto-install
@@ -762,6 +763,15 @@ classify_wework_path() {
 
 classify_path() {
   local path="$1"
+
+  case "$path" in
+    sdk/plugin-creator/* | sdk/plugin-auth/* | executor/src/local/plugin_creator.rs | \
+      wework/src/components/plugins/PluginCreateWorkspace* | \
+      wework/e2e/desktop/modules/plugin-flows.mjs)
+      select_target "plugins:plugin-marketplace-lifecycle"
+      select_target "cloud:plugin-workspace-publication"
+      ;;
+  esac
 
   case "$path" in
     sdk/plugin-auth/* | sdk/plugin-auth-go/* | sdk/dws-auth/* | executor/src/plugin_account_auth/* | \

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -386,6 +386,15 @@ wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-13","name":"Cloud / sha
 wework_desktop_other_e2e=false
 wework_desktop_other_e2e_matrix={"include":[]}' \
   "wework/e2e/desktop/fixtures/dws-store/main.go"
+assert_desktop_case "Creator resources select desktop and cloud delivery" \
+  'wework_desktop_e2e=true
+wework_desktop_core_e2e=false
+wework_desktop_core_e2e_matrix={"include":[]}
+wework_desktop_cloud_e2e=true
+wework_desktop_cloud_e2e_matrix={"include":[{"id":"cloud-15","name":"Cloud / shard 15","segments":"plugin-workspace-publication"}]}
+wework_desktop_other_e2e=true
+wework_desktop_other_e2e_matrix={"include":[{"id":"plugins-plugin-marketplace-lifecycle","name":"Plugins / plugin-marketplace-lifecycle","command":"e2e:desktop:plugins","segment":"plugin-marketplace-lifecycle"}]}' \
+  "sdk/plugin-creator/SKILL.md"
 for terminal_path in \
   wework/e2e/desktop/modules/terminal-compatibility-flows.mjs \
   backend/app/api/ws/terminal_namespace.py \

--- a/.github/workflows/plugin-auth-sdk.yml
+++ b/.github/workflows/plugin-auth-sdk.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - "sdk/plugin-auth/**"
+      - "sdk/plugin-creator/**"
       - "sdk/plugin-auth-go/**"
       - "sdk/dws-auth/**"
       - "sdk/plugin-build/**"
       - "shared/plugin_build.py"
       - "shared/tests/test_plugin_build.py"
       - "executor/src/plugin_account_auth/**"
+      - "executor/src/local/plugin_creator.rs"
       - "executor/src/process/mod.rs"
       - "executor/tests/plugin_account_auth_contract.rs"
       - ".github/workflows/plugin-auth-sdk.yml"
@@ -17,12 +19,14 @@ on:
     branches: [main]
     paths:
       - "sdk/plugin-auth/**"
+      - "sdk/plugin-creator/**"
       - "sdk/plugin-auth-go/**"
       - "sdk/dws-auth/**"
       - "sdk/plugin-build/**"
       - "shared/plugin_build.py"
       - "shared/tests/test_plugin_build.py"
       - "executor/src/plugin_account_auth/**"
+      - "executor/src/local/plugin_creator.rs"
       - "executor/src/process/mod.rs"
       - "executor/tests/plugin_account_auth_contract.rs"
       - ".github/workflows/plugin-auth-sdk.yml"
@@ -71,6 +75,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Test SDK, scaffolds, and isolated plugin processes
         run: uv run --no-project python -m unittest discover -s sdk/plugin-auth/tests -v
+      - name: Test Wework Creator Connector validation
+        run: uv run --no-project python -m unittest discover -s sdk/plugin-creator/tests -v
 
   native:
     strategy:

--- a/docker/device/Dockerfile
+++ b/docker/device/Dockerfile
@@ -57,6 +57,8 @@ ENV PATH=/root/.cargo/bin:${PATH}
 WORKDIR /build/executor
 COPY executor/Cargo.toml executor/Cargo.lock ./
 COPY executor/src ./src
+COPY sdk/plugin-auth /build/sdk/plugin-auth
+COPY sdk/plugin-creator /build/sdk/plugin-creator
 COPY shared/assets /build/shared/assets
 RUN if [ -n "$CARGO_REGISTRIES_CRATES_IO_INDEX" ]; then \
         export CARGO_REGISTRIES_CRATES_IO_INDEX; \

--- a/docker/executor/Dockerfile
+++ b/docker/executor/Dockerfile
@@ -29,6 +29,8 @@ FROM builder-deps AS builder
 ARG APP_VERSION=dev
 
 COPY executor/src /app/executor/src
+COPY sdk/plugin-auth /app/sdk/plugin-auth
+COPY sdk/plugin-creator /app/sdk/plugin-creator
 COPY shared/assets /app/shared/assets
 RUN cd /app/executor \
     && find src -type f -exec touch {} + \

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -152,6 +152,8 @@ ENV PATH=/root/.cargo/bin:${PATH}
 
 COPY executor/Cargo.toml executor/Cargo.lock /app/executor/
 COPY executor/src /app/executor/src
+COPY sdk/plugin-auth /app/sdk/plugin-auth
+COPY sdk/plugin-creator /app/sdk/plugin-creator
 COPY shared/assets /app/shared/assets
 RUN cd /app/executor && APP_VERSION="${APP_VERSION}" cargo build --release --locked
 

--- a/executor/src/agents/codex/home.rs
+++ b/executor/src/agents/codex/home.rs
@@ -30,7 +30,8 @@ pub(super) fn prepare_wework_codex_home(codex_home: &Path) -> Result<(), String>
         )
     })?;
     link_user_codex_auth(codex_home)?;
-    normalize_wework_codex_config(codex_home)
+    normalize_wework_codex_config(codex_home)?;
+    crate::local::plugin_creator::install(codex_home)
 }
 
 fn normalize_wework_codex_config(codex_home: &Path) -> Result<(), String> {

--- a/executor/src/local/local_skills.rs
+++ b/executor/src/local/local_skills.rs
@@ -78,20 +78,27 @@ impl SkillEntry {
 /// deduplicated, sorted JSON array of skills.
 pub async fn list_local_skills() -> CommandResult {
     let started_at = Instant::now();
-    let skills = tokio::task::spawn_blocking(collect_skills)
-        .await
-        .unwrap_or_default();
+    let result = tokio::task::spawn_blocking(|| {
+        super::plugin_creator::install(&codex_home_dir())?;
+        Ok::<_, String>(collect_skills())
+    })
+    .await;
+    let (skills, error) = match result {
+        Ok(Ok(skills)) => (skills, None),
+        Ok(Err(error)) => (Vec::new(), Some(error)),
+        Err(error) => (Vec::new(), Some(format!("Skill discovery failed: {error}"))),
+    };
     let stdout = Value::Array(skills.iter().map(SkillEntry::to_json).collect());
     CommandResult {
-        success: true,
-        exit_code: Some(0),
+        success: error.is_none(),
+        exit_code: Some(if error.is_none() { 0 } else { 1 }),
         stdout,
-        stderr: String::new(),
+        stderr: error.clone().unwrap_or_default(),
         duration: elapsed_seconds(started_at),
         timed_out: false,
         stdout_truncated: false,
         stderr_truncated: false,
-        error: None,
+        error,
     }
 }
 

--- a/executor/src/local/mod.rs
+++ b/executor/src/local/mod.rs
@@ -15,6 +15,7 @@ pub mod harnesses;
 pub mod local_skills;
 pub mod native_git;
 pub mod plugin_catalog;
+pub mod plugin_creator;
 pub mod plugin_import;
 pub mod pty;
 pub mod session;

--- a/executor/src/local/plugin_creator.rs
+++ b/executor/src/local/plugin_creator.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Executor-owned Creator resources, shared by desktop and cloud Codex homes.
+
+use std::{fs, io::Write, path::Path};
+
+use fs2::FileExt;
+
+pub const SKILL_NAME: &str = "wework-plugin-creator";
+
+const FILES: &[(&str, &[u8])] = &[
+    (
+        "SKILL.md",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-creator/SKILL.md"
+        )),
+    ),
+    (
+        "references/account-auth.md",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-creator/references/account-auth.md"
+        )),
+    ),
+    (
+        "references/account-auth.en.md",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-creator/references/account-auth.en.md"
+        )),
+    ),
+    (
+        "scripts/validate_wework_plugin.py",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-creator/scripts/validate_wework_plugin.py"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/tool.py",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/tool.py"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/README.md",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/README.md"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/README.en.md",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/README.en.md"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/LICENSE",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/LICENSE"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/templates/account-auth.py.tmpl",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/templates/account-auth.py.tmpl"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/templates/cli.py.tmpl",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/templates/cli.py.tmpl"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/templates/auth_provider.py.tmpl",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/templates/auth_provider.py.tmpl"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/templates/oauth-provider.inc",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/templates/oauth-provider.inc"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/wegent_plugin_auth/__init__.py",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/wegent_plugin_auth/__init__.py"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/wegent_plugin_auth/adapter.py",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/wegent_plugin_auth/adapter.py"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/wegent_plugin_auth/configuration.py",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/wegent_plugin_auth/configuration.py"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/wegent_plugin_auth/runtime.py",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/wegent_plugin_auth/runtime.py"
+        )),
+    ),
+    (
+        "scripts/auth-sdk/wegent_plugin_auth/transport.py",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sdk/plugin-auth/wegent_plugin_auth/transport.py"
+        )),
+    ),
+];
+
+/// Materialize the skill before discovery/startup. The SDK is embedded directly
+/// from its canonical source, so released executors never need a source checkout.
+pub fn install(codex_home: &Path) -> Result<(), String> {
+    install_files(codex_home)
+        .map_err(|error| format!("prepare Wework Plugin Creator failed: {error}"))
+}
+
+fn install_files(codex_home: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(codex_home)?;
+    let lock_path = codex_home.join(".wework-plugin-creator.lock");
+    reject_symlink(&lock_path)?;
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)?;
+    lock.lock_exclusive()?;
+    let skills = codex_home.join("skills");
+    create_directory(&skills)?;
+    let root = skills.join(SKILL_NAME);
+    create_directory(&root)?;
+    for (relative, content) in FILES {
+        let path = root.join(relative);
+        let mut parent = root.clone();
+        for component in Path::new(relative).parent().unwrap().components() {
+            parent.push(component);
+            create_directory(&parent)?;
+        }
+        reject_symlink(&path)?;
+        if fs::read(&path).is_ok_and(|current| current == *content) {
+            continue;
+        }
+        let mut temporary = tempfile::NamedTempFile::new_in(&parent)?;
+        temporary.write_all(content)?;
+        temporary.persist(&path).map_err(|error| error.error)?;
+    }
+    Ok(())
+}
+
+fn create_directory(path: &Path) -> std::io::Result<()> {
+    reject_symlink(path)?;
+    fs::create_dir_all(path)
+}
+
+fn reject_symlink(path: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Creator resources must not use symlinks",
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installs_and_repairs_resources_without_changing_codex_system_skills() {
+        let home = tempfile::tempdir().unwrap();
+        let upstream = home.path().join("skills/.system/plugin-creator");
+        fs::create_dir_all(&upstream).unwrap();
+        fs::write(upstream.join("SKILL.md"), "upstream-owned").unwrap();
+        install(home.path()).unwrap();
+        let root = home.path().join("skills").join(SKILL_NAME);
+        let script = root.join("scripts/auth-sdk/tool.py");
+        fs::write(&script, "obsolete").unwrap();
+        fs::remove_file(root.join("scripts/auth-sdk/templates/cli.py.tmpl")).unwrap();
+        install(home.path()).unwrap();
+        for (relative, content) in FILES {
+            assert_eq!(fs::read(root.join(relative)).unwrap(), *content);
+        }
+        assert_eq!(
+            fs::read_to_string(upstream.join("SKILL.md")).unwrap(),
+            "upstream-owned"
+        );
+        let before = fs::metadata(&script).unwrap().modified().unwrap();
+        install(home.path()).unwrap();
+        assert_eq!(fs::metadata(&script).unwrap().modified().unwrap(), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_to_write_through_a_skill_symlink() {
+        use std::os::unix::fs::symlink;
+        let home = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        fs::create_dir(home.path().join("skills")).unwrap();
+        symlink(other.path(), home.path().join("skills").join(SKILL_NAME)).unwrap();
+        assert!(install(home.path()).unwrap_err().contains("symlinks"));
+        assert_eq!(fs::read_dir(other.path()).unwrap().count(), 0);
+    }
+}

--- a/executor/tests/local_app_ipc_contract.rs
+++ b/executor/tests/local_app_ipc_contract.rs
@@ -1614,6 +1614,17 @@ async fn app_ipc_lists_codex_skills_from_runtime_directories() {
     assert_eq!(response["ok"], true);
     assert_eq!(response["result"]["success"], true);
     let skills = response["result"]["stdout"].as_array().unwrap();
+    assert_eq!(skills.len(), 4);
+    let creator = skills
+        .iter()
+        .find(|skill| skill["name"] == "wework-plugin-creator")
+        .unwrap();
+    assert_eq!(creator["source"], "codex");
+    assert!(Path::new(creator["path"].as_str().unwrap()).is_file());
+    let skills = skills
+        .iter()
+        .filter(|skill| skill["name"] != "wework-plugin-creator")
+        .collect::<Vec<_>>();
     assert_eq!(skills.len(), 3);
     assert_eq!(skills[0]["name"], json!("codex-review"));
     assert_eq!(

--- a/executor/tests/plugin_account_auth_contract.rs
+++ b/executor/tests/plugin_account_auth_contract.rs
@@ -19,6 +19,94 @@ fn definition() -> Value {
     json!({"protocolVersion":1,"credentialType":"password","adapter":"scripts/account-auth.py"})
 }
 
+#[tokio::test]
+async fn shipped_creator_scaffolds_execute_without_a_source_checkout() {
+    let home = tempfile::tempdir().unwrap();
+    wegent_executor::local::plugin_creator::install(home.path()).unwrap();
+    let tool = home
+        .path()
+        .join("skills/wework-plugin-creator/scripts/auth-sdk/tool.py");
+    for (kind, credential) in [
+        (
+            "password",
+            json!({"username":"alice","password":"synthetic-secret"}),
+        ),
+        ("bearer", json!({"token":"synthetic-token"})),
+        ("oauth2", json!({"access_token":"synthetic-access"})),
+    ] {
+        let output = std::process::Command::new(python())
+            .args([
+                tool.as_os_str(),
+                "scaffold".as_ref(),
+                kind.as_ref(),
+                "--parent".as_ref(),
+                home.path().as_os_str(),
+                "--credential-type".as_ref(),
+                kind.as_ref(),
+            ])
+            .current_dir(home.path())
+            .env_remove("PYTHONPATH")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let root = home.path().join(kind);
+        let mut manifest: Value =
+            serde_json::from_slice(&fs::read(root.join(".codex-plugin/plugin.json")).unwrap())
+                .unwrap();
+        // This fixture implements export/run only, so it must not advertise
+        // unimplemented OAuth lifecycle callbacks from the development template.
+        manifest["connectors"][0]["accountAuth"]
+            .as_object_mut()
+            .unwrap()
+            .remove("oauth2");
+        fs::write(root.join(".codex-plugin/plugin.json"), manifest.to_string()).unwrap();
+        let provider_path = root.join("scripts/auth_provider.py");
+        let provider_source = fs::read_to_string(&provider_path).unwrap();
+        fs::write(
+            &provider_path,
+            provider_source
+                + &format!(
+                    r#"
+import json
+ALLOWED_COMMANDS = ("status",)
+def export_local():
+    return json.loads({credential:?})
+def account_id(credential):
+    return "alice"
+def execute(credential, arguments):
+    assert credential == json.loads({credential:?})
+    print("business-ok")
+    return 0
+"#,
+                    credential = credential.to_string()
+                ),
+        )
+        .unwrap();
+        let adapter =
+            NativeAdapter::load(&root, kind, &manifest["connectors"][0]["accountAuth"]).unwrap();
+        let exported = adapter
+            .export(&python(), Duration::from_secs(10))
+            .await
+            .unwrap();
+        assert_eq!(exported.account_id, "alice");
+        let result = adapter
+            .run(
+                &python(),
+                exported.credential,
+                &["status".into()],
+                None,
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8(result).unwrap().trim(), "business-ok");
+    }
+}
+
 fn oauth_definition() -> Value {
     json!({"protocolVersion":1,"credentialType":"oauth2","adapter":"scripts/account-auth.py","oauth2":["authorize","refresh","revoke"]})
 }

--- a/frontend/e2e/fixtures/claudecode-executor/Dockerfile
+++ b/frontend/e2e/fixtures/claudecode-executor/Dockerfile
@@ -22,6 +22,8 @@ RUN mkdir -p src/bin \
 FROM builder-deps AS builder
 
 COPY executor/src ./src
+COPY sdk/plugin-auth /workspace/src/sdk/plugin-auth
+COPY sdk/plugin-creator /workspace/src/sdk/plugin-creator
 COPY shared/assets /workspace/src/shared/assets
 RUN find src -type f -exec touch {} + \
     && cargo build --release --locked --bin wegent-executor

--- a/sdk/plugin-creator/SKILL.md
+++ b/sdk/plugin-creator/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: wework-plugin-creator
+description: Create or extend Wework plugins, including native Connector login and account authentication for reuse on cloud devices. Use for Wework Plugin Creator tasks; preserve the selected Task workspace or managed personal marketplace.
+---
+
+# Wework Plugin Creator
+
+Use the installed Codex `plugin-creator` skill for common plugin structure,
+metadata, skills, and marketplace helpers. Apply the Wework workflow below to
+storage, authentication, and validation. This skill and its authentication SDK
+are shipped by the Executor and work without a Wegent source checkout.
+
+## Choose the authentication path
+
+Before generating a plugin, establish how its business commands authenticate:
+
+- Public data or a skill without authenticated commands: do not add Connectors.
+- An existing platform-managed remote Connector/MCP: reuse that connection;
+  do not export platform credentials or wrap it in a local account adapter.
+- A plugin-owned local CLI/session, password, API token, or OAuth authorization
+  that must work on cloud devices: read
+  [references/account-auth.md](references/account-auth.md), generate the adapter
+  using the bundled SDK, and route business calls through that SDK.
+
+`connectors` and `localAuth` alone do not enable account synchronization. Each
+supported local credential flow needs `connectors[].accountAuth`, a working
+provider implementation, and a delegated business entrypoint. If the provider
+cannot safely support this, explain the concrete limitation; do not advertise
+cloud authentication support or invent credential copying.
+
+## Create and iterate
+
+1. Resolve the source location from the task environment. For `DEVICE_TYPE=cloud`,
+   use `$WEGENT_TASK_WORKSPACE/plugins/<plugin-name>`. Otherwise resolve the
+   registered `wework-personal` marketplace and use its existing plugin directory.
+   Do not use upstream defaults under `~/plugins` or `~/.agents`.
+2. For native account authentication, use `scripts/auth-sdk/tool.py scaffold` as
+   described in the reference. For other plugins, use the upstream scaffold with
+   the explicit destination. Preserve existing source and manifest fields when
+   extending a plugin; scaffold into a temporary directory to obtain templates.
+3. Implement the requested skills/MCP/business commands. Keep the existing native
+   Connector login entry; authentication setup remains a host operation, and
+   cloud tasks must never request passwords, tokens, or exported credentials.
+4. Run the Wework validator below, then test provider behavior with synthetic
+   credentials and the unpacked distributable. A scaffold passing validation
+   does not mean its provider is implemented or authenticated.
+5. Locally, keep both managed marketplace manifests consistent and install/update
+   through the existing managed marketplace flow. In cloud tasks, leave the source
+   in the Task workspace and run `plugin-workspace describe` with the Executor.
+   Return the complete `[WEGENT_PLUGIN_RESULT]` line verbatim. Publish only when
+   requested, using the same source and the host's publication workflow.
+
+## Validate
+
+Run from this skill directory (use absolute script paths from another directory):
+
+```bash
+uv run --no-project --with pyyaml python scripts/validate_wework_plugin.py <plugin-root>
+```
+
+The validator reuses the installed upstream validator for standard manifest
+fields, assets, and skills, and separately validates Wework Connectors. It does
+not alter the plugin manifest. Do not run the upstream validator directly on a
+Wework manifest containing `connectors`, or remove that declaration to make it
+pass. For a Python adapter, also check the bundled SDK:
+
+```bash
+uv run --no-project python scripts/auth-sdk/tool.py vendor <plugin-root> --check
+```
+
+Report structural validation, provider tests, local login/synchronization, and
+real cloud business execution separately. Do not claim the latter from generated
+code or synthetic tests alone.

--- a/sdk/plugin-creator/references/account-auth.en.md
+++ b/sdk/plugin-creator/references/account-auth.en.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 1
+title: Wework plugin authentication
+---
+
+# Wework plugin authentication
+
+Use this flow for plugin-owned local authentication. Reuse existing
+platform-managed remote Connectors without exporting their credentials.
+`localAuth` describes native login; `accountAuth` enables account reuse across
+devices. The host synchronizes after local login and supplies temporary
+credentials to authorized native business calls. Do not add credential upload
+APIs, synchronization buttons, or model-visible export tools.
+
+From the skill root, run:
+
+```bash
+uv run --no-project python scripts/auth-sdk/tool.py scaffold my-service \
+  --parent <task-selected-parent> --credential-type password
+```
+
+Supported types are `password`, `bearer`, and `oauth2`. The Executor bundles the
+canonical SDK and templates; a Wegent checkout is unnecessary. The generated
+adapter, provider, business CLI, and SDK are development scaffolds that reject
+export and execution until implemented. For existing plugins, scaffold in a
+temporary directory and merge into the existing Connector without replacing its
+slug, `localAuth`, MCP, or unrelated manifest fields. Update SDK copies with
+`tool.py vendor <plugin-root>`.
+
+Implement read-only `export_local()`, public `account_id()`, a business-only
+`ALLOWED_COMMANDS`, and in-memory `execute()`. Add provider validation as needed.
+Existing CLIs must call `delegate_cloud_command()` before reading local auth and
+propagate its exit code when non-None. Cloud failures must not trigger local
+fallback or login. MCP servers must invoke the delegated business path; adding
+a declaration to a long-running MCP server that reads credentials itself is
+insufficient.
+
+Preserve native login. New `localAuth` definitions need real `health`, `start`,
+and, for `local_qr`, `poll` commands; optional `logout` should match the provider.
+Use `browser_oauth` only for a supported browser flow. Do not disguise password
+or API-key input as QR login. If native setup is unavailable, identify the
+missing host capability. Commands use package-relative paths and return public
+status metadata only.
+
+OAuth providers implement the declared `authorize`, `refresh`, and `revoke`
+operations, state/PKCE S256, absolute `expires_at`, and refresh-token rotation.
+Keep refresh-only secrets in `provider_private`. Business code must not refresh
+credentials or retry an uncertain refresh. CLI-managed OAuth requires transfer
+of exclusive refresh ownership with recoverable, idempotent `detach`, or a
+separate Wegent authorization. DWS requires its specialized native build and
+migration adapter. This scaffold supplies Python, not JavaScript/PowerShell SDKs.
+
+Declare non-secret local directories/enums in `accountAuth.localEnvironment` and
+read them through `local_configuration()` in source-device callbacks. Do not
+upload local paths or use configuration fields for secrets. See the bundled
+[SDK protocol](../scripts/auth-sdk/README.en.md) for details.
+
+Validate the full manifest with the Wework validator and run SDK `vendor --check`.
+Test the unpacked artifact with synthetic credentials, allowed/denied commands,
+exit-code propagation, redacted errors, and OAuth lifecycle where relevant.
+Separately verify native login and automatic sync, then real business execution
+on a device without local provider credentials. Revoked or unauthorized access
+must fail without login. Report these layers separately; structural validation
+does not prove an implemented provider or cloud authentication.

--- a/sdk/plugin-creator/references/account-auth.md
+++ b/sdk/plugin-creator/references/account-auth.md
@@ -1,0 +1,103 @@
+---
+sidebar_position: 1
+title: Wework 插件认证接入
+---
+
+# Wework 插件认证接入
+
+适用于插件自身管理的本机认证。已有平台托管的远程 Connector 继续复用平台连接。
+本机登录入口由 `localAuth` 描述，跨设备账号能力由 `accountAuth` 描述；二者职责不同。
+宿主在本机登录后后台同步账号凭据，并按设备权限为云端业务调用提供临时凭据。
+插件不实现凭据上传 API，不增加同步按钮，也不让模型调用认证导出入口。
+
+## 生成与修改
+
+从此 skill 根目录运行，`<parent>` 必须是任务确定的源码父目录：
+
+```bash
+uv run --no-project python scripts/auth-sdk/tool.py scaffold my-service \
+  --parent <parent> --credential-type password
+```
+
+类型可选 `password`、`bearer`、`oauth2`。工具随 Executor 分发，源码与模板来自同一份
+Wegent 公共 SDK；不用下载另一份 SDK，也不需要访问 Wegent 开发仓库。
+
+生成 `scripts/account-auth.py`、`scripts/auth_provider.py`、`scripts/cli.py` 和
+`scripts/wegent_plugin_auth/`，并声明：
+
+```json
+{
+  "connectors": [
+    {
+      "slug": "my-service",
+      "authPolicy": "optional",
+      "accountAuth": {
+        "protocolVersion": 1,
+        "credentialType": "password",
+        "adapter": "scripts/account-auth.py"
+      }
+    }
+  ]
+}
+```
+
+该骨架默认拒绝导出和执行，不是已完成的插件。修改现有插件时，在临时目录生成骨架，
+合并对应 Connector 的 `accountAuth`，保留已有 slug、`localAuth`、MCP 和其他 manifest 字段。
+通过 `tool.py vendor <plugin-root>` 更新 SDK；不要手改 SDK 副本。
+
+实现 `export_local()`（只读本机认证）、`account_id()`（稳定公开账号标识）、
+`ALLOWED_COMMANDS`（业务命令白名单）、`execute()`（内存中使用凭据）。按需实现
+`validate()`。不要把登录、登出、认证导出放入业务命令白名单。
+
+已有业务 CLI 应在读取本机认证之前调用 `delegate_cloud_command()`；返回非 `None`
+时传播退出码。本机普通命令继续原有实现；云端授权失败不得退回本机认证或发起云端登录。
+MCP 服务若调用业务 CLI，应使用这一入口。长期驻留且自行读取凭据的 MCP 服务不能只加
+manifest 就算完成适配，必须验证实际业务路径通过平台代理执行。
+
+## 本机登录入口
+
+保留已有原生 Connector 登录流程。新插件需要原生入口时，可声明 `localAuth`：
+
+```json
+{
+  "kind": "local_qr",
+  "health": ["python3", "scripts/login.py", "health"],
+  "start": ["python3", "scripts/login.py", "start"],
+  "poll": ["python3", "scripts/login.py", "poll"],
+  "logout": ["python3", "scripts/login.py", "logout"],
+  "statusField": "status",
+  "okValues": ["ok"],
+  "qrField": "qr_path"
+}
+```
+
+这只是协议示例，不提供登录实现。按服务真实能力选择 `local_qr` 或 `browser_oauth`，
+不要把密码/API Key 输入伪装成扫码。如果没有适合的原生登录机制，说明缺失的宿主能力。
+命令使用包内相对路径；公共状态只包含状态码、二维码路径等必要元数据。
+
+## OAuth 与特殊 CLI
+
+OAuth 模板包含 `authorize`、`refresh`、`revoke` 回调，通过 `accountAuth.oauth2`
+声明支持的操作；只声明已实现的操作。处理 state、PKCE S256、绝对时间 `expires_at`
+和 Refresh Token 轮换。业务回调只拿 Access Token 等业务必要字段，刷新秘密放入
+`provider_private`。不要在业务回调自行刷新或重试结果不确定的刷新。
+
+已有 CLI 会自行刷新 OAuth 时，先确认能否转移唯一刷新权。支持时才使用
+`exportMode: "exclusive"` 并实现可恢复、幂等的 `detach`；不支持时创建独立的 Wegent
+授权。DWS 等自带原生认证的 CLI 需要其专用构建与迁移适配，不能直接套密码模板。
+本 skill 的脚手架提供 Python SDK；不宣称已提供 JavaScript/PowerShell SDK。
+
+自定义本机认证目录通过 `accountAuth.localEnvironment` 声明，在源设备回调中调用
+`local_configuration()`。只允许目录和公开枚举，不存秘密，也不把本机路径上传后端。
+完整回调、OAuth、通道与配置规范见 [SDK 协议](../scripts/auth-sdk/README.md)。
+
+## 验收
+
+- 结构：完整 manifest 通过 Wework 校验；SDK `vendor --check` 通过；解包后仍含入口、
+  SDK、依赖及声明的原生产物。适配器不得从包外的 Wegent 源码导入模块。
+- 提供方：用合成凭据覆盖允许/拒绝命令、退出码、日志脱敏；OAuth 覆盖过期、刷新和撤销。
+  不把适配器注册为模型工具，不在 Skill 中要求模型读取本机凭据或执行导出。
+- 本机：用户通过原生入口登录后，后台同步成功；重新登录、登出后连接状态符合预期。
+- 云端：在无该服务本机凭据的设备上调用真实业务；未授权/断开时失败，不触发登录。
+
+无法执行某一层时记录具体未验证项；不要把脚手架成功等同于云端可用。

--- a/sdk/plugin-creator/scripts/validate_wework_plugin.py
+++ b/sdk/plugin-creator/scripts/validate_wework_plugin.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Compose Codex plugin validation with Wework Connector contract checks."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import re
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+def packaged_file(root: Path, value: Any) -> bool:
+    """Accept regular files inside the distributable, without symlink traversal."""
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9_./-]+", value):
+        return False
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        return False
+    candidate = root
+    for part in path.parts:
+        candidate = candidate / part
+        if candidate.is_symlink():
+            return False
+    return candidate.is_file()
+
+
+def validate_environment(value: Any, errors: list[str], label: str) -> None:
+    if not isinstance(value, dict) or not 1 <= len(value) <= 16:
+        errors.append(f"{label} must contain 1 to 16 non-secret settings")
+        return
+    for name, setting in value.items():
+        valid = isinstance(name, str) and re.fullmatch(r"[A-Z][A-Z0-9_]{0,63}", name)
+        if not isinstance(setting, dict):
+            valid = False
+        elif setting.get("type") == "directory":
+            valid = valid and set(setting) == {"type"}
+        elif setting.get("type") == "enum":
+            values = setting.get("values")
+            valid = (
+                valid
+                and set(setting) == {"type", "values"}
+                and isinstance(values, list)
+                and 1 <= len(values) <= 16
+                and all(
+                    isinstance(item, str)
+                    and re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", item)
+                    for item in values
+                )
+            )
+            if valid:
+                valid = len(set(values)) == len(values)
+        else:
+            valid = False
+        if not valid:
+            errors.append(f"{label} contains an invalid directory/enum declaration")
+
+
+def validate_account_auth(
+    root: Path, value: Any, errors: list[str], label: str
+) -> None:
+    if not isinstance(value, dict):
+        errors.append(f"{label} must be an object")
+        return
+    required = {"protocolVersion", "credentialType", "adapter"}
+    allowed = required | {"oauth2", "exportMode", "localEnvironment"}
+    if not required <= set(value) or set(value) - allowed:
+        errors.append(f"{label} has missing or unsupported fields")
+    if type(value.get("protocolVersion")) is not int or value["protocolVersion"] != 1:
+        errors.append(f"{label}.protocolVersion must be integer 1")
+    kind = value.get("credentialType")
+    if kind not in ("password", "bearer", "oauth2"):
+        errors.append(f"{label}.credentialType must be password, bearer, or oauth2")
+    adapter = value.get("adapter")
+    if (
+        not packaged_file(root, adapter)
+        or len(adapter) > 256
+        or not adapter.endswith((".py", ".mjs", ".sh", ".ps1"))
+    ):
+        errors.append(f"{label}.adapter must reference a packaged relative script")
+    if "oauth2" in value:
+        operations = value["oauth2"]
+        valid = (
+            kind == "oauth2"
+            and isinstance(operations, list)
+            and bool(operations)
+            and all(item in ("authorize", "refresh", "revoke") for item in operations)
+        )
+        if not valid or len(set(operations)) != len(operations):
+            errors.append(
+                f"{label}.oauth2 requires distinct supported OAuth operations"
+            )
+    if "exportMode" in value and (
+        value["exportMode"] != "exclusive" or kind != "oauth2"
+    ):
+        errors.append(f"{label}.exportMode requires exclusive OAuth ownership")
+    if "localEnvironment" in value:
+        validate_environment(
+            value["localEnvironment"], errors, f"{label}.localEnvironment"
+        )
+
+
+def validate_local_auth(root: Path, value: Any, errors: list[str], label: str) -> None:
+    if not isinstance(value, dict):
+        errors.append(f"{label} must be an object")
+        return
+    kind = value.get("kind", "local_qr")
+    if kind not in ("local_qr", "browser_oauth"):
+        errors.append(f"{label}.kind must be local_qr or browser_oauth")
+    required = {"health", "start"} | ({"poll"} if kind == "local_qr" else set())
+    for operation in ("health", "start", "poll", "logout"):
+        command = value.get(operation, [])
+        if (
+            not isinstance(command, list)
+            or (operation in required and not command)
+            or not all(isinstance(arg, str) and arg.strip() for arg in command)
+        ):
+            errors.append(f"{label}.{operation} must contain a valid command array")
+            continue
+        for arg in command:
+            if (
+                arg.startswith(("/", "~"))
+                or ".." in PurePosixPath(arg).parts
+                or re.match(r"^[A-Za-z]:[\\/]", arg)
+            ):
+                errors.append(f"{label}.{operation} must use plugin-relative paths")
+            elif arg.startswith(("scripts/", "./scripts/", "bin/", "./bin/")):
+                if not packaged_file(root, arg):
+                    errors.append(
+                        f"{label}.{operation} references a missing packaged file"
+                    )
+
+
+def validate_connectors(root: Path, value: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(value, list):
+        return ["connectors must be an array"]
+    seen: set[str] = set()
+    for index, connector in enumerate(value):
+        label = f"connectors[{index}]"
+        if not isinstance(connector, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        if set(connector) - {"slug", "authPolicy", "localAuth", "accountAuth"}:
+            errors.append(f"{label} contains unsupported fields")
+        slug = connector.get("slug")
+        if not isinstance(slug, str) or not re.fullmatch(
+            r"[a-z0-9][a-z0-9_-]{0,99}", slug
+        ):
+            errors.append(f"{label}.slug is invalid")
+        elif slug in seen:
+            errors.append(f"{label}.slug must be unique")
+        else:
+            seen.add(slug)
+        if connector.get("authPolicy", "optional") not in (
+            "on_install",
+            "on_use",
+            "optional",
+        ):
+            errors.append(f"{label}.authPolicy is invalid")
+        if "accountAuth" in connector:
+            validate_account_auth(
+                root, connector["accountAuth"], errors, f"{label}.accountAuth"
+            )
+        if "localAuth" in connector:
+            validate_local_auth(
+                root, connector["localAuth"], errors, f"{label}.localAuth"
+            )
+    return errors
+
+
+def load_codex_validator(creator_root: Path) -> Any:
+    path = creator_root / "scripts/validate_plugin.py"
+    if not path.is_file():
+        raise ValueError("Installed Codex plugin-creator validator is missing")
+    spec = importlib.util.spec_from_file_location("codex_plugin_validator", path)
+    if spec is None or spec.loader is None:
+        raise ValueError("Cannot load the installed Codex plugin-creator validator")
+    validator = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(validator)
+    return validator
+
+
+def validate_plugin(root: Path, codex_validator: Any) -> list[str]:
+    errors: list[str] = []
+    manifest = codex_validator.load_json_object(
+        root / ".codex-plugin/plugin.json", errors
+    )
+    if manifest is None:
+        return errors
+    codex_validator.reject_todo_markers(manifest, "$", errors)
+    # Validate standard fields on a projection while retaining the original file
+    # and root for asset/skill checks. Never suppress upstream validation errors.
+    standard = {key: value for key, value in manifest.items() if key != "connectors"}
+    codex_validator.validate_manifest_shape(root, standard, errors)
+    if "connectors" in manifest:
+        errors.extend(validate_connectors(root, manifest["connectors"]))
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plugin_root", type=Path)
+    parser.add_argument("--codex-creator-root", type=Path)
+    args = parser.parse_args()
+    creator_root = args.codex_creator_root
+    if creator_root is None:
+        home = os.environ.get("WEGENT_CODEX_HOME") or os.environ.get("CODEX_HOME")
+        if not home:
+            parser.error("Set CODEX_HOME or pass --codex-creator-root")
+        creator_root = Path(home) / "skills/.system/plugin-creator"
+    try:
+        errors = validate_plugin(
+            args.plugin_root.resolve(), load_codex_validator(creator_root)
+        )
+    except (OSError, ValueError, ImportError):
+        print(
+            "Unable to load plugin or Codex validator; check installation and dependencies."
+        )
+        raise SystemExit(1) from None
+    for error in errors:
+        print(error)
+    if errors:
+        raise SystemExit(1)
+    print(
+        "Wework plugin structure passed; provider behavior requires separate verification."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/plugin-creator/tests/test_validation.py
+++ b/sdk/plugin-creator/tests/test_validation.py
@@ -1,0 +1,155 @@
+"""Structural validation and composition without running provider code."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "wework_validator", ROOT / "scripts/validate_wework_plugin.py"
+)
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class ConnectorValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        (self.root / "scripts").mkdir()
+        (self.root / "scripts/account-auth.py").write_text(
+            'raise RuntimeError("Validation must not execute provider code")\n'
+        )
+        self.connector = {
+            "slug": "service",
+            "authPolicy": "optional",
+            "accountAuth": {
+                "protocolVersion": 1,
+                "credentialType": "password",
+                "adapter": "scripts/account-auth.py",
+            },
+        }
+
+    def test_password_bearer_and_oauth_declarations(self) -> None:
+        for kind in ("password", "bearer", "oauth2"):
+            with self.subTest(kind=kind):
+                connector = copy.deepcopy(self.connector)
+                auth = connector["accountAuth"]
+                auth["credentialType"] = kind
+                if kind == "oauth2":
+                    auth["oauth2"] = ["authorize", "refresh", "revoke"]
+                    auth["exportMode"] = "exclusive"
+                auth["localEnvironment"] = {
+                    "AUTH_DIR": {"type": "directory"},
+                    "KEYCHAIN_DISABLED": {"type": "enum", "values": ["1"]},
+                }
+                self.assertEqual(
+                    validator.validate_connectors(self.root, [connector]), []
+                )
+
+    def test_rejects_invalid_or_missing_adapter_contracts(self) -> None:
+        invalid = (
+            {"protocolVersion": True},
+            {"protocolVersion": 2},
+            {"credentialType": "session"},
+            {"adapter": "../scripts/account-auth.py"},
+            {"adapter": "/scripts/account-auth.py"},
+            {"adapter": "scripts/missing.py"},
+            {"adapter": []},
+            {"oauth2": ["refresh"]},
+            {"oauth2": [["refresh"]]},
+            {"exportMode": "exclusive"},
+            {"localEnvironment": {"TOKEN": {"type": "secret"}}},
+            {
+                "localEnvironment": {
+                    "AUTH_DIR": {"type": "directory", "value": "/local"}
+                }
+            },
+            {"localEnvironment": {"MODE": {"type": "enum", "values": ["a", "a"]}}},
+            {"credential": "must-not-be-in-manifest"},
+        )
+        for change in invalid:
+            with self.subTest(change=change):
+                connector = copy.deepcopy(self.connector)
+                connector["accountAuth"].update(change)
+                self.assertTrue(validator.validate_connectors(self.root, [connector]))
+
+    def test_duplicate_or_malformed_connectors_fail_instead_of_disappearing(
+        self,
+    ) -> None:
+        for connectors in (
+            {},
+            [None],
+            [self.connector, self.connector],
+            [{"slug": "UPPER"}],
+            [{"slug": "service", "authPolicy": "ON_USE"}],
+            [{"slug": "service", "accountAuth": None}],
+        ):
+            with self.subTest(connectors=connectors):
+                self.assertTrue(validator.validate_connectors(self.root, connectors))
+        self.assertEqual(validator.validate_connectors(self.root, []), [])
+        self.assertEqual(
+            validator.validate_connectors(
+                self.root, [{"slug": "remote", "authPolicy": "on_use"}]
+            ),
+            [],
+        )
+
+    def test_native_login_requires_real_packaged_commands(self) -> None:
+        connector = copy.deepcopy(self.connector)
+        connector["localAuth"] = {
+            "kind": "local_qr",
+            "health": ["python3", "scripts/login.py", "health"],
+            "start": ["python3", "scripts/login.py", "start"],
+            "poll": ["python3", "scripts/login.py", "poll"],
+        }
+        self.assertTrue(validator.validate_connectors(self.root, [connector]))
+        (self.root / "scripts/login.py").write_text("# Packaged login entry\n")
+        self.assertEqual(validator.validate_connectors(self.root, [connector]), [])
+        del connector["localAuth"]["poll"]
+        self.assertTrue(validator.validate_connectors(self.root, [connector]))
+        connector["localAuth"]["kind"] = "browser_oauth"
+        self.assertEqual(validator.validate_connectors(self.root, [connector]), [])
+
+    def test_standard_validator_receives_original_root_and_all_standard_fields(
+        self,
+    ) -> None:
+        manifest = {
+            "name": "service",
+            "connectors": [self.connector],
+            "unsupported": True,
+        }
+        (self.root / ".codex-plugin").mkdir()
+        path = self.root / ".codex-plugin/plugin.json"
+        content = json.dumps(manifest)
+        path.write_text(content)
+        received = []
+
+        def validate_standard(root, standard, errors):
+            received.append((root, standard))
+            errors.append("upstream rejected unsupported")
+
+        upstream = SimpleNamespace(
+            load_json_object=lambda path, errors: json.loads(path.read_text()),
+            reject_todo_markers=lambda value, path, errors: None,
+            validate_manifest_shape=validate_standard,
+        )
+        self.assertEqual(
+            validator.validate_plugin(self.root, upstream),
+            ["upstream rejected unsupported"],
+        )
+        self.assertEqual(
+            received, [(self.root, {"name": "service", "unsupported": True})]
+        )
+        self.assertEqual(path.read_text(), content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs
+++ b/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs
@@ -312,10 +312,9 @@ async function verifyCloudWorkspacePathMentions({ composerSelector, control, wor
   await control.command('click', '[data-testid="new-chat-button"]')
   await control.command('waitFor', composerSelector, { timeoutMs: WORKBENCH_READY_TIMEOUT_MS })
   await control.command('fill', composerSelector, { value: `@${folderName}` })
-  await control.command('waitFor', '[data-testid="workspace-mention-option-0"]', {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  await control.command('clickElementWithText', '[data-testid^="workspace-mention-option-"]', {
+    text: folderName,
   })
-  await control.command('click', '[data-testid="workspace-mention-option-0"]')
   const folderChipSelector = `[data-testid="composer-path-chip-${folderName}"]`
   await control.command('waitFor', folderChipSelector, {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
@@ -329,10 +328,9 @@ async function verifyCloudWorkspacePathMentions({ composerSelector, control, wor
   )
 
   await control.command('fill', composerSelector, { value: '@auth' })
-  await control.command('waitFor', '[data-testid="workspace-mention-option-0"]', {
-    timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+  await control.command('clickElementWithText', '[data-testid^="workspace-mention-option-"]', {
+    text: 'auth.ts',
   })
-  await control.command('click', '[data-testid="workspace-mention-option-0"]')
   const fileChipSelector = '[data-testid="composer-path-chip-auth-ts"]'
   await control.command('waitFor', fileChipSelector, {
     timeoutMs: DEFAULT_STEP_TIMEOUT_MS,

--- a/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs
+++ b/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs
@@ -1,5 +1,6 @@
 import { access } from 'node:fs/promises'
 import { verifyPluginUpgrade } from './plugin-upgrade-flow.mjs'
+import { verifyCreatorAuthenticationToolkit } from './plugin-flows.mjs'
 import { basename } from 'node:path'
 
 import { verifyShortConversationLayout } from './conversation-layout.mjs'
@@ -368,6 +369,7 @@ async function verifyPluginWorkspacePublication({ cloudEnvironment, control }) {
   const taskId = taskAddress.taskId
   const runtimeTask = await cloudEnvironment.waitForRuntimeTask(taskAddress)
   const taskWorkspace = runtimeTask.workspacePath
+  await verifyCreatorAuthenticationToolkit(cloudEnvironment.remoteCodexHome, taskWorkspace)
   const pluginRoot = join(taskWorkspace, 'plugins', 'cloud-workspace-e2e')
   await mkdir(join(pluginRoot, '.codex-plugin'), { recursive: true })
   await mkdir(join(pluginRoot, 'skills', 'cloud-draft'), { recursive: true })

--- a/wework/e2e/desktop/modules/cloud-environment.mjs
+++ b/wework/e2e/desktop/modules/cloud-environment.mjs
@@ -593,6 +593,7 @@ class RealCloudEnvironment {
         runtime: 'codex',
         message,
         title,
+        additionalSkills: [{ name: 'wework-plugin-creator', namespace: 'codex', is_public: false }],
         modelId: CLOUD_PUBLIC_MODEL_NAME,
         modelType: 'public',
         modelOptions: CLOUD_PUBLIC_MODEL_OPTIONS,

--- a/wework/e2e/desktop/modules/desktop-server.mjs
+++ b/wework/e2e/desktop/modules/desktop-server.mjs
@@ -2116,6 +2116,12 @@ class DesktopE2EServer {
     }
 
     if (JSON.stringify(body).includes(PLUGIN_CREATOR_PROMPT)) {
+      if (JSON.stringify(body).includes('Read wework-plugin-creator before scaffolding')) {
+        assert.ok(
+          JSON.stringify(body).includes('wework-plugin-creator/SKILL.md'),
+          'Wework Plugin Creator did not resolve its shipped skill'
+        )
+      }
       this.writeSse(response, [
         responseCreated(responseId),
         assistantMessage(PLUGIN_CREATOR_COMPLETION_TEXT),

--- a/wework/e2e/desktop/modules/plugin-flows.mjs
+++ b/wework/e2e/desktop/modules/plugin-flows.mjs
@@ -836,6 +836,7 @@ async function verifyMarketplacePluginLifecycle({
     text: PLUGIN_CREATOR_COMPLETION_TEXT,
     timeoutMs: WORKBENCH_READY_TIMEOUT_MS,
   })
+  await verifyCreatorAuthenticationToolkit(codexHome, workspacePath)
 
   await control.command('click', '[data-testid="plugins-button"]')
   await control.command('waitFor', '[data-testid="plugins-workspace"]', {
@@ -1191,6 +1192,61 @@ async function verifyMarketplacePluginLifecycle({
   await closeComposerPluginPicker(control)
 }
 
+async function verifyCreatorAuthenticationToolkit(codexHome, workspacePath) {
+  const skillRoot = join(codexHome, 'skills', 'wework-plugin-creator')
+  const toolkit = join(skillRoot, 'scripts', 'auth-sdk', 'tool.py')
+  const validator = join(skillRoot, 'scripts', 'validate_wework_plugin.py')
+  const fixtureRoot = join(workspacePath, 'creator-auth-fixtures')
+  const environment = { ...process.env, CODEX_HOME: codexHome, WEGENT_CODEX_HOME: codexHome }
+  await mkdir(fixtureRoot, { recursive: true })
+  try {
+    for (const credentialType of ['password', 'bearer', 'oauth2']) {
+      const pluginRoot = join(fixtureRoot, credentialType)
+      commandOutput(
+        'uv',
+        [
+          'run',
+          '--no-project',
+          'python',
+          toolkit,
+          'scaffold',
+          credentialType,
+          '--parent',
+          fixtureRoot,
+          '--credential-type',
+          credentialType,
+        ],
+        { cwd: fixtureRoot, env: environment }
+      )
+      commandOutput(
+        'uv',
+        ['run', '--no-project', '--with', 'pyyaml', 'python', validator, pluginRoot],
+        { cwd: fixtureRoot, env: environment }
+      )
+      commandOutput(
+        'uv',
+        ['run', '--no-project', 'python', toolkit, 'vendor', pluginRoot, '--check'],
+        { cwd: fixtureRoot, env: environment }
+      )
+      const manifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json')
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+      assert.equal(manifest.connectors[0].accountAuth.credentialType, credentialType)
+      await rm(join(pluginRoot, 'scripts', 'account-auth.py'))
+      assert.throws(
+        () =>
+          commandOutput(
+            'uv',
+            ['run', '--no-project', '--with', 'pyyaml', 'python', validator, pluginRoot],
+            { cwd: fixtureRoot, env: environment }
+          ),
+        /adapter must reference a packaged relative script/
+      )
+    }
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true })
+  }
+}
+
 async function verifySkillMentionRendering({ control, fixture }) {
   const officialPluginTaskId = await createOfficialPluginTask({
     control,
@@ -1301,6 +1357,7 @@ export {
   verifyPluginLifecycle,
   waitForMarketplaceInstallStateAfterUninstall,
   verifyMarketplacePluginLifecycle,
+  verifyCreatorAuthenticationToolkit,
   verifySkillMentionRendering,
   uninstallOfficialPlugin,
   verifyCoreDshPluginManagement,

--- a/wework/e2e/desktop/modules/task-flow-main.mjs
+++ b/wework/e2e/desktop/modules/task-flow-main.mjs
@@ -2859,10 +2859,9 @@ source = ${JSON.stringify(staleBundledMarketplacePath)}`
 
       phase = 'workspace-mention'
       await control.command('fill', composerSelector, { value: '@auth' })
-      await control.command('waitFor', '[data-testid="workspace-mention-option-0"]', {
-        timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
+      await control.command('clickElementWithText', '[data-testid^="workspace-mention-option-"]', {
+        text: 'auth.ts',
       })
-      await control.command('click', '[data-testid="workspace-mention-option-0"]')
       await control.command('waitFor', '[data-testid="composer-path-chip-auth-ts"]', {
         timeoutMs: DEFAULT_STEP_TIMEOUT_MS,
       })

--- a/wework/src/components/plugins/PluginCreateWorkspace.test.tsx
+++ b/wework/src/components/plugins/PluginCreateWorkspace.test.tsx
@@ -159,7 +159,7 @@ describe('PluginCreateWorkspace', () => {
 
     expect(workbench.setSelectedSkills).toHaveBeenCalledWith([
       {
-        name: 'plugin-creator',
+        name: 'wework-plugin-creator',
         namespace: 'codex',
         is_public: false,
       },
@@ -173,7 +173,7 @@ describe('PluginCreateWorkspace', () => {
           forceNewTask: true,
           additionalSkills: [
             {
-              name: 'plugin-creator',
+              name: 'wework-plugin-creator',
               namespace: 'codex',
               is_public: false,
             },

--- a/wework/src/components/plugins/PluginCreateWorkspace.tsx
+++ b/wework/src/components/plugins/PluginCreateWorkspace.tsx
@@ -133,15 +133,16 @@ export function PluginCreateWorkspace({ topBarLeftActions }: PluginCreateWorkspa
     setIsSubmitting(true)
     setSubmitError(null)
     const pluginCreatorSkill = {
-      name: 'plugin-creator',
+      name: 'wework-plugin-creator',
       namespace: 'codex',
       is_public: false,
     }
     projectChat.setSelectedSkills([pluginCreatorSkill])
     const message = [
       editPluginName
-        ? `Use the Codex plugin-creator workflow to continue editing the plugin "${editPluginName}" in Wegent.`
-        : 'Use the Codex plugin-creator workflow to create a Codex-compatible plugin for Wegent.',
+        ? `Use the wework-plugin-creator skill to continue editing the plugin "${editPluginName}" in Wegent.`
+        : 'Use the wework-plugin-creator skill to create a Codex-compatible plugin for Wegent.',
+      'Read wework-plugin-creator before scaffolding. For plugin-owned local authentication, use its bundled accountAuth SDK, implement provider callbacks and delegated business commands, and run its Wework validator on the complete manifest.',
       'Choose the storage flow from the Executor environment:',
       '- When DEVICE_TYPE=cloud, the Task workspace is the draft. Create or edit the source only under "$WEGENT_TASK_WORKSPACE/plugins/<plugin-name>". Do not install it into a personal marketplace and do not write the source under $HOME.',
       `- Otherwise, use the existing desktop flow: create and install it in the registered managed local marketplace named "${WEWORK_PERSONAL_MARKETPLACE_ID}". Resolve that marketplace's existing local path first, do not use the defaults under ~/plugins or ~/.agents, and keep both managed marketplace manifests in sync.`,


### PR DESCRIPTION
Wework Plugin Creator currently uses the upstream Codex workflow, which has no account-authentication guidance and rejects Wework Connector declarations during validation. This change selects an Executor-shipped Wework skill that guides plugin authors through native login, accountAuth provider callbacks, delegated business commands, and complete-manifest validation.

The Executor embeds the canonical authentication SDK and materializes the skill, templates, and validator in both desktop and cloud Codex homes. Docker builders include those source resources. The validator composes upstream validation with Wework Connector checks, preserving the original manifest and upstream errors. Existing platform-managed Connectors continue using their platform connection. File-mention E2E checks select the requested filename instead of assuming a workspace result is the first row; the newly available authentication skill also matches @auth.

Validation:
- 53 focused tests passed across the SDK, Creator validator, native adapter contracts, resource delivery, skill discovery, and Creator UI.
- Packaged desktop marketplace lifecycle and cloud plugin-workspace publication checkpoints passed; both are selected by CI for Creator changes.
- Rust Clippy, formatting/lint checks, CI classification tests, and Husky pre-commit checks passed.
- CI on a6dd742c0: 87 checks passed, 2 conditionally skipped, no failures or pending checks. Both previously failing Core shard 7 and Cloud shard 15 passed after the filename-based selection fix.
- Real provider authentication and production credential sync have not been performed. Windows and Docker were covered by CI rather than local runtime verification. An accidentally selected broader cloud suite failed on screenshot capture before this publication flow; its result is not counted as a pass.

The corrected cloud workspace-attachments checkpoint passed locally. Local core-task-flow stopped earlier at the macOS native drag/popout assertion, before file mention verification; the complete core flow passed in the final Linux CI run.
