### PR TITLE
fix(wework): retry transient update downloads

### DIFF
--- a/docs/en/wework/developer-guide/wework-macos-release.md
+++ b/docs/en/wework/developer-guide/wework-macos-release.md
@@ -222,6 +222,16 @@ readiness, and includes bytes transferred before a failed differential attempt.
 The local Squirrel.Mac handoff of the cached ZIP is not counted as network
 traffic.
 
+When one component download encounters an explicitly transient transport
+failure, the client makes at most three attempts, waiting one second and then
+two seconds before retrying. Retries are limited to interrupted connections,
+DNS, connection, or request timeouts, HTTP 408, HTTP 429, and HTTP 5xx
+responses. Other HTTP 4xx responses, archive size or SHA-256 mismatches, and
+extracted-content SHA-256 mismatches are not retried and remain real update
+failures. Bytes transferred by a failed component attempt are removed from the
+current progress before retrying. Failure events in `app-update.log` record the
+sanitized error type, code, message, and first-level cause without logging URLs.
+
 Wework no longer packages or downloads a second Node runtime. At startup it
 creates a lightweight `node` entry under the user data directory, prepends it
 to `PATH`, points `WEWORK_NODE_PATH`, `NODE`, and `npm_node_execpath` at

--- a/docs/zh/wework/developer-guide/wework-macos-release.md
+++ b/docs/zh/wework/developer-guide/wework-macos-release.md
@@ -166,6 +166,13 @@ Electron 宿主在线更新使用独立的 `WeWorkHostUpdate` 产物。滚动 El
 宿主下载、校验和安装就绪阶段，并累计差分失败前已经传输的字节；Squirrel.Mac 对
 本地缓存 ZIP 的安装交接不计入网络下载量。
 
+单个组件下载遇到明确的瞬时传输失败时，客户端最多尝试三次，并在失败后分别等待
+一秒、两秒再重试。可重试范围仅包括连接中断、DNS/连接/请求超时、HTTP 408、429
+和 5xx。HTTP 4xx（408、429 除外）、压缩包大小或 SHA-256 不匹配、解包内容
+SHA-256 不匹配不得重试，必须保留为真实更新失败。失败尝试已传输的组件字节会在
+重试前从当前进度扣除。`app-update.log` 的失败事件记录脱敏后的错误类型、错误码、
+消息及首层 cause，URL 不写入日志。
+
 Wework 不再打包或下载第二份 Node。启动时会在用户数据目录生成轻量 `node`
 入口，将 `PATH`、`WEWORK_NODE_PATH`、`NODE` 和 `npm_node_execpath` 统一指向
 Electron，并设置 `ELECTRON_RUN_AS_NODE=1`。因此 Core DSH 以及 Codex skill 中

--- a/wework/electron/src/host/app-update-service.test.ts
+++ b/wework/electron/src/host/app-update-service.test.ts
@@ -217,6 +217,48 @@ describe('AppUpdateService', () => {
 
     await expect(service(updater).check('stable')).rejects.toThrow('GitHub is unavailable')
   })
