### PR TITLE
feat(todo): mark unread tasks read after preview stays open

### DIFF
--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -27,6 +27,7 @@ interface HoverCardProps {
   pinOnInteractionSelector?: string
   pinned?: boolean
   onPinnedChange?: (pinned: boolean) => void
+  onOpenChange?: (open: boolean) => void
   closeLabel?: string
   cardClassName?: string
   estimatedWidth?: number
@@ -99,6 +100,7 @@ export function HoverCard({
   pinOnInteractionSelector,
   pinned: controlledPinned,
   onPinnedChange,
+  onOpenChange,
   closeLabel = 'Close',
   cardClassName,
   estimatedWidth = 310,
@@ -118,6 +120,10 @@ export function HoverCard({
   const [uncontrolledPinned, setUncontrolledPinned] = useState(false)
   const pinned = controlledPinned ?? uncontrolledPinned
   const displayedOpen = open || pinned
+
+  useEffect(() => {
+    onOpenChange?.(displayedOpen)
+  }, [displayedOpen, onOpenChange])
 
   useEffect(() => {
     pinnedRef.current = pinned

--- a/wework/src/features/todo/CloudTodoBoardCard.test.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@/i18n'
 import type { TaskChangeRequestSnapshot } from '@/api/changeRequests'
 import type { CloudLoopItem } from '@/api/deliveries'
@@ -91,6 +91,10 @@ const snapshot: TaskChangeRequestSnapshot = {
 }
 
 describe('CloudTodoBoardCard', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   beforeEach(async () => {
     await installDshUiTestContributions(
       {
@@ -501,6 +505,88 @@ describe('CloudTodoBoardCard', () => {
     expect(conversation).toHaveAttribute('data-collapse-composer', 'true')
     expect(conversation).toHaveAttribute('data-cloud-project-id', String(item.cloud_project_id))
     expect(conversation).toHaveAttribute('data-initial-scroll-position', 'latest')
+  })
+
+  it('marks an unread task as read after its conversation preview stays open for 3 seconds', async () => {
+    vi.useFakeTimers()
+    const onMarkRead = vi.fn()
+    render(
+      <CloudTodoBoardCard
+        item={{ ...item, is_unread: true }}
+        taskBindings={[
+          {
+            id: 85,
+            device_id: 'local',
+            task_id: 'task-85',
+            task_title: 'Fix the board popup',
+            running: false,
+            finalResponsePreview: '已完成',
+          },
+        ]}
+        onClick={vi.fn()}
+        onArchive={vi.fn()}
+        onMarkRead={onMarkRead}
+        display={{
+          showAssignee: false,
+          showPriority: false,
+          showTags: false,
+          showDate: false,
+        }}
+      />
+    )
+
+    fireEvent.mouseEnter(screen.getByTestId('cloud-todo-card-WEG-85'))
+    await act(async () => vi.advanceTimersByTime(450))
+    expect(screen.getByTestId('cloud-todo-card-progress-popup-WEG-85')).toBeInTheDocument()
+
+    await act(async () => vi.advanceTimersByTime(2999))
+    expect(onMarkRead).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTime(1))
+    expect(onMarkRead).toHaveBeenCalledOnce()
+    expect(onMarkRead).toHaveBeenCalledWith(expect.objectContaining({ id: 'WEG-85' }))
+  })
+
+  it('keeps an unread task unread when its conversation preview closes before 3 seconds', async () => {
+    vi.useFakeTimers()
+    const onMarkRead = vi.fn()
+    render(
+      <CloudTodoBoardCard
+        item={{ ...item, is_unread: true }}
+        taskBindings={[
+          {
+            id: 85,
+            device_id: 'local',
+            task_id: 'task-85',
+            task_title: 'Fix the board popup',
+            running: false,
+            finalResponsePreview: '已完成',
+          },
+        ]}
+        onClick={vi.fn()}
+        onArchive={vi.fn()}
+        onMarkRead={onMarkRead}
+        display={{
+          showAssignee: false,
+          showPriority: false,
+          showTags: false,
+          showDate: false,
+        }}
+      />
+    )
+
+    const card = screen.getByTestId('cloud-todo-card-WEG-85')
+    fireEvent.mouseEnter(card)
+    await act(async () => vi.advanceTimersByTime(450))
+    await act(async () => vi.advanceTimersByTime(2000))
+
+    fireEvent.mouseLeave(card)
+    fireEvent.pointerMove(document.body)
+    await act(async () => vi.advanceTimersByTime(120))
+    expect(screen.queryByTestId('cloud-todo-card-progress-popup-WEG-85')).not.toBeInTheDocument()
+
+    await act(async () => vi.advanceTimersByTime(1000))
+    expect(onMarkRead).not.toHaveBeenCalled()
   })
 
   it('shows the current conversation goal and pins the same hover preview', async () => {

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -12,7 +12,7 @@ import {
   Target,
   UserRound,
 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import type { CloudLoopItem } from '@/api/deliveries'
 import type { TaskChangeRequestSnapshot, TaskChangeRequestTarget } from '@/api/changeRequests'
 import { DshContributionSlotSurface } from '@/features/dsh-runtime/DshContributionSlotSurface'
@@ -67,6 +67,8 @@ export interface BoardCardDisplaySettings {
 }
 
 export type BoardCardProgressDisplay = 'compact' | 'focused'
+
+const MARK_READ_PREVIEW_DELAY_MS = 3000
 
 const priorityLabels: Record<CloudLoopItem['priority'], string> = {
   none: '普通',
@@ -302,6 +304,7 @@ interface CloudTodoBoardCardProps {
   onArchive: () => void
   previewPinned?: boolean
   onPreviewPinnedChange?: (pinned: boolean) => void
+  onMarkRead?: (item: CloudLoopItem) => void
   onLoadRuntimeGoal?: (address: RuntimeTaskAddress) => Promise<void>
   display: BoardCardDisplaySettings
   processingStatus: boolean
@@ -325,6 +328,7 @@ export function CloudTodoBoardCard({
   onArchive,
   previewPinned = false,
   onPreviewPinnedChange,
+  onMarkRead,
   onLoadRuntimeGoal,
   display,
   processingStatus,
@@ -339,6 +343,11 @@ export function CloudTodoBoardCard({
   const { t } = useTranslation('common')
   const [menuOpen, setMenuOpen] = useState(false)
   const [hoveredTaskBindingId, setHoveredTaskBindingId] = useState<number | null>(null)
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const itemRef = useRef(item)
+  useEffect(() => {
+    itemRef.current = item
+  }, [item])
   const currentWorkflowNode = item.workflow ? getCurrentWorkflowNode(item.workflow.nodes) : null
   const needsExecutionConfiguration =
     processingStatus && itemNeedsExecutionConfiguration(item) && Boolean(onConfigureExecution)
@@ -376,6 +385,12 @@ export function CloudTodoBoardCard({
     disabled: item.can_edit === false || dragDisabled,
   })
   const { isOver, setNodeRef: setDropRef } = useDroppable({ id: `todo-card:${item.id}` })
+
+  useEffect(() => {
+    if (!previewOpen || !item.is_unread || !onMarkRead) return
+    const timer = window.setTimeout(() => onMarkRead(itemRef.current), MARK_READ_PREVIEW_DELAY_MS)
+    return () => window.clearTimeout(timer)
+  }, [item.is_unread, onMarkRead, previewOpen])
 
   const card = (
     <article
@@ -526,6 +541,7 @@ export function CloudTodoBoardCard({
       pinOnInteractionSelector="[data-hover-card-pin-region], [data-hover-card-pin-trigger]"
       pinned={previewPinned}
       onPinnedChange={onPreviewPinnedChange}
+      onOpenChange={setPreviewOpen}
       closeLabel={t('common.close', '关闭')}
       estimatedWidth={480}
       estimatedHeight={620}

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -1447,6 +1447,7 @@ export function CloudTodoWorkspace({
   const [projectHeaderLevel, setProjectHeaderLevel] = useState(0)
   const boardSnapshotSignatureRef = useRef<string | null>(null)
   const boardLiveSubscriptionActiveRef = useRef(false)
+  const markingReadItemKeysRef = useRef(new Set<string>())
   const resetProjectViewState = useCallback(() => {
     setProjectView('board')
     setBoardParentId(null)
@@ -1925,24 +1926,27 @@ export function CloudTodoWorkspace({
       throw new Error(t('workbench.change_request_continue_repair_failed', '无法继续任务'))
     }
   }
-  const projectForItem = (item: Pick<LocatedLoopItem, 'cloud_project_id' | 'project_store'>) => {
-    if (item.project_store) {
-      return projects.find(project =>
-        sameProjectSpace(projectSpaceRef(project), {
-          projectStore: item.project_store!,
-          projectId: item.cloud_project_id,
-        })
-      )
-    }
-    const matches = projects.filter(project => project.id === item.cloud_project_id)
-    if (selectedProjectKey) {
-      const selectedMatch = matches.find(
-        project => projectSpaceKey(projectSpaceRef(project)) === selectedProjectKey
-      )
-      if (selectedMatch) return selectedMatch
-    }
-    return matches.length === 1 ? matches[0] : undefined
-  }
+  const projectForItem = useCallback(
+    (item: Pick<LocatedLoopItem, 'cloud_project_id' | 'project_store'>) => {
+      if (item.project_store) {
+        return projects.find(project =>
+          sameProjectSpace(projectSpaceRef(project), {
+            projectStore: item.project_store!,
+            projectId: item.cloud_project_id,
+          })
+        )
+      }
+      const matches = projects.filter(project => project.id === item.cloud_project_id)
+      if (selectedProjectKey) {
+        const selectedMatch = matches.find(
+          project => projectSpaceKey(projectSpaceRef(project)) === selectedProjectKey
+        )
+        if (selectedMatch) return selectedMatch
+      }
+      return matches.length === 1 ? matches[0] : undefined
+    },
+    [projects, selectedProjectKey]
+  )
   const locateItems = useCallback(
     <T extends CloudLoopItem>(
       sourceItems: T[],
@@ -2315,6 +2319,54 @@ export function CloudTodoWorkspace({
   }, [startupBoardReady])
   const selectedItemProject = selectedItem ? projectForItem(selectedItem) : undefined
   const selectedItemApi = apiForProject(selectedItemProject)
+  const markItemRead = useCallback(
+    async (item: LocatedLoopItem) => {
+      if (!item.is_unread) return
+      const project = projectForItem(item)
+      const itemApi = apiForProject(project)
+      if (!project || !itemApi) return
+      const projectKey = projectSpaceKey(projectSpaceRef(project))
+      const requestKey = `${projectKey}\0${item.id}`
+      if (markingReadItemKeysRef.current.has(requestKey)) return
+      markingReadItemKeysRef.current.add(requestKey)
+
+      try {
+        const updated = {
+          ...(await itemApi.markLoopItemRead(item.id)),
+          project_store: item.project_store,
+        }
+        const applyReadSnapshot = (current: LocatedLoopItem) => ({
+          ...preferNewestLoopItemSnapshot(current, updated),
+          is_unread: false,
+        })
+        setSelectedItem(current => (current?.id === item.id ? applyReadSnapshot(current) : current))
+        setItems(current =>
+          current.map(candidate =>
+            candidate.id === item.id ? applyReadSnapshot(candidate) : candidate
+          )
+        )
+        setDetailItems(current =>
+          current.map(candidate =>
+            candidate.id === item.id ? applyReadSnapshot(candidate) : candidate
+          )
+        )
+        setProjectItems(current => ({
+          ...current,
+          [projectKey]: (current[projectKey] ?? []).map(candidate =>
+            candidate.id === item.id ? applyReadSnapshot(candidate) : candidate
+          ),
+        }))
+      } catch (error) {
+        console.warn('[Wework project board] mark Issue read failed', {
+          itemId: item.id,
+          error,
+        })
+      } finally {
+        markingReadItemKeysRef.current.delete(requestKey)
+      }
+    },
+    [apiForProject, projectForItem]
+  )
   useEffect(() => {
     if (!selectedItem || selectedItem.detail_loaded !== false || !selectedItemApi) return
     let active = true
@@ -2349,43 +2401,8 @@ export function CloudTodoWorkspace({
     ) {
       return
     }
-    let active = true
-    const itemId = selectedItem.id
-    const projectKey = projectSpaceKey(projectSpaceRef(selectedItemProject))
-    void selectedItemApi
-      .markLoopItemRead(itemId)
-      .then(updated => {
-        if (!active) return
-        const locatedUpdated = {
-          ...updated,
-          project_store: selectedItem.project_store,
-        }
-        setSelectedItem(current => (current?.id === itemId ? locatedUpdated : current))
-        setItems(current => current.map(item => (item.id === itemId ? locatedUpdated : item)))
-        setDetailItems(current => current.map(item => (item.id === itemId ? locatedUpdated : item)))
-        setProjectItems(current => ({
-          ...current,
-          [projectKey]: (current[projectKey] ?? []).map(item =>
-            item.id === itemId ? locatedUpdated : item
-          ),
-        }))
-      })
-      .catch(error => {
-        console.warn('[Wework project board] mark Issue read failed', {
-          itemId,
-          error,
-        })
-      })
-    return () => {
-      active = false
-    }
-  }, [
-    selectedItem?.id,
-    selectedItem?.is_unread,
-    selectedItem?.project_store,
-    selectedItemApi,
-    selectedItemProject,
-  ])
+    window.queueMicrotask(() => void markItemRead(selectedItem))
+  }, [markItemRead, selectedItem, selectedItemApi, selectedItemProject])
   // Source for the detail drawer / creation dialog when the selected todo lives
   // in a project other than the one shown on the board.
   const detailAllItems =
@@ -5297,6 +5314,7 @@ export function CloudTodoWorkspace({
                                             : null
                                         )
                                       }
+                                      onMarkRead={markItemRead}
                                       onLoadRuntimeGoal={loadBoardTaskRuntimeGoal}
                                       display={boardCardDisplay}
                                       agentNames={agentNameById}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unread cloud todo items are now automatically marked as read after their progress preview remains open for three seconds.
  - Read status updates across the workspace immediately, keeping item lists and details in sync.

- **Bug Fixes**
  - Items are no longer marked as read when the preview closes before the three-second delay.
  - Repeated read requests are prevented while an item is already being updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->