### PR TITLE
fix(wework): recover stale transcript fork points

### DIFF
--- a/backend/app/services/wework_transcript_service.py
+++ b/backend/app/services/wework_transcript_service.py
@@ -102,20 +102,15 @@ def acquire_lease(
         .first()
     )
     now = utcnow()
+    if request.parent_transcript_id is not None:
+        parent = get_transcript(
+            db,
+            user_id=user_id,
+            transcript_id=request.parent_transcript_id,
+            for_update=True,
+        )
+        forked_at_sequence = min(forked_at_sequence, parent.current_sequence)
     if transcript is None:
-        if request.parent_transcript_id is not None:
-            parent = get_transcript(
-                db,
-                user_id=user_id,
-                transcript_id=request.parent_transcript_id,
-                for_update=True,
-            )
-            if forked_at_sequence > parent.current_sequence:
-                raise WeworkTranscriptError(
-                    "invalid_fork_point",
-                    "Wework transcript fork point is newer than its parent",
-                    status_code=422,
-                )
         transcript = WeworkTranscript(
             user_id=user_id,
             transcript_id=transcript_id,

--- a/backend/tests/api/endpoints/test_wework_transcripts_api.py
+++ b/backend/tests/api/endpoints/test_wework_transcripts_api.py
@@ -509,6 +509,42 @@ def test_creates_branch_without_copying_parent_objects(
     assert test_db.query(WeworkTranscriptTurn).count() == 0
 
 
+def test_normalizes_stale_future_fork_point_to_parent_head(
+    test_client, test_token, test_db
+):
+    _lease(test_client, test_token)
+    parent = test_db.query(WeworkTranscript).one()
+    parent.current_sequence = 11
+    test_db.commit()
+    request = {
+        "clientId": "client-b",
+        "ttlSeconds": 60,
+        "parentTranscriptId": "transcript-1",
+        "forkedAtSequence": 15,
+    }
+
+    branch = test_client.post(
+        "/api/wework-transcripts/fork-device-b/lease",
+        headers=_headers(test_token),
+        json=request,
+    )
+    retry = test_client.post(
+        "/api/wework-transcripts/fork-device-b/lease",
+        headers=_headers(test_token),
+        json=request,
+    )
+
+    assert branch.status_code == 200
+    assert retry.status_code == 200
+    item = (
+        test_db.query(WeworkTranscript)
+        .filter(WeworkTranscript.transcript_id == "fork-device-b")
+        .one()
+    )
+    assert item.parent_transcript_id == "transcript-1"
+    assert item.forked_at_sequence == 11
+
+
 def test_download_streams_the_object_through_backend(
     test_client, test_token, test_db, monkeypatch
 ):

--- a/wework/dsh/transcript-sync/index.js
+++ b/wework/dsh/transcript-sync/index.js
@@ -313,7 +313,7 @@ export class WeworkSync {
     const delivered = await this.reconcilePendingSegment(turn)
     await this.releaseLease(turn, lease)
     if (!delivered) {
-      this.forkPendingTurn(turn)
+      this.forkPendingTurn(turn, Math.min(turn.baseSequence, lease.currentSequence))
       return
     }
     await this.acknowledgeNativeTurn(delivered)
@@ -423,11 +423,11 @@ export class WeworkSync {
     return encryption
   }
 
-  forkPendingTurn(turn) {
+  forkPendingTurn(turn, forkedAtSequence = turn.baseSequence) {
     const transcriptId = `fork-${createHash('sha256')
       .update(`${this.clientId}\u0000${turn.transcriptId}\u0000${turn.turnId}`)
       .digest('hex')}`
-    this.outbox.fork(turn, transcriptId)
+    this.outbox.fork(turn, transcriptId, forkedAtSequence)
   }
 
   async pullTranscripts() {

--- a/wework/dsh/transcript-sync/index.test.mjs
+++ b/wework/dsh/transcript-sync/index.test.mjs
@@ -312,6 +312,59 @@ test('branches deterministically when the cloud causal head changed', async () =
   assert.equal(source.calls.at(-1).options.snapshot, true)
 })
 
+test('branches from the available cloud head when the cached causal base is newer', async () => {
+  const source = await segmentSource()
+  const pending = turn({
+    transcriptId: 'shared',
+    taskId: 'local-task',
+    sequence: 16,
+    turnId: 'turn-b',
+    baseSequence: 15,
+    cloudSequence: 16,
+  })
+  const outbox = new MemorySyncOutbox([pending])
+  const leases = []
+  const sync = new WeworkSync({
+    apiBaseUrl: 'https://cloud.example.com/api',
+    clientId: 'device-b',
+    outbox,
+    source,
+    state: state(),
+    target: { async acknowledge() {} },
+    desktop: {
+      weworkSync: {
+        async request(request) {
+          if (request.path.endsWith('/lease')) {
+            leases.push(request)
+            return {
+              status: 200,
+              body: {
+                fencingToken: 9,
+                currentSequence: request.path.includes('/shared/') ? 11 : 0,
+              },
+            }
+          }
+          if (request.path.endsWith('/encryption-key')) {
+            return {
+              status: 200,
+              body: { algorithm: 'aes-256-gcm', key: TEST_ENCRYPTION_KEY },
+            }
+          }
+          return { status: 200, body: {} }
+        },
+      },
+    },
+  })
+
+  await sync.flushPending()
+
+  assert.equal(outbox.count(), 0)
+  const branchLease = leases.find(request => request.path.includes('/fork-'))
+  assert.equal(branchLease.body.parentTranscriptId, 'shared')
+  assert.equal(branchLease.body.forkedAtSequence, 11)
+  assert.equal(source.calls.at(-1).options.snapshot, true)
+})
+
 test('discards an orphaned session and continues uploading healthy sessions', async () => {
   const source = await segmentSource()
   const summarize = source.summarize.bind(source)

--- a/wework/dsh/transcript-sync/outbox.js
+++ b/wework/dsh/transcript-sync/outbox.js
@@ -237,7 +237,7 @@ export class SqliteSyncOutbox {
     return Boolean(this.selectTranscriptPending.get(transcriptId))
   }
 
-  fork(turn, transcriptId) {
+  fork(turn, transcriptId, forkedAtSequence = turn.baseSequence) {
     const pending = this.selectSessionPending.all(turn.sessionId)
     const start = pending.findIndex(item => item.turn_id === turn.turnId)
     if (start < 0) throw new Error(`Pending transcript turn is unavailable: ${turn.turnId}`)
@@ -245,7 +245,7 @@ export class SqliteSyncOutbox {
       this.updateForkRoute.run(
         transcriptId,
         turn.transcriptId,
-        turn.baseSequence,
+        forkedAtSequence,
         Date.now(),
         turn.sessionId
       )
@@ -255,7 +255,7 @@ export class SqliteSyncOutbox {
           index,
           index + 1,
           turn.transcriptId,
-          turn.baseSequence,
+          forkedAtSequence,
           item.turn_id
         )
       }
@@ -367,7 +367,7 @@ export class MemorySyncOutbox {
     return this.turns.some(turn => turn.transcriptId === transcriptId)
   }
 
-  fork(turn, transcriptId) {
+  fork(turn, transcriptId, forkedAtSequence = turn.baseSequence) {
     const sessionTurns = this.turns
       .filter(item => item.sessionId === turn.sessionId)
       .sort((left, right) => left.sequence - right.sequence)
@@ -376,7 +376,7 @@ export class MemorySyncOutbox {
     this.routes.set(turn.sessionId, {
       transcriptId,
       parentTranscriptId: turn.transcriptId,
-      forkedAtSequence: turn.baseSequence,
+      forkedAtSequence,
       acknowledgedSequence: 0,
     })
     for (const [index, item] of sessionTurns.slice(start).entries()) {
@@ -385,7 +385,7 @@ export class MemorySyncOutbox {
         baseSequence: index,
         cloudSequence: index + 1,
         parentTranscriptId: turn.transcriptId,
-        forkedAtSequence: turn.baseSequence,
+        forkedAtSequence,
       })
     }
   }

--- a/wework/dsh/transcript-sync/outbox.test.mjs
+++ b/wework/dsh/transcript-sync/outbox.test.mjs
@@ -123,6 +123,36 @@ test('persists an automatic branch route for later turns across restart', async 
   reopened.close()
 })
 
+test('persists a corrected branch point when the cloud parent is behind', async t => {
+  const directory = await mkdtemp(join(tmpdir(), 'wework-sync-outbox-'))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const path = join(directory, 'outbox.sqlite3')
+  const outbox = new SqliteSyncOutbox(path)
+  const turn = {
+    transcriptId: 'shared-transcript',
+    taskId: 'local-task',
+    title: 'Shared transcript',
+    sequence: 16,
+    turnId: 'conflicting-turn',
+    sessionId: 'local-session',
+  }
+
+  outbox.enqueue(turn, 15)
+  outbox.fork(outbox.first(), 'fork-stable-id', 11)
+  outbox.close()
+
+  const reopened = new SqliteSyncOutbox(path)
+  assert.deepEqual(reopened.first(), {
+    ...turn,
+    transcriptId: 'fork-stable-id',
+    baseSequence: 0,
+    cloudSequence: 1,
+    parentTranscriptId: 'shared-transcript',
+    forkedAtSequence: 11,
+  })
+  reopened.close()
+})
+
 test('discards every pending turn and route for an orphaned session', async t => {
   const directory = await mkdtemp(join(tmpdir(), 'wework-sync-outbox-'))
   t.after(() => rm(directory, { recursive: true, force: true }))

--- a/wework/e2e/desktop/scenarios/transcript-sync.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/transcript-sync.scenario.mjs
@@ -685,7 +685,11 @@ export function createDesktopScenario({
         uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
         'The second active device did not restore the shared transcript before diverging'
       )
-      await control.command('click', `[data-testid="runtime-local-task-row-${transcriptId}"]`)
+      const deviceCRestoredTaskRowSelector = `[data-testid="runtime-local-task-row-${transcriptId}"]`
+      await control.command('waitFor', deviceCRestoredTaskRowSelector, {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', deviceCRestoredTaskRowSelector)
       await control.command('fill', ACTIVE_COMPOSER_SELECTOR, { value: REMOTE_PROMPT })
       await control.command('press', ACTIVE_COMPOSER_SELECTOR, { key: 'Enter' })
       await control.command('waitFor', '[data-testid="message-assistant"]', {
@@ -753,7 +757,6 @@ export function createDesktopScenario({
       const [forkTranscriptId, forkTranscript] = forkEntry
       assert.equal(forkTranscript.turns[0].payload.assistantMessage, THIRD_COMPLETION)
       assert.equal(activeTranscript().turns[3].payload.assistantMessage, REMOTE_COMPLETION)
-      assert.equal(sqliteOutboxCount(deviceBOutboxPath), 0)
       await waitFor(
         async () => {
           const index = JSON.parse(
@@ -763,6 +766,11 @@ export function createDesktopScenario({
         },
         uiTimeoutMs + SYNC_POLL_INTERVAL_MS,
         'The fork and original transcript did not become two independent local conversations'
+      )
+      await waitFor(
+        () => sqliteOutboxCount(deviceBOutboxPath) === 0,
+        uiTimeoutMs,
+        'The acknowledged branch turn was not removed from the outbox'
       )
       await control.command('waitFor', '[data-testid="transcript-sync-enabled-status"]', {
         text: '同步正常',


### PR DESCRIPTION
## Summary

- clamp transcript fork points to the actual parent head when local cached sequence is newer
- normalize stale future fork points on the backend so already-persisted outboxes recover without local data deletion
- persist corrected fork metadata for future pending turns
- remove two transcript-sync E2E timing races proven by failure logs and final state evidence

## Root cause

A real local outbox contained `forkedAtSequence=15` while the same parent transcript had `currentSequence=11`. The client retried the impossible fork identity indefinitely, and the backend rejected every lease with `invalid_fork_point`, blocking all later sessions in the outbox.

## Verification

- `node --test dsh/transcript-sync/index.test.mjs dsh/transcript-sync/outbox.test.mjs` (18 passed)
- `cd backend && uv run pytest tests/api/endpoints/test_wework_transcripts_api.py -q` (13 passed)
- Black and isort checks for changed Python files
- Prettier and ESLint checks for changed Wework files
- `pnpm --filter wework e2e:desktop --segment transcript-sync` (passed with real Electron and Executor)
