### PR TITLE
fix(wework): contain project menu within popover

### DIFF
--- a/wework/src/components/chat/composer/ProjectWorkBar.test.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.test.tsx
@@ -676,6 +676,34 @@ describe('ProjectWorkBar', () => {
     })
   })
 
+  test('keeps constrained desktop project options inside the popover surface', async () => {
+    render(
+      <ProjectWorkBar
+        projects={[project]}
+        devices={[localDevice]}
+        runtimeWork={runtimeWork}
+        currentProject={project}
+        currentProjectId={project.id}
+        currentStandaloneDeviceId={null}
+        executionMode="current_workspace"
+        onSelectProject={vi.fn()}
+        onSelectStandaloneDevice={vi.fn()}
+        onExecutionModeChange={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('project-work-button'))
+
+    const menu = screen.getByTestId('project-work-menu')
+    expect(menu).toHaveClass('overflow-hidden', 'bg-popover')
+    expect(menu.firstElementChild).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col')
+    expect(screen.getByTestId('project-options-list')).toHaveClass(
+      'min-h-0',
+      'flex-1',
+      'overflow-y-auto'
+    )
+  })
+
   test('resolves the selected workspace within the current project before showing remote state', () => {
     const localDevice: DeviceInfo = {
       ...device,

--- a/wework/src/components/chat/composer/ProjectWorkBar.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.tsx
@@ -496,7 +496,7 @@ export function ProjectWorkBar({
                 isMobile
                   ? 'fixed inset-x-0 bottom-0 z-modal flex max-h-[45dvh] flex-col rounded-t-[28px] border border-border bg-background shadow-[0_-18px_48px_rgba(0,0,0,0.18)]'
                   : cn(
-                      'z-popover flex w-80 flex-col rounded-2xl border border-border bg-background p-1.5 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
+                      'z-popover flex w-80 flex-col overflow-hidden rounded-2xl border border-border bg-popover p-1.5 shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
                       externalMenuAnchorElement
                         ? 'fixed'
                         : `absolute left-0 ${menuLayout.placement === 'below' ? 'top-9' : 'bottom-9'}`
@@ -521,7 +521,7 @@ export function ProjectWorkBar({
                     t('workbench.enter_project_work', '进入项目工作'),
                   closeMenu
                 )}
-              <div className={cn(isMobile && 'flex min-h-0 flex-col px-5 pb-5')}>
+              <div className={cn('flex min-h-0 flex-1 flex-col', isMobile && 'px-5 pb-5')}>
                 <label
                   className={cn(
                     'mb-1.5 flex h-9 shrink-0 items-center gap-2 rounded-xl border border-border bg-surface px-3 text-text-secondary',


### PR DESCRIPTION
## Summary

- keep the desktop project selector list inside its rounded popover surface
- use the popover background token and clip overflowing content at the rounded boundary
- preserve the fixed project-creation actions while the project list scrolls
- add focused regression coverage for the desktop flex/overflow contract

## Verification

- `pnpm --filter wework test -- src/components/chat/composer/ProjectWorkBar.test.tsx` (39 passed)
- focused Prettier and ESLint checks passed
- pre-push ESLint, TypeScript, and unit tests passed
- verified in an isolated real Electron session with six local projects: menu opens within one background surface, project list scrolls independently, footer actions remain contained, and selecting a project closes the menu and updates the trigger

## Issue

- WORK-468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project menu layout and scrolling behavior.
  * Updated desktop menu styling and mobile spacing for a more consistent appearance.

* **Tests**
  * Added coverage to verify project menu surfaces, layout, and scrollable options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->