### PR TITLE
fix(wework): preserve selected project for created tasks

### DIFF
--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { ensureExperimentalFeaturesEnabled } from '../modules/preferences-automation-flows.mjs'
@@ -388,7 +389,12 @@ function assertExecutionTruthContract(execution) {
   }
 }
 
-export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspacePath }) {
+export function createDesktopScenario({
+  captureScreenshot,
+  resultDir,
+  uiTimeoutMs,
+  workspacePath,
+}) {
   // Cloud executions are claimed asynchronously. Keep the assertion budget
   // beyond one complete claim window so a commit at the boundary is observed.
   const automationRuntimeTimeoutMs = Math.max(
@@ -679,6 +685,110 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
       timeoutMs: uiTimeoutMs,
       visible: true,
     })
+    await control.command('click', `${activeBoard} [data-testid="cloud-todo-add"]`)
+    await control.command('waitFor', `${activeBoard} [data-testid="workspace-issue-input"]`, {
+      timeoutMs: uiTimeoutMs,
+    })
+    await control.command('click', `${activeBoard} [data-testid="workspace-create-task-tab"]`)
+    const taskProjectButton = `${activeBoard} [data-testid="workspace-issue-composer"] [data-testid="project-work-button"]`
+    await control.command('waitFor', taskProjectButton, {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    await control.command('click', taskProjectButton)
+    await control.command('waitFor', '[data-testid="project-options-list"]', {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    const taskProjectMenuSnapshot = JSON.parse(await control.command('snapshot', 'body'))
+    const currentTaskProjectId = taskProjectMenuSnapshot.testIds
+      .find(testId => testId.startsWith('project-selected-icon-'))
+      ?.slice('project-selected-icon-'.length)
+    let taskTargetProjectTestId = null
+    for (const testId of taskProjectMenuSnapshot.testIds.filter(
+      candidate =>
+        candidate.startsWith('project-option-') &&
+        candidate !== `project-option-${currentTaskProjectId ?? ''}` &&
+        !taskProjectMenuSnapshot.testIds.includes(
+          `project-bind-workspace-${candidate.slice('project-option-'.length)}`
+        )
+    )) {
+      const projectText = await control.command('getText', `[data-testid="${testId}"]`, {
+        visible: true,
+      })
+      if (projectText.includes('project-automation-primary')) {
+        taskTargetProjectTestId = testId
+        break
+      }
+    }
+    assert.ok(
+      taskTargetProjectTestId,
+      'Task creation requires another runtime project for project-switch regression coverage'
+    )
+    const taskTargetProjectText = await control.command(
+      'getText',
+      `[data-testid="${taskTargetProjectTestId}"]`,
+      { visible: true }
+    )
+    assert.ok(
+      taskTargetProjectText.includes('project-automation-primary'),
+      'The task regression did not select the primary runtime project'
+    )
+    const taskTargetProjectName = 'project-automation-primary'
+    await control.command('click', `[data-testid="${taskTargetProjectTestId}"]`, {
+      visible: true,
+    })
+    const taskTargetWorkspaceSelector = '[data-testid^="project-workspace-option-"]'
+    if (
+      Number(
+        await control.command('getElementCount', taskTargetWorkspaceSelector, {
+          visible: true,
+        })
+      ) > 0
+    ) {
+      await control.command('clickWhenEnabled', taskTargetWorkspaceSelector, {
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
+    }
+    await control.command('waitFor', taskProjectButton, {
+      timeoutMs: uiTimeoutMs,
+      text: taskTargetProjectName,
+      visible: true,
+    })
+    const switchedTaskTitle = '创建任务时切换运行项目'
+    await control.command('fill', `${activeBoard} [data-testid="workspace-issue-input"]`, {
+      value: switchedTaskTitle,
+    })
+    await control.command('click', `${activeBoard} [data-testid="workspace-issue-submit"]`)
+    const switchedTaskIssue = await waitForValue(
+      () => cloudRequest(`/api/v1/cloud-projects/${projectId}/loop-items`),
+      response => (response.items ?? []).find(item => item.title === switchedTaskTitle),
+      'The project-switched task Issue was not persisted',
+      uiTimeoutMs
+    ).then(response => response.items.find(item => item.title === switchedTaskTitle))
+    const switchedTaskBindings = await waitForValue(
+      () => cloudRequest(`/api/v1/loop-items/${switchedTaskIssue.id}/tasks`),
+      bindings => bindings.length > 0,
+      'The project-switched task was not bound to its Issue',
+      uiTimeoutMs
+    )
+    const switchedTaskBinding = switchedTaskBindings[0]
+    const switchedTaskRuntimeLog = await waitForValue(
+      () => readFile(join(resultDir, 'executor.log'), 'utf8').catch(() => ''),
+      content =>
+        new RegExp(
+          `local_task_id=${switchedTaskBinding.task_id}[^\\n]*project_name=${taskTargetProjectName}(?:\\s|$)`
+        ).test(content),
+      'The created task did not run in the runtime project selected before submission',
+      uiTimeoutMs
+    )
+    assert.match(
+      switchedTaskRuntimeLog,
+      new RegExp(
+        `local_task_id=${switchedTaskBinding.task_id}[^\\n]*project_name=${taskTargetProjectName}(?:\\s|$)`
+      )
+    )
 
     const statusWorkflowRule = await cloudRequest(
       `/api/v1/cloud-projects/${projectId}/automations`,

--- a/wework/src/features/todo/BackgroundTaskStarter.test.tsx
+++ b/wework/src/features/todo/BackgroundTaskStarter.test.tsx
@@ -1,15 +1,33 @@
 import { render, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { RuntimeTaskAddress } from '@/types/api'
+import { runtimeProjectUiId } from '@/lib/runtime-project'
+import type { RuntimeTaskAddress, RuntimeTaskCreateRequest } from '@/types/api'
 import { BackgroundTaskStarter } from './BackgroundTaskStarter'
 
 const mocks = vi.hoisted(() => ({
   createConversation: vi.fn(),
+  useComposer: vi.fn(),
+  runtimeWork: {
+    projects: [],
+    chats: [],
+    totalTasks: 0,
+  } as import('@/types/api').RuntimeWorkListResponse,
 }))
 
 vi.mock('./useProjectRuntimeTaskComposer', () => ({
-  useProjectRuntimeTaskComposer: () => mocks.createConversation,
+  useProjectRuntimeTaskComposer: (options: unknown) => {
+    mocks.useComposer(options)
+    return mocks.createConversation
+  },
+}))
+
+vi.mock('@/features/workbench/useWorkbench', () => ({
+  useWorkbenchPaneContext: () => ({
+    state: {
+      runtimeWork: mocks.runtimeWork,
+    },
+  }),
 }))
 
 describe('BackgroundTaskStarter', () => {
@@ -73,5 +91,110 @@ describe('BackgroundTaskStarter', () => {
     )
     expect(onAddressChange).toHaveBeenCalledOnce()
     expect(onAddressChange).toHaveBeenCalledWith(address)
+  })
+
+  it('uses the project captured by the task request instead of the previous project', async () => {
+    const taskRequest: RuntimeTaskCreateRequest = {
+      schemaVersion: 2,
+      runtime: 'codex',
+      message: 'Implement cloud MCP',
+      deviceId: 'local-device',
+      runtimeProjectKey: 'primary-project',
+      runtimeProjectName: '主项目',
+      runtimeWorkspaceRoots: ['/workspace/primary'],
+    }
+    mocks.runtimeWork = {
+      projects: [
+        {
+          project: {
+            key: 'secondary-project',
+            name: '次项目',
+            source: 'local_project',
+            stateDeviceId: 'local-device',
+          },
+          deviceWorkspaces: [
+            {
+              id: 901,
+              deviceId: 'local-device',
+              workspacePath: '/workspace/secondary',
+              workspaceKind: 'worktree',
+              workspaceSource: 'local',
+              available: true,
+              tasks: [],
+            },
+          ],
+        },
+        {
+          project: {
+            key: 'primary-project',
+            name: '主项目',
+            source: 'local_project',
+            stateDeviceId: 'local-device',
+          },
+          deviceWorkspaces: [
+            {
+              id: 902,
+              deviceId: 'local-device',
+              workspacePath: '/workspace/primary',
+              workspaceKind: 'worktree',
+              workspaceSource: 'local',
+              available: true,
+              tasks: [],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalTasks: 0,
+    }
+    const runtimeProjectId = runtimeProjectUiId(mocks.runtimeWork.projects[1].project)
+    mocks.createConversation.mockResolvedValue(false)
+
+    render(
+      <BackgroundTaskStarter
+        project={{
+          id: 11,
+          name: 'Wegent V4',
+          description: '',
+        }}
+        localProjects={[
+          { id: 91, name: '次项目', tasks: [] },
+          { id: runtimeProjectId, name: '主项目', tasks: [] },
+        ]}
+        task={{
+          id: 'WEG-1',
+          cloud_project_id: 11,
+          sequence_number: 1,
+          parent_id: null,
+          created_by_user_id: 1,
+          assignee_user_id: null,
+          title: 'Implement cloud MCP',
+          description: 'Use the shared workspace',
+          status: 'pending',
+          priority: 'high',
+          due_at: null,
+          sort_order: 0,
+          current_delivery_id: null,
+          version: 1,
+          created_at: '2026-07-22T00:00:00Z',
+          updated_at: '2026-07-22T00:00:00Z',
+          completed_at: null,
+        }}
+        input="Implement cloud MCP"
+        initialLocalProjectId={91}
+        taskRequest={taskRequest}
+        onAddressChange={vi.fn()}
+        onError={vi.fn()}
+      />
+    )
+
+    await waitFor(() =>
+      expect(mocks.useComposer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          project: expect.objectContaining({ id: runtimeProjectId, name: '主项目' }),
+          taskRequest,
+        })
+      )
+    )
   })
 })

--- a/wework/src/features/todo/BackgroundTaskStarter.tsx
+++ b/wework/src/features/todo/BackgroundTaskStarter.tsx
@@ -2,7 +2,10 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import type { CloudLoopItem, CloudProject } from '@/api/deliveries'
 import { createRuntimeUserMessage } from '@/features/workbench/runtimeUserMessage'
-import type { ProjectWithTasks, RuntimeTaskAddress } from '@/types/api'
+import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
+import { resolveRuntimeTaskProjects } from '@/lib/runtime-project'
+import { runtimeTaskProjectUiId } from '@/lib/runtime-task-workspace-binding'
+import type { ProjectWithTasks, RuntimeTaskAddress, RuntimeTaskCreateRequest } from '@/types/api'
 import { useProjectRuntimeTaskComposer } from './useProjectRuntimeTaskComposer'
 import { buildWorkItemRuntimeContext } from './workItemRuntimeContext'
 
@@ -12,6 +15,7 @@ interface BackgroundTaskStarterProps {
   task: CloudLoopItem
   input: string
   initialLocalProjectId?: number | null
+  taskRequest?: RuntimeTaskCreateRequest | null
   inheritFromTask?: RuntimeTaskAddress | null
   workflowNodeId?: string
   prepareTask?: (
@@ -32,6 +36,7 @@ export function BackgroundTaskStarter({
   task,
   input,
   initialLocalProjectId = null,
+  taskRequest = null,
   inheritFromTask = null,
   workflowNodeId,
   prepareTask,
@@ -39,16 +44,23 @@ export function BackgroundTaskStarter({
   onAddressChange,
   onError,
 }: BackgroundTaskStarterProps) {
+  const { state } = useWorkbenchPaneContext()
   const startedRef = useRef(false)
   const addressReportedRef = useRef(false)
-  const selectedLocalProject = useMemo(
-    () =>
-      localProjects.find(candidate => candidate.id === initialLocalProjectId) ??
-      localProjects.find(candidate => String(candidate.id) === String(project.id)) ??
-      localProjects[0] ??
-      null,
-    [initialLocalProjectId, localProjects, project.id]
+  const runtimeTaskProjects = useMemo(
+    () => resolveRuntimeTaskProjects(localProjects, state?.runtimeWork),
+    [localProjects, state?.runtimeWork]
   )
+  const selectedLocalProject = useMemo(() => {
+    const requestedProjectId = runtimeTaskProjectUiId(state?.runtimeWork, taskRequest)
+    return (
+      runtimeTaskProjects.find(candidate => candidate.id === requestedProjectId) ??
+      runtimeTaskProjects.find(candidate => candidate.id === initialLocalProjectId) ??
+      runtimeTaskProjects.find(candidate => String(candidate.id) === String(project.id)) ??
+      runtimeTaskProjects[0] ??
+      null
+    )
+  }, [initialLocalProjectId, project.id, runtimeTaskProjects, state?.runtimeWork, taskRequest])
   const runtimeContext = useMemo(
     () => buildWorkItemRuntimeContext(project, task, workflowNodeId),
     [project, task, workflowNodeId]
@@ -56,6 +68,7 @@ export function BackgroundTaskStarter({
   const createConversation = useProjectRuntimeTaskComposer({
     project: selectedLocalProject,
     workspaceSource: inheritFromTask,
+    taskRequest,
     runtimeContext,
     prepareTask,
     onTaskCreated,

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -20,7 +20,7 @@ import {
   applyRuntimeConversationAction,
   clearRuntimeConversationCacheForTests,
 } from '@/features/workbench/runtimeConversationCache'
-import type { User } from '@/types/api'
+import type { RuntimeTaskCreateRequest, User } from '@/types/api'
 import { CloudTodoWorkspace } from './CloudTodoWorkspace'
 import {
   isSelfManagedWorkItem,
@@ -229,8 +229,10 @@ vi.mock('./BackgroundTaskStarter', () => ({
     onAddressChange,
     onTaskCreated,
     prepareTask,
+    taskRequest,
   }: {
     onAddressChange: (address: { deviceId: string; taskId: string }) => void
+    taskRequest?: RuntimeTaskCreateRequest | null
     onTaskCreated?: (
       address: { deviceId: string; taskId: string },
       localProject: { id: number; name: string; tasks: [] } | null
@@ -243,6 +245,7 @@ vi.mock('./BackgroundTaskStarter', () => ({
     <button
       type="button"
       data-testid="mock-start-background-task"
+      data-task-request={JSON.stringify(taskRequest ?? null)}
       onClick={() => {
         const address = { deviceId: 'local-device', taskId: 'runtime-created' }
         const localProject = { id: 91, name: '运营工作区', tasks: [] as [] }
@@ -3908,6 +3911,17 @@ describe('CloudTodoWorkspace', () => {
       })
     )
     expect(screen.getByTestId('mock-start-background-task')).toBeInTheDocument()
+    expect(
+      JSON.parse(
+        screen.getByTestId('mock-start-background-task').getAttribute('data-task-request') ?? 'null'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        message: 'Start release work',
+        title: 'Start release work',
+        cloudProjectId: '11',
+      })
+    )
     expect(screen.queryByTestId('ai-chat-modal')).not.toBeInTheDocument()
     expect(screen.queryByTestId('cloud-todo-panel-stack')).not.toBeInTheDocument()
     expect(screen.queryByTestId('cloud-todo-detail-dismiss-layer')).not.toBeInTheDocument()

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -5909,6 +5909,7 @@ export function CloudTodoWorkspace({
               localProjectIdForItem(selectedItem) ??
               (isMyTasksBoard ? selectedLocalProject?.id : null)
             }
+            taskRequest={taskComposerRequest.taskRequest}
             inheritFromTask={taskComposerRequest.inheritFromTask}
             workflowNodeId={taskComposerRequest.workflowNodeId}
             onAddressChange={() => {


### PR DESCRIPTION
## Summary

- propagate the workspace task request into the background task starter
- resolve the runtime project from the project selected in the task composer instead of retaining the previous/default project
- add unit coverage and a desktop E2E assertion against the persisted executor task binding

## Root cause

The task composer updated its selected project in `taskRequest`, but `BackgroundTaskStarter` independently selected a project from runtime state and never received that request. Task creation therefore used the prior/default project even though the UI showed the newly selected project.

## Verification

- `pnpm --filter wework test --run src/features/todo/BackgroundTaskStarter.test.tsx src/features/todo/CloudTodoWorkspace.test.tsx` (103 tests passed)
- `pnpm --filter wework typecheck`
- `pnpm --filter wework e2e:desktop --segment project-automation` (all checkpoints passed)
- pre-push Wework ESLint, TypeScript, and unit-test checks passed
