### PR TITLE
fix(wework): position task hover preview beside card

### DIFF
--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -1222,14 +1222,25 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
     const [moonshotPopupMetrics] = JSON.parse(
       await control.command('getElementMetrics', moonshotProgressPopup)
     )
+    const [moonshotCardMetrics] = JSON.parse(
+      await control.command('getElementMetrics', moonshotOverrideCard)
+    )
     const [bodyMetrics] = JSON.parse(await control.command('getElementMetrics', 'body'))
+    const popupHorizontalGap =
+      moonshotPopupMetrics.left >= moonshotCardMetrics.right
+        ? moonshotPopupMetrics.left - moonshotCardMetrics.right
+        : moonshotCardMetrics.left - moonshotPopupMetrics.right
     assert.ok(
-      Math.abs(moonshotPopupMetrics.top - 48) <= 1,
-      `The board popup did not keep its stable viewport top: ${JSON.stringify(moonshotPopupMetrics)}`
+      Math.abs(popupHorizontalGap - 10) <= 1,
+      `The board popup was not positioned beside its card: ${JSON.stringify({
+        moonshotCardMetrics,
+        moonshotPopupMetrics,
+      })}`
     )
     assert.ok(
-      Math.abs(bodyMetrics.right - moonshotPopupMetrics.right - 8) <= 1,
-      `The board popup did not stay at the viewport right edge: ${JSON.stringify({
+      moonshotPopupMetrics.top >= bodyMetrics.top + 8 - 1 &&
+        moonshotPopupMetrics.bottom <= bodyMetrics.bottom - 8 + 1,
+      `The board popup escaped the viewport bounds: ${JSON.stringify({
         bodyMetrics,
         moonshotPopupMetrics,
       })}`

--- a/wework/src/features/todo/CloudTodoBoardCard.test.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.test.tsx
@@ -590,6 +590,30 @@ describe('CloudTodoBoardCard', () => {
   })
 
   it('keeps repeated task text out of the card and switches the shared hover conversation', async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      const isPreview = this.dataset.testid === 'cloud-todo-card-progress-popup-WEG-85'
+      const isAnchor =
+        this.firstElementChild?.getAttribute('data-testid') === 'cloud-todo-card-drop-WEG-85'
+      if (!isPreview && !isAnchor) return originalGetBoundingClientRect.call(this)
+
+      const left = isPreview ? 0 : 100
+      const top = isPreview ? 0 : 80
+      const width = isPreview ? 480 : 280
+      const height = isPreview ? 300 : 160
+      return {
+        x: left,
+        y: top,
+        width,
+        height,
+        top,
+        right: left + width,
+        bottom: top + height,
+        left,
+        toJSON: () => undefined,
+      }
+    })
+
     render(
       <CloudTodoBoardCard
         item={{ ...item, description: 'This description must be hidden from the card' }}
@@ -632,6 +656,7 @@ describe('CloudTodoBoardCard', () => {
     const popup = await screen.findByTestId('cloud-todo-card-progress-popup-WEG-85')
     expect(popup).toHaveClass('w-[480px]', 'overflow-x-hidden')
     expect(popup).toHaveAttribute('role', 'dialog')
+    expect(popup).toHaveStyle({ left: '390px', top: '80px' })
     expect(screen.getByTestId('cloud-todo-card-progress-title-WEG-85')).toHaveTextContent(
       'Keep the pull request popup visible'
     )

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -529,8 +529,6 @@ export function CloudTodoBoardCard({
       closeLabel={t('common.close', '关闭')}
       estimatedWidth={480}
       estimatedHeight={620}
-      placement="viewport-right"
-      viewportTop={48}
       cardClassName="w-[480px] max-w-[calc(100vw-1rem)]"
       content={
         <RuntimeTaskProgressPopup


### PR DESCRIPTION
## Summary
- show running task hover previews beside their board cards instead of fixing them to the viewport top-right
- preserve the existing interactive and pinned preview behavior
- add a regression assertion for anchor-relative positioning

## Verification
- `pnpm --filter wework test src/features/todo/CloudTodoBoardCard.test.tsx src/components/ui/hover-card.test.tsx`
- `pnpm --filter wework exec prettier --check src/features/todo/CloudTodoBoardCard.tsx src/features/todo/CloudTodoBoardCard.test.tsx src/components/ui/hover-card.tsx src/components/ui/hover-card.test.tsx`
- `pnpm --filter wework exec eslint src/features/todo/CloudTodoBoardCard.tsx src/features/todo/CloudTodoBoardCard.test.tsx src/components/ui/hover-card.tsx src/components/ui/hover-card.test.tsx`
- isolated Electron build, launch, and snapshot via `pnpm --filter wework ai:verify start`

Closes WORK-482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud todo progress popups to position more reliably beside their associated cards.
  - Popups now maintain a consistent gap and remain vertically contained within the visible window.
  - Removed rigid positioning behavior that could cause alignment issues near screen edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->