### PR TITLE
fix(wework): route board hover conversation actions

### DIFF
--- a/executor/src/runtime_work/native_transcript.rs
+++ b/executor/src/runtime_work/native_transcript.rs
@@ -692,6 +692,7 @@ fn append_workspace_snapshot(
     snapshot: &WorkspaceSnapshot,
 ) -> Result<(), String> {
     let mut command = Command::new("git");
+    crate::local::native_git::clear_local_git_env(&mut command);
     command
         .arg("--git-dir")
         .arg(&snapshot.git_common_dir)
@@ -1119,6 +1120,27 @@ mod tests {
 
     use super::*;
 
+    fn git(path: &Path, args: &[&str]) -> std::process::Output {
+        let mut command = Command::new("git");
+        crate::local::native_git::clear_local_git_env(&mut command);
+        command
+            .current_dir(path)
+            .args(args)
+            .output()
+            .expect("git should start")
+    }
+
+    fn assert_git(path: &Path, args: &[&str]) {
+        let output = git(path, args);
+        assert!(
+            output.status.success(),
+            "git -C {} {} failed: {}",
+            path.display(),
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     fn environment_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
@@ -1135,33 +1157,20 @@ mod tests {
             vec!["config", "user.name", "Wegent Test"],
             vec!["config", "user.email", "test@wegent.local"],
         ] {
-            assert!(Command::new("git")
-                .current_dir(&source)
-                .args(args)
-                .status()
-                .unwrap()
-                .success());
+            assert_git(&source, &args);
         }
         fs::write(source.join("tracked.txt"), "base\n").unwrap();
-        assert!(Command::new("git")
-            .current_dir(&source)
-            .args(["add", "."])
-            .status()
-            .unwrap()
-            .success());
-        assert!(Command::new("git")
-            .current_dir(&source)
-            .args(["commit", "-m", "base"])
-            .status()
-            .unwrap()
-            .success());
-        assert!(Command::new("git")
-            .current_dir(&source)
-            .args(["worktree", "add", "--detach"])
-            .arg(&workspace)
-            .status()
-            .unwrap()
-            .success());
+        assert_git(&source, &["add", "."]);
+        assert_git(&source, &["commit", "-m", "base"]);
+        assert_git(
+            &source,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                workspace.to_str().expect("temporary path must be UTF-8"),
+            ],
+        );
         fs::write(workspace.join("tracked.txt"), "snapshot content\n").unwrap();
         fs::create_dir_all(workspace.join("node_modules/package")).unwrap();
         fs::write(
@@ -1169,36 +1178,21 @@ mod tests {
             "ignored\n",
         )
         .unwrap();
-        assert!(Command::new("git")
-            .current_dir(&workspace)
-            .args(["add", "-f", "."])
-            .status()
+        assert_git(&workspace, &["add", "-f", "."]);
+        assert_git(&workspace, &["commit", "-m", "snapshot"]);
+        let reference = String::from_utf8(git(&workspace, &["rev-parse", "HEAD"]).stdout)
             .unwrap()
-            .success());
-        assert!(Command::new("git")
-            .current_dir(&workspace)
-            .args(["commit", "-m", "snapshot"])
-            .status()
-            .unwrap()
-            .success());
-        let reference = String::from_utf8(
-            Command::new("git")
-                .current_dir(&workspace)
-                .args(["rev-parse", "HEAD"])
-                .output()
-                .unwrap()
-                .stdout,
-        )
-        .unwrap()
-        .trim()
-        .to_owned();
-        assert!(Command::new("git")
-            .current_dir(&source)
-            .args(["worktree", "remove", "--force"])
-            .arg(&workspace)
-            .status()
-            .unwrap()
-            .success());
+            .trim()
+            .to_owned();
+        assert_git(
+            &source,
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                workspace.to_str().expect("temporary path must be UTF-8"),
+            ],
+        );
 
         let archive_path = root.path().join("workspace.tgz");
         let output = fs::File::create(&archive_path).unwrap();

--- a/wework/AGENTS.md
+++ b/wework/AGENTS.md
@@ -31,6 +31,7 @@ Before changing a Wework flow, identify the affected product area and trace its 
 - Preserve platform text-navigation semantics in the ProseMirror chat composer. Register only composer-specific key bindings instead of the document-level `baseKeymap`, and scope mention caret workarounds to unmodified arrow keys.
 - Focus popup composers through their exact editor target; a mixed `querySelector` returns the first matching element in DOM order, not the first selector in the list. In WKWebView, keep a completely empty contenteditable position native instead of replacing it with a decoration widget so programmatic focus can start the platform text input session.
 - Keep model selector controls mounted while refreshing an already-loaded model catalog. Reserve loading placeholders for the initial catalog load so background refreshes do not create blank composer actions.
+- In project-board hover conversations, handle self-contained actions such as sending, retrying, answering runtime input, and loading or reverting diffs inside the popup. Actions that require workbench UI, including opening files, skills, reviews, plans, or switching the retry model, must navigate to the bound Runtime task. Never render an enabled conversation action without a real handler.
 
 ## i18n
 

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -41,7 +41,7 @@ const MOONSHOT_OVERRIDE_ISSUE_TITLE = 'Issue 临时云端 Moonshot 覆盖本地 
 const MOONSHOT_OVERRIDE_FOLLOW_UP =
   'WEWORK_PROJECT_AUTOMATION_MOONSHOT_FOLLOW_UP: verify immutable task model routing.'
 const MOONSHOT_OVERRIDE_FOLLOW_UP_COMPLETION =
-  'WEWORK_PROJECT_AUTOMATION_MOONSHOT_FOLLOW_UP_COMPLETE'
+  'WEWORK_PROJECT_AUTOMATION_MOONSHOT_FOLLOW_UP_COMPLETE\n\n[打开任务文件](README.md)'
 const CLOUD_MODEL_UPSTREAM_ID = 'desktop-e2e-public-upstream-model'
 
 const PROJECT = {
@@ -1434,6 +1434,13 @@ export function createDesktopScenario({
       routedFollowUp?.model,
       CLOUD_MODEL_UPSTREAM_ID,
       'The board popup follow-up used the global default instead of the task model'
+    )
+    assert.equal(
+      await control.command('getAttribute', boardWorkspaceTabSelector, {
+        value: 'aria-selected',
+      }),
+      'true',
+      'A locally handled board-popup message unexpectedly left the project-space tab'
     )
     try {
       await control.command('press', 'body', { key: 'Escape' })

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -41,7 +41,8 @@ const MOONSHOT_OVERRIDE_ISSUE_TITLE = 'Issue 临时云端 Moonshot 覆盖本地 
 const MOONSHOT_OVERRIDE_FOLLOW_UP =
   'WEWORK_PROJECT_AUTOMATION_MOONSHOT_FOLLOW_UP: verify immutable task model routing.'
 const MOONSHOT_OVERRIDE_FOLLOW_UP_COMPLETION =
-  'WEWORK_PROJECT_AUTOMATION_MOONSHOT_FOLLOW_UP_COMPLETE\n\n[打开任务文件](README.md)'
+  'WEWORK_PROJECT_AUTOMATION_MOONSHOT_FOLLOW_UP_COMPLETE'
+const MOONSHOT_OVERRIDE_INITIAL_COMPLETION = '真实自动化执行已完成。\n\n[打开任务文件](README.md)'
 const CLOUD_MODEL_UPSTREAM_ID = 'desktop-e2e-public-upstream-model'
 
 const PROJECT = {
@@ -446,6 +447,7 @@ export function createDesktopScenario({
   let personalApiKey = null
   let managerToolCalls = 0
   const upstreamResponseRequests = []
+  let moonshotOverrideIssueId = null
   let uiProject = { ...PROJECT }
   let nextBoardItemSequence = 201
   let orchestratedItemId = null
@@ -1125,6 +1127,7 @@ export function createDesktopScenario({
         }),
       }
     )
+    moonshotOverrideIssueId = moonshotOverrideIssue.id
     assert.equal(moonshotOverrideIssue.assignee_agent_id, localDefaultAgent.id)
     assert.equal(
       moonshotOverrideIssue.execution_config?.execution_device_id,
@@ -1329,6 +1332,7 @@ export function createDesktopScenario({
     const moonshotPopupModelSelector = `${moonshotPopupConversation} [data-testid="model-selector-button"]`
     const moonshotPopupInput = `${moonshotPopupConversation} [data-testid="chat-message-input"]`
     const moonshotPopupSend = `${moonshotPopupConversation} [data-testid="send-message-button"]`
+    const taskFileLink = `${moonshotPopupConversation} [data-testid="assistant-markdown-link"]`
     await control.command('scrollIntoView', moonshotOverrideCard, { visible: true })
     await control.command('hover', moonshotOverrideCard, { visible: true })
     await control.command('waitFor', moonshotProgressPopup, {
@@ -1391,6 +1395,42 @@ export function createDesktopScenario({
       `The board popup did not start from the latest message: ${JSON.stringify(popupScrollMetrics)}`
     )
     await captureScreenshot(control, 'project-automation-board-hover-stable-latest.png')
+    await control.command('waitFor', taskFileLink, {
+      text: '打开任务文件',
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    await control.command('click', taskFileLink, { visible: true })
+    await control.command(
+      'waitFor',
+      '[data-testid="workspace-tab-select-fixed-task"][aria-selected="true"]',
+      {
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      }
+    )
+    await waitForValue(
+      async () => JSON.parse(await control.command('getWorkbenchDebugSnapshot', 'body')),
+      snapshot =>
+        snapshot.workbench?.currentRuntimeTask?.taskId === moonshotExecution.runtimeTaskId,
+      'The board-popup file action did not return to its bound Runtime task',
+      uiTimeoutMs
+    )
+    await control.command('click', '[data-testid="new-chat-button"]', { visible: true })
+    await control.command('waitFor', '[data-testid="desktop-empty-composer-frame"]', {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    await control.command('click', boardWorkspaceTabSelector, { visible: true })
+    await control.command('waitFor', moonshotOverrideCard, {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    await control.command('hover', moonshotOverrideCard, { visible: true })
+    await control.command('waitFor', moonshotProgressPopup, {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
     const followUpRequestOffset = upstreamResponseRequests.length
     await control.command('click', moonshotPopupInput, { visible: true })
     await waitForValue(
@@ -2994,7 +3034,11 @@ export function createDesktopScenario({
         }
         writeEvents([
           responseCreated(responseId),
-          assistantMessage('真实自动化执行已完成。'),
+          assistantMessage(
+            serialized.includes(`task_id: ${moonshotOverrideIssueId}`)
+              ? MOONSHOT_OVERRIDE_INITIAL_COMPLETION
+              : '真实自动化执行已完成。'
+          ),
           responseCompleted(responseId),
         ])
         return true

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -2180,13 +2180,18 @@ export function createDesktopScenario({
     await control.command('waitFor', '[data-testid="ai-coordinator-prompt"]', {
       timeoutMs: uiTimeoutMs,
     })
-    await control.command('click', '[data-testid^="execution-node-step-"]', {
+    const executionNodeSelector = '[data-testid^="execution-node-step-"]'
+    await control.command('waitFor', executionNodeSelector, {
+      timeoutMs: uiTimeoutMs,
+      visible: true,
+    })
+    await control.command('click', executionNodeSelector, {
       visible: true,
     })
     await control.command('click', '[data-testid="automation-canvas-fit-view"]', {
       visible: true,
     })
-    await control.command('hover', '[data-testid^="execution-node-step-"]', {
+    await control.command('hover', executionNodeSelector, {
       visible: true,
     })
     await control.command('waitFor', '[data-testid^="automation-node-insert-before-step-"]', {

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -676,6 +676,7 @@ function AssistantMarkdownLink({
 
   if (target.kind === 'file') {
     const filePath = target.path
+    const canOpenWithoutWorkspace = isHtmlFilePath(filePath)
     const lineLabel = formatMarkdownLineLabel(target)
     const tooltip = formatMarkdownFileTooltip(target)
     const openOptions = getMarkdownFileOpenOptions(target)
@@ -690,6 +691,7 @@ function AssistantMarkdownLink({
           type="button"
           className={ASSISTANT_MARKDOWN_LINK_CLASS}
           data-testid="assistant-markdown-link"
+          disabled={!onOpenFile && !canOpenWithoutWorkspace}
           onClick={() => {
             if (isHtmlFilePath(filePath)) {
               if (requestEmbeddedBrowserOpen(filePath)) return

--- a/wework/src/components/chat/AssistantPlanCard.tsx
+++ b/wework/src/components/chat/AssistantPlanCard.tsx
@@ -75,7 +75,11 @@ export function AssistantPlanCard({
             </span>
           ) : null}
         </div>
-        <PlanCardActions content={content} onDownload={handleDownload} onExpand={openPlan} />
+        <PlanCardActions
+          content={content}
+          onDownload={handleDownload}
+          onExpand={onOpenPlan ? openPlan : undefined}
+        />
       </div>
       <div
         data-testid="assistant-plan-card-preview"
@@ -100,7 +104,7 @@ function PlanCardActions({
 }: {
   content: string
   onDownload: () => void | Promise<void>
-  onExpand: () => void
+  onExpand?: () => void
 }) {
   const { t } = useTranslation('chat')
   const [copied, setCopied] = useState(false)
@@ -129,13 +133,17 @@ function PlanCardActions({
       onClick: handleCopy,
       testId: 'assistant-plan-copy-button',
     },
-    {
-      key: 'expand',
-      label: t('plan_card.expand'),
-      icon: <Maximize2 className="h-4 w-4" aria-hidden="true" />,
-      onClick: onExpand,
-      testId: 'assistant-plan-expand-button',
-    },
+    ...(onExpand
+      ? [
+          {
+            key: 'expand',
+            label: t('plan_card.expand'),
+            icon: <Maximize2 className="h-4 w-4" aria-hidden="true" />,
+            onClick: onExpand,
+            testId: 'assistant-plan-expand-button',
+          },
+        ]
+      : []),
   ]
 
   return (

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -732,6 +732,8 @@ describe('MessageList', () => {
 
     const { container } = render(
       <MessageList
+        onRetryFailedMessage={vi.fn()}
+        onSwitchModelForFailedMessage={vi.fn()}
         messages={[
           {
             id: 'assistant-streaming-windowed',
@@ -5020,6 +5022,8 @@ describe('MessageList', () => {
             createdAt: '2026-05-25T18:46:00.000+08:00',
           },
         ]}
+        onRetryFailedMessage={vi.fn()}
+        onSwitchModelForFailedMessage={vi.fn()}
       />
     )
 
@@ -5561,6 +5565,8 @@ describe('MessageList', () => {
             createdAt: '2026-05-25T18:46:00.000+08:00',
           },
         ]}
+        onRetryFailedMessage={vi.fn()}
+        onSwitchModelForFailedMessage={vi.fn()}
       />
     )
 

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -2050,13 +2050,15 @@ export function AssistantMessage({
   )
   const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
 
-  const openFileFromLink = (path: string, options?: WorkspaceFileOpenOptions) => {
-    if (options) {
-      onOpenWorkspaceFile?.(path, options)
-      return
-    }
-    onOpenWorkspaceFile?.(path)
-  }
+  const openFileFromLink = onOpenWorkspaceFile
+    ? (path: string, options?: WorkspaceFileOpenOptions) => {
+        if (options) {
+          onOpenWorkspaceFile(path, options)
+          return
+        }
+        onOpenWorkspaceFile(path)
+      }
+    : undefined
   const references = getAssistantReferences(message.references, visibleContent, message.fileChanges)
   const processingTimeline = shouldShowProcessingSummary
     ? processingSegments.map((segment, index) => (
@@ -2236,7 +2238,7 @@ export function AssistantMessage({
           {canShowFinalArtifacts && memoryCitations.length > 0 && (
             <CodexMemoryCitations citations={memoryCitations} onOpenFile={onOpenWorkspaceFile} />
           )}
-          {canShowFinalArtifacts && references.length > 0 && (
+          {canShowFinalArtifacts && references.length > 0 && openFileFromLink && (
             <CodexReferenceList references={references} onOpenFile={openFileFromLink} />
           )}
           {message.status === 'failed' && (
@@ -2659,22 +2661,26 @@ function AssistantErrorCard({
         <p className="text-sm font-semibold leading-5 text-text-primary">{title}</p>
         <p className="mt-0.5 text-xs leading-[18px] text-text-secondary">{description}</p>
         <div className="mt-3 flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            data-testid="assistant-error-switch-model-retry"
-            onClick={() => onSwitchModel?.(message)}
-            className="h-8 rounded-lg border border-text-primary bg-text-primary px-3 text-xs font-semibold text-background hover:bg-text-primary/90"
-          >
-            {t('assistant_error.actions.switch_model_retry', '切换模型并重试')}
-          </button>
-          <button
-            type="button"
-            data-testid="assistant-error-retry"
-            onClick={() => onRetry?.(message)}
-            className="h-8 rounded-lg border border-border bg-base px-3 text-xs font-semibold text-text-secondary hover:bg-muted hover:text-text-primary"
-          >
-            {t('assistant_error.actions.retry', '重试')}
-          </button>
+          {onSwitchModel ? (
+            <button
+              type="button"
+              data-testid="assistant-error-switch-model-retry"
+              onClick={() => onSwitchModel(message)}
+              className="h-8 rounded-lg border border-text-primary bg-text-primary px-3 text-xs font-semibold text-background hover:bg-text-primary/90"
+            >
+              {t('assistant_error.actions.switch_model_retry', '切换模型并重试')}
+            </button>
+          ) : null}
+          {onRetry ? (
+            <button
+              type="button"
+              data-testid="assistant-error-retry"
+              onClick={() => onRetry(message)}
+              className="h-8 rounded-lg border border-border bg-base px-3 text-xs font-semibold text-text-secondary hover:bg-muted hover:text-text-primary"
+            >
+              {t('assistant_error.actions.retry', '重试')}
+            </button>
+          ) : null}
           {hasErrorDetails && (
             <button
               type="button"

--- a/wework/src/components/chat/RequestUserInputCard.test.tsx
+++ b/wework/src/components/chat/RequestUserInputCard.test.tsx
@@ -1,6 +1,6 @@
 import '@/i18n'
 
-import { render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import { RequestUserInputCard } from './RequestUserInputCard'
@@ -52,6 +52,27 @@ describe('RequestUserInputCard', () => {
       },
     })
     expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  test('ignores duplicate submissions while the runtime request is in flight', async () => {
+    let resolveSubmit: ((accepted: boolean) => void) | undefined
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          resolveSubmit = resolve
+        })
+    )
+    render(<RequestUserInputCard payload={payload} onSubmit={onSubmit} />)
+
+    const option = screen.getByTestId('request-user-input-option-goal-1')
+    fireEvent.click(option)
+    fireEvent.click(option)
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveSubmit?.(true)
+    })
   })
 
   test('wraps long option text and scrolls an oversized question list', () => {

--- a/wework/src/components/chat/RequestUserInputCard.tsx
+++ b/wework/src/components/chat/RequestUserInputCard.tsx
@@ -46,7 +46,7 @@ export interface RequestUserInputPayload {
 interface RequestUserInputCardProps {
   payload: RequestUserInputPayload
   disabled?: boolean
-  onSubmit?: (response: RequestUserInputResponse) => void
+  onSubmit?: (response: RequestUserInputResponse) => boolean | void | Promise<boolean | void>
   onIgnore?: () => void
 }
 
@@ -81,11 +81,11 @@ export function RequestUserInputCard({
     formRef.current?.focus({ preventScroll: true })
   }, [])
 
-  const handleSubmit = (
+  const handleSubmit = async (
     answersOverride?: Record<string, string>,
     activeQuestionIdOverride?: string | null
-  ) => {
-    if (isDisabled || questions.length === 0) return
+  ): Promise<boolean> => {
+    if (isDisabled || questions.length === 0 || !onSubmit) return false
 
     const effectiveAnswers = answersOverride ?? selectedAnswers
     const answers = responseAnswers(
@@ -93,17 +93,18 @@ export function RequestUserInputCard({
       effectiveAnswers,
       activeQuestionIdOverride ?? activeQuestionId
     )
-    setSubmitted(true)
-    onSubmit?.({
+    const accepted = await onSubmit({
       requestId: payload.requestId ?? payload.request_id,
       itemId: payload.itemId ?? payload.item_id,
       answers,
     })
+    if (accepted !== false) setSubmitted(true)
+    return accepted !== false
   }
 
   const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    handleSubmit()
+    void handleSubmit()
   }
 
   const selectOption = (
@@ -118,7 +119,7 @@ export function RequestUserInputCard({
     setActiveQuestionId(question.id)
     setSelectedAnswers(nextAnswers)
     if (shouldSubmitOnOptionSelect(question, option, questions)) {
-      handleSubmit(nextAnswers, question.id)
+      void handleSubmit(nextAnswers, question.id)
     }
   }
 
@@ -143,7 +144,7 @@ export function RequestUserInputCard({
 
     event.preventDefault()
     event.stopPropagation()
-    handleSubmit()
+    void handleSubmit()
   }
 
   const actionControls = (
@@ -151,7 +152,7 @@ export function RequestUserInputCard({
       <button
         type="button"
         data-testid="request-user-input-ignore-button"
-        disabled={isDisabled}
+        disabled={isDisabled || !onIgnore}
         onClick={onIgnore}
         className="inline-flex h-11 min-w-[44px] shrink-0 items-center gap-1.5 rounded-lg px-2 text-sm font-medium text-text-muted hover:bg-muted hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60 md:h-8"
       >
@@ -163,8 +164,8 @@ export function RequestUserInputCard({
       <button
         type="button"
         data-testid="request-user-input-submit-button"
-        disabled={isDisabled || questions.length === 0}
-        onClick={() => handleSubmit()}
+        disabled={isDisabled || questions.length === 0 || !onSubmit}
+        onClick={() => void handleSubmit()}
         className="inline-flex h-11 min-w-[68px] shrink-0 items-center justify-center gap-1.5 rounded-lg bg-text-primary px-3 text-sm font-medium text-background shadow-sm hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 md:h-8"
       >
         {t('request_user_input.submit')}

--- a/wework/src/components/chat/RequestUserInputCard.tsx
+++ b/wework/src/components/chat/RequestUserInputCard.tsx
@@ -58,6 +58,7 @@ export function RequestUserInputCard({
 }: RequestUserInputCardProps) {
   const { t } = useTranslation('chat')
   const formRef = useRef<HTMLFormElement | null>(null)
+  const submitInFlightRef = useRef(false)
   const questions = useMemo(
     () => normalizeQuestions(localizeApprovalQuestions(payload, t)),
     [payload, t]
@@ -85,7 +86,7 @@ export function RequestUserInputCard({
     answersOverride?: Record<string, string>,
     activeQuestionIdOverride?: string | null
   ): Promise<boolean> => {
-    if (isDisabled || questions.length === 0 || !onSubmit) return false
+    if (isDisabled || submitInFlightRef.current || questions.length === 0 || !onSubmit) return false
 
     const effectiveAnswers = answersOverride ?? selectedAnswers
     const answers = responseAnswers(
@@ -93,13 +94,18 @@ export function RequestUserInputCard({
       effectiveAnswers,
       activeQuestionIdOverride ?? activeQuestionId
     )
-    const accepted = await onSubmit({
-      requestId: payload.requestId ?? payload.request_id,
-      itemId: payload.itemId ?? payload.item_id,
-      answers,
-    })
-    if (accepted !== false) setSubmitted(true)
-    return accepted !== false
+    submitInFlightRef.current = true
+    try {
+      const accepted = await onSubmit({
+        requestId: payload.requestId ?? payload.request_id,
+        itemId: payload.itemId ?? payload.item_id,
+        answers,
+      })
+      if (accepted !== false) setSubmitted(true)
+      return accepted !== false
+    } finally {
+      submitInFlightRef.current = false
+    }
   }
 
   const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -278,13 +278,15 @@ function PlanBlockItem({
   if (!block.content.trim()) return null
 
   const isStreaming = block.status !== 'done' && block.status !== 'error'
-  const openPlan = () => {
-    onOpenAssistantPlan?.({
-      blockId: block.id,
-      subtaskId: String(block.subtaskId),
-      content: block.content,
-    })
-  }
+  const openPlan = onOpenAssistantPlan
+    ? () => {
+        onOpenAssistantPlan({
+          blockId: block.id,
+          subtaskId: String(block.subtaskId),
+          content: block.content,
+        })
+      }
+    : undefined
 
   return (
     <div data-processing-block-id={block.id}>

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -1662,7 +1662,7 @@ export const ComposerTextarea = forwardRef<ComposerTextareaHandle, ComposerTexta
               skillLoadingLabel={t('workbench.loading_slash_command_skills')}
               skillLoadErrorLabel={t('workbench.slash_command_skills_error')}
               skillRetryLabel={t('workbench.retry_local_skills')}
-              onSelectCommand={command => selectSlashCommand(command)}
+              onSelectCommand={command => selectSlashCommand(command, activeMenu?.trigger)}
               onHighlightCommand={setSelectedIndex}
               onRetrySkills={() => loadLocalMentions({ force: true })}
             />

--- a/wework/src/components/chat/requestUserInputMessages.ts
+++ b/wework/src/components/chat/requestUserInputMessages.ts
@@ -48,6 +48,14 @@ export function requestUserInputResponseKey(response: RequestUserInputResponse):
   return null
 }
 
+export function requestUserInputResponseText(response: RequestUserInputResponse): string {
+  const answers = Object.values(response.answers)
+    .flatMap(answer => answer.answers)
+    .map(answer => answer.trim())
+    .filter(Boolean)
+  return answers.length > 0 ? answers.join('\n') : '继续'
+}
+
 export function isImplementationPlanRequestUserInput(
   payload: RequestUserInputPayload | null | undefined
 ): boolean {

--- a/wework/src/components/layout/runtimeRetry.ts
+++ b/wework/src/components/layout/runtimeRetry.ts
@@ -1,0 +1,2 @@
+export const RUNTIME_RETRY_CONTINUATION_PROMPT =
+  'Continue the unfinished work from the previous turn. Use the existing conversation context and do not repeat work that is already complete.'

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -36,6 +36,7 @@ import {
   applyRequestUserInputResponseToBlock,
   requestUserInputPayloadKey,
   requestUserInputResponseKey,
+  requestUserInputResponseText,
 } from '@/components/chat/requestUserInputMessages'
 import type { RequestUserInputPayload } from '@/components/chat/RequestUserInputCard'
 import { debugComposerEvent, textMetrics } from '@/components/chat/composer/composerDebug'
@@ -118,6 +119,7 @@ import {
   createRuntimeUserMessage,
   type RuntimeUserMessageOptions,
 } from '@/features/workbench/runtimeUserMessage'
+import { RUNTIME_RETRY_CONTINUATION_PROMPT } from './runtimeRetry'
 
 interface WorkbenchPaneSessionOptions {
   currentRuntimeTask: RuntimeTaskAddress | null
@@ -178,8 +180,7 @@ interface PendingRuntimeGoalState {
 const runtimePaneGoalSeeds = new Map<string, PendingRuntimeGoalState>()
 const DEFAULT_RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
 const MAX_CACHED_RUNTIME_PANE_GOALS = 3
-export const RUNTIME_RETRY_CONTINUATION_PROMPT =
-  'Continue the unfinished work from the previous turn. Use the existing conversation context and do not repeat work that is already complete.'
+export { RUNTIME_RETRY_CONTINUATION_PROMPT } from './runtimeRetry'
 const EMPTY_ATTACHMENT_STATE = {
   attachments: [],
   uploadingFiles: new Map(),
@@ -3468,12 +3469,4 @@ function createPendingRuntimeGoal(objective: string): RuntimeGoal {
     createdAt: now,
     updatedAt: now,
   }
-}
-
-function requestUserInputResponseText(response: RequestUserInputResponse): string {
-  const answers = Object.values(response.answers)
-    .flatMap(answer => answer.answers)
-    .map(answer => answer.trim())
-    .filter(Boolean)
-  return answers.length > 0 ? answers.join('\n') : '继续'
 }

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx
@@ -10,6 +10,7 @@ import type {
   RuntimeTaskAddress,
   UnifiedModel,
 } from '@/types/api'
+import { RUNTIME_RETRY_CONTINUATION_PROMPT } from '@/components/layout/runtimeRetry'
 import { TemporaryChatPanel } from './TemporaryChatPanel'
 
 const attachment: Attachment = {
@@ -33,7 +34,17 @@ const mocks = vi.hoisted(() => ({
   sendRuntimePaneMessage: vi.fn(async () => true),
   createTask: vi.fn(),
   loadRuntimeTranscriptForPane: vi.fn(),
+  loadTurnFileChangesDiff: vi.fn(),
+  revertTurnFileChanges: vi.fn(),
+  cancelRuntimePaneTask: vi.fn(async () => true),
   syncTranscript: vi.fn(),
+  conversationMessages: [] as Array<{
+    id: string
+    role: 'assistant' | 'user'
+    content: string
+    status: 'done' | 'failed'
+    createdAt: string
+  }>,
   lifecycleSnapshot: null as {
     derived: {
       isRunning: boolean
@@ -50,7 +61,34 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/components/chat/ScrollableMessageArea', () => ({
-  ScrollableMessageArea: ({ messages }: { messages: Array<{ attachments?: Attachment[] }> }) => (
+  ScrollableMessageArea: ({
+    messages,
+    onRetryFailedMessage,
+    onSwitchModelForFailedMessage,
+    onOpenWorkspaceFile,
+    onOpenFileChangesReview,
+    onOpenAssistantPlan,
+    onRequestUserInputSubmit,
+    onRequestUserInputIgnore,
+  }: {
+    messages: Array<{
+      id: string
+      attachments?: Attachment[]
+      role?: string
+      content?: string
+      status?: string
+    }>
+    onRetryFailedMessage?: (message: unknown) => void
+    onSwitchModelForFailedMessage?: (message: unknown) => void
+    onOpenWorkspaceFile?: (path: string) => void
+    onOpenFileChangesReview?: () => void
+    onOpenAssistantPlan?: () => void
+    onRequestUserInputSubmit?: (response: {
+      requestId: string
+      answers: Record<string, { answers: string[] }>
+    }) => void
+    onRequestUserInputIgnore?: (payload: { kind: string; request_id: string }) => void
+  }) => (
     <div data-testid="mock-message-list">
       {messages.flatMap(message =>
         (message.attachments ?? []).map(messageAttachment => (
@@ -59,6 +97,68 @@ vi.mock('@/components/chat/ScrollableMessageArea', () => ({
           </span>
         ))
       )}
+      {onRetryFailedMessage && messages[0] ? (
+        <button
+          type="button"
+          data-testid="mock-retry"
+          onClick={() => onRetryFailedMessage(messages[0])}
+        >
+          重试
+        </button>
+      ) : null}
+      {onSwitchModelForFailedMessage && messages[0] ? (
+        <button
+          type="button"
+          data-testid="mock-switch-model"
+          onClick={() => onSwitchModelForFailedMessage(messages[0])}
+        >
+          切换模型
+        </button>
+      ) : null}
+      {onOpenWorkspaceFile ? (
+        <button
+          type="button"
+          data-testid="mock-open-file"
+          onClick={() => onOpenWorkspaceFile('/tmp/workspace/file.ts')}
+        >
+          打开文件
+        </button>
+      ) : null}
+      {onOpenFileChangesReview ? (
+        <button type="button" data-testid="mock-open-review" onClick={onOpenFileChangesReview}>
+          打开 Review
+        </button>
+      ) : null}
+      {onOpenAssistantPlan ? (
+        <button type="button" data-testid="mock-open-plan" onClick={onOpenAssistantPlan}>
+          打开 Plan
+        </button>
+      ) : null}
+      {onRequestUserInputSubmit ? (
+        <button
+          type="button"
+          data-testid="mock-submit-input"
+          onClick={() =>
+            onRequestUserInputSubmit({
+              requestId: 'request-1',
+              answers: { choice: { answers: ['继续'] } },
+            })
+          }
+        >
+          回答
+        </button>
+      ) : null}
+      {onRequestUserInputIgnore ? (
+        <button
+          type="button"
+          data-testid="mock-ignore-input"
+          onClick={() =>
+            onRequestUserInputIgnore({ kind: 'request_user_input', request_id: 'request-1' })
+          }
+        >
+          忽略
+        </button>
+      ) : null}
     </div>
   ),
 }))
@@ -146,9 +246,11 @@ vi.mock('@/features/workbench/useWorkbench', () => ({
     createTemporaryRuntimeTask: vi.fn(),
     sendRuntimePaneMessage: mocks.sendRuntimePaneMessage,
     sendRuntimePaneGuidance: vi.fn(),
-    cancelRuntimePaneTask: vi.fn(),
+    cancelRuntimePaneTask: mocks.cancelRuntimePaneTask,
     subscribeRuntimeTaskStream: () => () => undefined,
     loadRuntimeTranscriptForPane: mocks.loadRuntimeTranscriptForPane,
+    loadTurnFileChangesDiff: mocks.loadTurnFileChangesDiff,
+    revertTurnFileChanges: mocks.revertTurnFileChanges,
   }),
 }))
 
@@ -189,9 +291,10 @@ vi.mock('@/features/workbench/runtimeConversationCache', () => ({
   ) => (action.type === 'user_added' && action.message ? [action.message] : []),
   beginRuntimeConversationHydration: vi.fn(),
   completeRuntimeConversationHydration: vi.fn(),
-  getRuntimeConversationMessages: () => [],
+  getRuntimeConversationMessages: () => mocks.conversationMessages,
   removeRuntimeConversationTurn: () => [],
   subscribeRuntimeConversation: () => () => undefined,
+  updateRuntimeConversationBlocks: () => mocks.conversationMessages,
 }))
 
 vi.mock('@/features/workbench/runtimeTaskLifecycle', () => ({
@@ -223,6 +326,11 @@ describe('TemporaryChatPanel', () => {
       afterCursor: null,
     })
     mocks.syncTranscript.mockReset()
+    mocks.loadTurnFileChangesDiff.mockReset()
+    mocks.revertTurnFileChanges.mockReset()
+    mocks.cancelRuntimePaneTask.mockReset()
+    mocks.cancelRuntimePaneTask.mockResolvedValue(true)
+    mocks.conversationMessages = []
     mocks.lifecycleSnapshot = null
     mocks.activeModelSelection = null
     mocks.isBootstrapping = false
@@ -489,5 +597,83 @@ describe('TemporaryChatPanel', () => {
       }),
       expect.any(Object)
     )
+  })
+
+  it('handles retry and runtime input actions inside the temporary conversation', async () => {
+    mocks.activeModelSelection = {
+      modelName: 'gpt-5.6-codex',
+      modelType: 'public',
+      options: {},
+    }
+    mocks.conversationMessages = [
+      {
+        id: 'failed-assistant',
+        role: 'assistant',
+        content: '',
+        status: 'failed',
+        createdAt: '2026-09-10T00:00:00Z',
+      },
+    ]
+
+    render(
+      <TemporaryChatPanel
+        currentProject={null}
+        source={address}
+        instanceId="local-actions"
+        initialAddress={address}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('mock-retry'))
+    expect(mocks.sendRuntimePaneMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address,
+        message: RUNTIME_RETRY_CONTINUATION_PROMPT,
+        modelId: 'gpt-5.6-codex',
+      })
+    )
+
+    await userEvent.click(screen.getByTestId('mock-submit-input'))
+    expect(mocks.sendRuntimePaneMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address,
+        message: '继续',
+        requestUserInputResponse: expect.objectContaining({ requestId: 'request-1' }),
+      })
+    )
+
+    await userEvent.click(screen.getByTestId('mock-ignore-input'))
+    expect(mocks.cancelRuntimePaneTask).toHaveBeenCalledWith(address)
+  })
+
+  it('returns task-page actions to the current runtime task', async () => {
+    mocks.conversationMessages = [
+      {
+        id: 'assistant',
+        role: 'assistant',
+        content: 'Open the workspace result',
+        status: 'done',
+        createdAt: '2026-09-10T00:00:00Z',
+      },
+    ]
+    const onOpenRuntimeTask = vi.fn()
+
+    render(
+      <TemporaryChatPanel
+        currentProject={null}
+        source={address}
+        instanceId="task-page-actions"
+        initialAddress={address}
+        onOpenRuntimeTask={onOpenRuntimeTask}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('mock-open-file'))
+    await userEvent.click(screen.getByTestId('mock-open-review'))
+    await userEvent.click(screen.getByTestId('mock-open-plan'))
+    await userEvent.click(screen.getByTestId('mock-switch-model'))
+
+    expect(onOpenRuntimeTask).toHaveBeenCalledTimes(4)
+    expect(onOpenRuntimeTask).toHaveBeenCalledWith(address)
   })
 })

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { ChevronRight, MessageCircle } from 'lucide-react'
 import { ScrollableMessageArea } from '@/components/chat/ScrollableMessageArea'
+import type { RequestUserInputPayload } from '@/components/chat/RequestUserInputCard'
+import {
+  applyRequestUserInputResponseToBlock,
+  requestUserInputPayloadKey,
+  requestUserInputResponseText,
+} from '@/components/chat/requestUserInputMessages'
 import type { ChatSubmitOptions, ProjectWorkControls } from '@/components/chat/ChatInput'
 import { BufferedChatInput } from '@/components/layout/BufferedChatInput'
+import { RUNTIME_RETRY_CONTINUATION_PROMPT } from '@/components/layout/runtimeRetry'
 import {
   DESKTOP_CHAT_CONTENT_WIDTH_CLASS,
   DESKTOP_MESSAGE_LIST_CLASS,
@@ -24,6 +31,7 @@ import {
   getRuntimeConversationTurnIds,
   removeRuntimeConversationTurn,
   subscribeRuntimeConversation,
+  updateRuntimeConversationBlocks,
 } from '@/features/workbench/runtimeConversationCache'
 import {
   consumeRuntimeTaskLifecycleBlock,
@@ -44,6 +52,7 @@ import type {
   ModelOptions,
   ModelType,
   ProjectWithTasks,
+  RequestUserInputResponse,
   RuntimeSendRequest,
   RuntimeGoalCreateInput,
   RuntimeTaskAddress,
@@ -92,6 +101,7 @@ interface TemporaryChatPanelProps {
   onRestoreConversation?: () => void
   initialScrollPosition?: 'restore' | 'latest'
   scrollOrigin?: 'top' | 'bottom'
+  onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void> | void
 }
 
 export function TemporaryChatPanel({
@@ -119,6 +129,7 @@ export function TemporaryChatPanel({
   onRestoreConversation,
   initialScrollPosition = 'restore',
   scrollOrigin = 'top',
+  onOpenRuntimeTask,
 }: TemporaryChatPanelProps) {
   const { t } = useTranslation('common')
   const {
@@ -131,6 +142,8 @@ export function TemporaryChatPanel({
     cancelRuntimePaneTask,
     subscribeRuntimeTaskStream,
     loadRuntimeTranscriptForPane,
+    loadTurnFileChangesDiff,
+    revertTurnFileChanges,
   } = useWorkbenchPaneContext()
   const attachmentSelection = useWorkbenchAttachments({
     uploadAttachment: services.attachmentApi?.uploadAttachment,
@@ -188,6 +201,9 @@ export function TemporaryChatPanel({
   const [goalDraftActive, setGoalDraftActive] = useState(false)
   const [queuedMessages, setQueuedMessages] = useState<RuntimePaneQueuedMessage[]>([])
   const [loadingFullTranscript, setLoadingFullTranscript] = useState(false)
+  const [hiddenRequestUserInputIds, setHiddenRequestUserInputIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  )
   const lifecycleStore = useRuntimeTaskLifecycleStore()
   const taskLifecycle = useRuntimeTaskLifecycle(address)
   const paneStatus = useMemo(
@@ -205,6 +221,7 @@ export function TemporaryChatPanel({
   const queuedMessagesRef = useRef(queuedMessages)
   const createdAddressKeyRef = useRef<string | null>(null)
   const autoSubmittedInitialInputRef = useRef(false)
+  const retryInFlightRef = useRef(false)
 
   useEffect(() => {
     queuedMessagesRef.current = queuedMessages
@@ -757,6 +774,101 @@ export function TemporaryChatPanel({
     }).finally(() => setSending(false))
   }, [address, cancelRuntimePaneTask])
 
+  const openRuntimeTask = useCallback(() => {
+    if (!address || !onOpenRuntimeTask) return
+    void onOpenRuntimeTask(address)
+  }, [address, onOpenRuntimeTask])
+
+  const retryFailedMessage = useCallback(
+    async (message: WorkbenchMessage): Promise<boolean> => {
+      if (!address || retryInFlightRef.current) return false
+      const failedMessage = messages.find(
+        candidate =>
+          candidate.id === message.id &&
+          candidate.role === 'assistant' &&
+          candidate.status === 'failed'
+      )
+      if (!failedMessage) {
+        setError(t('workbench.retry_message_missing', '未找到可重试的失败消息'))
+        return false
+      }
+
+      retryInFlightRef.current = true
+      setError(null)
+      const clientUserMessageId = `runtime-retry-continuation-${Date.now()}`
+      const visibleMessage = createRuntimeUserMessage(
+        t('workbench.retry_continue_message', '继续'),
+        [],
+        { id: clientUserMessageId }
+      )
+      setMessages(
+        applyRuntimeConversationAction(address, {
+          type: 'user_added',
+          message: visibleMessage,
+        })
+      )
+      try {
+        const sent = await sendRuntimePaneMessage({
+          address,
+          message: RUNTIME_RETRY_CONTINUATION_PROMPT,
+          clientUserMessageId,
+          ...selectedModelFields,
+          ...runtimeContext,
+        })
+        if (!sent) {
+          setMessages(removeRuntimeConversationTurn(address, { clientUserMessageId }))
+        }
+        return sent
+      } catch (caughtError) {
+        setMessages(removeRuntimeConversationTurn(address, { clientUserMessageId }))
+        setError(caughtError instanceof Error ? caughtError.message : t('workbench.retry_failed'))
+        return false
+      } finally {
+        retryInFlightRef.current = false
+      }
+    },
+    [address, messages, runtimeContext, selectedModelFields, sendRuntimePaneMessage, t]
+  )
+
+  const submitRequestUserInput = useCallback(
+    async (response: RequestUserInputResponse): Promise<boolean> => {
+      if (!address) return false
+      const sent = await sendRuntimePaneMessage({
+        address,
+        message: requestUserInputResponseText(response),
+        requestUserInputResponse: response,
+        ...runtimeContext,
+      })
+      if (!sent) return false
+      setMessages(
+        updateRuntimeConversationBlocks(address, block =>
+          applyRequestUserInputResponseToBlock(block, response)
+        )
+      )
+      return true
+    },
+    [address, runtimeContext, sendRuntimePaneMessage]
+  )
+
+  const ignoreRequestUserInput = useCallback(
+    async (payload: RequestUserInputPayload) => {
+      if (!address) return
+      const key = requestUserInputPayloadKey(payload)
+      if (key) {
+        setHiddenRequestUserInputIds(current => new Set(current).add(key))
+      }
+      const cancelled = await cancelRuntimePaneTask(address)
+      if (!cancelled && key) {
+        setHiddenRequestUserInputIds(current => {
+          const next = new Set(current)
+          next.delete(key)
+          return next
+        })
+      }
+    },
+    [address, cancelRuntimePaneTask]
+  )
+
   return (
     <section data-testid={testId} className="flex min-h-0 min-w-0 flex-1 flex-col">
       {messages.length === 0 ? (
@@ -775,6 +887,33 @@ export function TemporaryChatPanel({
           scrollTestId="right-workspace-chat-scroll-area"
           onLoadFullTranscript={loadFullTranscript}
           loadingFullTranscript={loadingFullTranscript}
+          onRetryFailedMessage={
+            address
+              ? message => {
+                  void retryFailedMessage(message)
+                }
+              : undefined
+          }
+          onSwitchModelForFailedMessage={onOpenRuntimeTask ? openRuntimeTask : undefined}
+          onLoadFileChangesDiff={
+            address
+              ? (subtaskId, fileChanges) =>
+                  loadTurnFileChangesDiff(subtaskId, messages, fileChanges, address)
+              : undefined
+          }
+          onRevertFileChanges={
+            address
+              ? (subtaskId, fileChanges) =>
+                  revertTurnFileChanges(subtaskId, messages, fileChanges, address)
+              : undefined
+          }
+          onOpenFileChangesReview={onOpenRuntimeTask ? openRuntimeTask : undefined}
+          onOpenWorkspaceFile={onOpenRuntimeTask ? openRuntimeTask : undefined}
+          onOpenLocalSkillFile={onOpenRuntimeTask ? openRuntimeTask : undefined}
+          onRequestUserInputSubmit={address ? submitRequestUserInput : undefined}
+          onRequestUserInputIgnore={address ? ignoreRequestUserInput : undefined}
+          onOpenAssistantPlan={onOpenRuntimeTask ? openRuntimeTask : undefined}
+          hiddenRequestUserInputIds={hiddenRequestUserInputIds}
           initialScrollPosition={initialScrollPosition}
           scrollOrigin={scrollOrigin}
         />

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -316,6 +316,7 @@ interface CloudTodoBoardCardProps {
   onPreviewPinnedChange?: (pinned: boolean) => void
   onMarkRead?: (item: CloudLoopItem) => void
   onLoadRuntimeGoal?: (address: RuntimeTaskAddress) => Promise<void>
+  onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void> | void
   display: BoardCardDisplaySettings
   processingStatus: boolean
   agentNames?: Record<string, string>
@@ -340,6 +341,7 @@ export function CloudTodoBoardCard({
   onPreviewPinnedChange,
   onMarkRead,
   onLoadRuntimeGoal,
+  onOpenRuntimeTask,
   display,
   processingStatus,
   agentNames,
@@ -568,6 +570,7 @@ export function CloudTodoBoardCard({
           pinned={previewPinned}
           onPin={() => onPreviewPinnedChange?.(true)}
           onLoadRuntimeGoal={onLoadRuntimeGoal}
+          onOpenRuntimeTask={onOpenRuntimeTask}
         />
       }
     >
@@ -633,6 +636,7 @@ function RuntimeTaskProgressSummary({
   repairingChangeRequest,
   onContinueChangeRequestRepair,
   onLoadRuntimeGoal,
+  onOpenRuntimeTask,
 }: {
   item: CloudLoopItem
   binding: CloudTodoBoardTaskBinding
@@ -643,6 +647,7 @@ function RuntimeTaskProgressSummary({
   repairingChangeRequest: boolean
   onContinueChangeRequestRepair?: () => Promise<void>
   onLoadRuntimeGoal?: (address: RuntimeTaskAddress) => Promise<void>
+  onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void> | void
 }) {
   const { t } = useTranslation('common')
   const taskAddress = useMemo<RuntimeTaskAddress>(
@@ -741,6 +746,7 @@ function RuntimeTaskProgressSummary({
             scrollOrigin="bottom"
             emptyStateText={t('todo.task_progress_empty', '暂无任务进展详情')}
             placeholder={t('workbench.task_activity_inline_placeholder')}
+            onOpenRuntimeTask={onOpenRuntimeTask}
           />
         </div>
       ) : responsePreview ? (
@@ -809,6 +815,7 @@ function RuntimeTaskProgressPopup({
   pinned,
   onPin,
   onLoadRuntimeGoal,
+  onOpenRuntimeTask,
 }: {
   item: CloudLoopItem
   bindings: CloudTodoBoardTaskBinding[]
@@ -818,6 +825,7 @@ function RuntimeTaskProgressPopup({
   pinned: boolean
   onPin: () => void
   onLoadRuntimeGoal?: (address: RuntimeTaskAddress) => Promise<void>
+  onOpenRuntimeTask?: (address: RuntimeTaskAddress) => Promise<void> | void
 }) {
   const { t } = useTranslation('common')
   const visibleBindings = focusedBindingId
@@ -878,6 +886,7 @@ function RuntimeTaskProgressPopup({
                 changeRequestSnapshot={null}
                 repairingChangeRequest={false}
                 onLoadRuntimeGoal={onLoadRuntimeGoal}
+                onOpenRuntimeTask={onOpenRuntimeTask}
               />
             </div>
           ))}

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -1418,6 +1418,13 @@ export function CloudTodoWorkspace({
     contextKey: string
     itemId: string
   } | null>(null)
+  const openBoardRuntimeTask = useCallback(
+    (address: RuntimeTaskAddress) => {
+      setPinnedBoardPreview(null)
+      return onOpenRuntimeTask?.(address)
+    },
+    [onOpenRuntimeTask]
+  )
   const [pendingExecutionConfiguration, setPendingExecutionConfiguration] =
     useState<PendingExecutionConfiguration | null>(null)
   const executionFailureByItemRef = useRef(new Map<string, boolean>())
@@ -5367,7 +5374,7 @@ export function CloudTodoWorkspace({
                                       }
                                       onMarkRead={markItemRead}
                                       onLoadRuntimeGoal={loadBoardTaskRuntimeGoal}
-                                      onOpenRuntimeTask={onOpenRuntimeTask}
+                                      onOpenRuntimeTask={openBoardRuntimeTask}
                                       display={boardCardDisplay}
                                       agentNames={agentNameById}
                                       dragDisabled={isAITableProject}

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -5367,6 +5367,7 @@ export function CloudTodoWorkspace({
                                       }
                                       onMarkRead={markItemRead}
                                       onLoadRuntimeGoal={loadBoardTaskRuntimeGoal}
+                                      onOpenRuntimeTask={onOpenRuntimeTask}
                                       display={boardCardDisplay}
                                       agentNames={agentNameById}
                                       dragDisabled={isAITableProject}

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -37,6 +37,7 @@
     "project_chat_cloud_required": "Connect to cloud to use activity",
     "project_chat_load_failed": "Failed to load activity",
     "project_chat_send_failed": "Failed to send message",
+    "retry_failed": "Retry failed",
     "project_chat_close": "Close AI messages",
     "project_chat_loading": "Loading activity…",
     "project_chat_empty_title": "Message AI",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -38,6 +38,7 @@
     "project_chat_cloud_required": "连接云端后可使用动态",
     "project_chat_load_failed": "动态加载失败",
     "project_chat_send_failed": "消息发送失败",
+    "retry_failed": "重试失败",
     "project_chat_close": "关闭问AI",
     "project_chat_loading": "正在加载动态…",
     "project_chat_empty_title": "问AI",


### PR DESCRIPTION
## Summary

- handle retry, runtime input, and file-change actions directly in project-board hover conversations
- route file, skill, review, plan, and switch-model actions to the bound Runtime task
- remove enabled conversation affordances when no real handler is available
- document the project-board hover interaction boundary
- add a CI-covered `e2e:desktop` regression to the `project-automation` checkpoint

## Verification

- `pnpm --filter wework test src/components/layout/workspace-panels/TemporaryChatPanel.test.tsx src/components/chat/MessageList.test.tsx src/features/todo/CloudTodoBoardCard.test.tsx` (176 passed)
- `pnpm --filter wework typecheck`
- focused ESLint and Prettier checks
- `WEWORK_E2E_APP_BIN=... WEWORK_E2E_EXECUTOR_BIN=... pnpm --filter wework e2e:desktop --segment project-automation` (passed, 4m51s)
- pre-push Wework ESLint, TypeScript, and unit tests (passed)

## E2E coverage

The project-automation scenario now verifies that sending a follow-up from the hover conversation remains in the project-space tab, while clicking a workspace file link opens the exact Runtime task bound to the board card. The scenario restores the blank task tab before continuing so later checkpoints retain independent prerequisites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project-board popups now support retrying messages, responding to input requests, opening runtime tasks, and loading or reverting file changes.
  - Follow-up responses can open linked task files while preserving the selected board and task workspace.
  - User-input submissions support asynchronous processing and cancellation.
  - Moving pending items into processing can now start runtime tasks immediately.
- **Bug Fixes**
  - Unavailable actions no longer appear or trigger ineffective interactions.
  - Duplicate input submissions are prevented while a request is in progress.
  - Slash-command selection now consistently uses the active menu.
  - Retry and browser authorization messages have been updated.
- **Tests**
  - Added coverage for runtime retry, task cancellation, input handling, file changes, and board navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->