+
+  test('logs the concrete download failure without exposing its URL', async () => {
+    const updater = new FakeUpdater()
+    const log = vi.fn()
+    updater.checkForUpdates.mockResolvedValue({
+      updateInfo: {
+        version: '0.2.7',
+        files: [],
+        path: 'pending',
+        sha512: 'sha',
+        releaseDate: '2026-08-25T00:00:00Z',
+      },
+      cancellationToken: {} as never,
+      downloadPromise: null,
+      isUpdateAvailable: true,
+    })
+    const failure = Object.assign(new Error('fetch failed for https://example.com/private'), {
+      code: 'ECONNRESET',
+    })
+    updater.downloadUpdate.mockRejectedValue(failure)
+    const appUpdate = new AppUpdateService({
+      updater: updater as unknown as AppUpdater,
+      currentVersion: () => '0.2.6',
+      isPackaged: () => true,
+      prepareUpdate: vi.fn().mockResolvedValue(undefined),
+      prepareInstall: vi.fn().mockResolvedValue(undefined),
+      updateBaseUrl: 'https://example.com',
+      log,
+    })
+
+    await appUpdate.check('stable')
+    await expect(appUpdate.download()).rejects.toBe(failure)
+
+    expect(log).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        event: 'update-failed',
+        errorType: 'Error',
+        errorCode: 'ECONNRESET',
+        errorMessage: 'fetch failed for [URL removed]',
+      })
+    )
+  })
 })
 
 test('preserves an active download across repeated checks and accumulates failed differential bytes', async () => {

--- a/wework/electron/src/host/app-update-service.ts
+++ b/wework/electron/src/host/app-update-service.ts
@@ -195,7 +195,12 @@ export class AppUpdateService {
         this.progress = { ...this.progress, phase: 'ready' }
         this.log({ taskId, event: 'update-ready', ...this.progress })
       } catch (error) {
-        this.log({ taskId, event: 'update-failed', downloadedBytes: this.progress.downloadedBytes })
+        this.log({
+          taskId,
+          event: 'update-failed',
+          downloadedBytes: this.progress.downloadedBytes,
+          ...errorLogFields(error),
+        })
         throw error
       } finally {
         this.updater.off('download-progress', progress)
@@ -215,6 +220,28 @@ export class AppUpdateService {
       this.updater.quitAndInstall(false, true)
     }
   }
+}
+
+function errorLogFields(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) return { errorType: typeof error }
+  return {
+    errorType: error.name,
+    errorMessage: sanitizeLogMessage(error.message),
+    ...('code' in error && typeof error.code === 'string' ? { errorCode: error.code } : {}),
+    ...(error.cause instanceof Error
+      ? {
+          causeType: error.cause.name,
+          causeMessage: sanitizeLogMessage(error.cause.message),
+          ...('code' in error.cause && typeof error.cause.code === 'string'
+            ? { causeCode: error.cause.code }
+            : {}),
+        }
+      : {}),
+  }
+}
+
+function sanitizeLogMessage(message: string): string {
+  return message.replace(/\b(?:https?|wss?):\/\/[^\s<>"']+/gi, '[URL removed]').slice(0, 500)
 }
 
 function isMissingChannelManifestError(error: unknown): boolean {

--- a/wework/electron/src/runtime/component-update-manager.test.ts
+++ b/wework/electron/src/runtime/component-update-manager.test.ts
@@ -260,6 +260,64 @@ describe('ComponentUpdateManager', () => {
     await expect(manager.stageAvailableUpdate()).rejects.toThrow('archive size mismatch')
     expect(await readFile((await manager.prepareStartup()).executor, 'utf8')).toBe('executor-v1')
   })
+
+  test('retries transient component download failures before failing the update', async () => {
+    const fixture = await createFixture()
+    const update = await createExecutorUpdate(fixture.root, 'executor-v2')
+    const logs: Array<Record<string, unknown>> = []
+    let assetRequests = 0
+    const manager = new ComponentUpdateManager({
+      resourcesRoot: fixture.resources,
+      dataDirectory: fixture.data,
+      updateBaseUrl,
+      currentAppVersion: appVersion,
+      platform: 'darwin',
+      arch: 'arm64',
+      retryDelay: async () => undefined,
+      log: event => logs.push(event),
+      fetch: async input => {
+        const url = String(input)
+        if (url.endsWith('.json')) return Response.json(update.manifest)
+        assetRequests++
+        if (assetRequests < 3) {
+          throw new TypeError('fetch failed', {
+            cause: Object.assign(new Error('socket closed'), { code: 'ECONNRESET' }),
+          })
+        }
+        return new Response(update.archive)
+      },
+    })
+
+    await expect(manager.stageAvailableUpdate()).resolves.toBe(true)
+
+    expect(assetRequests).toBe(3)
+    expect(logs.filter(event => event.event === 'component-download-retry')).toHaveLength(2)
+    expect(await readFile((await manager.prepareStartup()).executor, 'utf8')).toBe('executor-v2')
+  })
+
+  test('does not retry component integrity failures', async () => {
+    const fixture = await createFixture()
+    const update = await createExecutorUpdate(fixture.root, 'executor-v2')
+    let assetRequests = 0
+    const manager = new ComponentUpdateManager({
+      resourcesRoot: fixture.resources,
+      dataDirectory: fixture.data,
+      updateBaseUrl,
+      currentAppVersion: appVersion,
+      platform: 'darwin',
+      arch: 'arm64',
+      retryDelay: async () => undefined,
+      fetch: async input => {
+        const url = String(input)
+        if (url.endsWith('.json')) return Response.json(update.manifest)
+        assetRequests++
+        return new Response(Buffer.from('corrupt'))
+      },
+    })
+
+    await expect(manager.stageAvailableUpdate()).rejects.toThrow('archive size mismatch')
+    expect(assetRequests).toBe(1)
+  })
 })
 
 interface Fixture {

--- a/wework/electron/src/runtime/component-update-manager.ts
+++ b/wework/electron/src/runtime/component-update-manager.ts
@@ -29,6 +29,8 @@ export const MANAGED_COMPONENT_IDS = [
 ] as const
 
 const WEWORK_APP_STATIC_DIRECTORIES = ['vendor', 'wasm'] as const
+const COMPONENT_DOWNLOAD_MAX_ATTEMPTS = 3
+const COMPONENT_DOWNLOAD_RETRY_DELAY_MS = 1_000
 
 export type ManagedComponentId = (typeof MANAGED_COMPONENT_IDS)[number]
 
@@ -101,6 +103,7 @@ export interface ComponentUpdateManagerOptions {
   platform?: NodeJS.Platform
   arch?: string
   fetch?: typeof fetch
+  retryDelay?: (attempt: number) => Promise<void>
   log?: (event: Record<string, unknown>) => void
 }
 
@@ -112,6 +115,7 @@ export class ComponentUpdateManager {
   private readonly platform: NodeJS.Platform
   private readonly arch: string
   private readonly fetch: typeof fetch
+  private readonly retryDelay: (attempt: number) => Promise<void>
   private readonly log: (event: Record<string, unknown>) => void
   private activeStage: {
     id: string
@@ -131,6 +135,12 @@ export class ComponentUpdateManager {
     this.platform = options.platform ?? process.platform
     this.arch = options.arch ?? process.arch
     this.fetch = options.fetch ?? globalThis.fetch
+    this.retryDelay =
+      options.retryDelay ??
+      (attempt =>
+        new Promise(resolve => {
+          setTimeout(resolve, COMPONENT_DOWNLOAD_RETRY_DELAY_MS * attempt)
+        }))
   }
 
   async prepareStartup(): Promise<ComponentPaths> {
@@ -632,7 +642,7 @@ export class ComponentUpdateManager {
       while (!controller.signal.aborted && next < downloads.length) {
         const { id, component } = downloads[next++]!
         try {
-          await this.ensureComponent(id, component, controller.signal, bytes => {
+          await this.downloadComponent(id, component, controller.signal, bytes => {
             progress.downloadedBytes += bytes
             onProgress({ ...progress })
           })
@@ -647,6 +657,38 @@ export class ComponentUpdateManager {
     }
     await Promise.all(Array.from({ length: Math.min(3, downloads.length) }, worker))
     if (controller.signal.aborted) throw failure
+  }
+
+  private async downloadComponent(
+    id: ManagedComponentId,
+    component: RemoteComponent,
+    signal: AbortSignal,
+    onBytes: (bytes: number) => void
+  ): Promise<void> {
+    for (let attempt = 1; attempt <= COMPONENT_DOWNLOAD_MAX_ATTEMPTS; attempt++) {
+      let attemptBytes = 0
+      try {
+        await this.ensureComponent(id, component, signal, bytes => {
+          attemptBytes += bytes
+          onBytes(bytes)
+        })
+        return
+      } catch (error) {
+        if (attemptBytes > 0) onBytes(-attemptBytes)
+        const canRetry =
+          attempt < COMPONENT_DOWNLOAD_MAX_ATTEMPTS &&
+          !signal.aborted &&
+          isTransientDownloadError(error)
+        if (!canRetry) throw error
+        this.log({
+          event: 'component-download-retry',
+          id,
+          attempt,
+          ...errorLogFields(error),
+        })
+        await this.retryDelay(attempt)
+      }
+    }
   }
 
   private async ensureComponent(
@@ -667,7 +709,7 @@ export class ComponentUpdateManager {
     try {
       const response = await this.fetch(component.downloadUrl, { cache: 'no-store', signal })
       if (!response.ok || !response.body) {
-        throw new Error(`Component download failed for ${id}: HTTP ${response.status}`)
+        throw new ComponentDownloadHttpError(id, response.status)
       }
       await pipeline(
         Readable.fromWeb(response.body as import('node:stream/web').ReadableStream),
@@ -724,6 +766,59 @@ export class ComponentUpdateManager {
     const temporary = `${path}.${process.pid}.tmp`
     await writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 })
     await rename(temporary, path)
+  }
+}
+
+function isTransientDownloadError(error: unknown): boolean {
+  let current = error
+  const visited = new Set<unknown>()
+  while (current != null && !visited.has(current)) {
+    visited.add(current)
+    if (current instanceof ComponentDownloadHttpError) {
+      return current.status === 408 || current.status === 429 || current.status >= 500
+    }
+    if (current instanceof Error) {
+      const code = errorCode(current)
+      if (
+        code &&
+        /^(?:ECONNRESET|ECONNREFUSED|EHOSTUNREACH|ENETUNREACH|ENOTFOUND|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT|UND_ERR_SOCKET)$/.test(
+          code
+        )
+      ) {
+        return true
+      }
+      if (/\b(?:fetch failed|network error|socket hang up|terminated)\b/i.test(current.message)) {
+        return true
+      }
+      current = current.cause
+      continue
+    }
+    break
+  }
+  return false
+}
+
+function errorLogFields(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) return { errorType: typeof error }
+  const code = errorCode(error)
+  return {
+    errorType: error.name,
+    ...(code ? { errorCode: code } : {}),
+  }
+}
+
+function errorCode(error: Error): string | null {
+  if (!('code' in error) || typeof error.code !== 'string') return null
+  return error.code
+}
+
+class ComponentDownloadHttpError extends Error {
+  constructor(
+    readonly id: ManagedComponentId,
+    readonly status: number
+  ) {
+    super(`Component download failed for ${id}: HTTP ${status}`)
+    this.name = 'ComponentDownloadHttpError'
   }
 }
 


### PR DESCRIPTION
## 问题

Wework 组件更新在连接中断、DNS/连接超时或服务端临时错误时会立即终止整个应用更新。现场 `app-update.log` 显示同一版本前两次下载因 `fetch failed` 中止，第三次人工重试成功，证明更新包本身有效，根因是瞬时传输失败缺少受控重试。原失败日志还只记录事件名和字节数，无法保留底层异常。

## 修改

- 组件下载对明确的瞬时网络错误最多尝试三次，采用 1 秒、2 秒退避
- 仅重试连接类错误、HTTP 408/429/5xx，不重试其他 4xx 和任何完整性校验错误
- 重试前扣除失败尝试的已传输字节，避免进度累计超过实际值
- 更新失败日志记录脱敏后的异常类型、错误码、消息和首层 cause，并移除 URL
- 补充中英文 macOS 发布文档

## 验证

- `pnpm --dir wework/electron test src/runtime/component-update-manager.test.ts src/host/app-update-service.test.ts`（26 tests passed）
- `pnpm --dir wework/electron typecheck`
- 相关文件 ESLint 与 Prettier 检查
- `component-update` 真实 Electron E2E（PASS）
- pre-push：ESLint、Electron TypeScript、Unit Tests 全部通过

## 额外证据

`app-update-differential` 的本地入口在正式 `.app` 构建后因发布目录没有 macOS arm64 ZIP fixture 而在启动 Electron 前失败；未修改 E2E。使用同一正式构建产物运行 `component-update` 场景通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Component downloads now automatically retry transient failures up to three times, with progressive wait intervals.
  * Download progress is corrected after failed attempts before retries continue.
  * Update failure logs now include structured, sanitized error details without exposing URLs.

* **Bug Fixes**
  * Permanent HTTP errors and archive integrity mismatches are no longer retried and continue to be reported as failures.

* **Documentation**
  * macOS release guides now describe download retry behavior, failure handling, and log details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->