### PR TITLE
fix(ci): run only e2e in merge queue

### DIFF
--- a/.github/scripts/classify-plugin-auth-sdk.sh
+++ b/.github/scripts/classify-plugin-auth-sdk.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+plugin_auth_sdk=false
+
+classify_path() {
+  local path="$1"
+
+  case "$path" in
+    sdk/plugin-auth/* | \
+      sdk/plugin-creator/* | \
+      sdk/plugin-auth-go/* | \
+      sdk/dws-auth/* | \
+      sdk/plugin-build/* | \
+      shared/plugin_build.py | \
+      shared/tests/test_plugin_build.py | \
+      executor/src/plugin_account_auth/* | \
+      executor/src/local/plugin_creator.rs | \
+      executor/src/process/mod.rs | \
+      executor/tests/plugin_account_auth_contract.rs | \
+      .github/scripts/classify-plugin-auth-sdk.sh | \
+      .github/workflows/plugin-auth-sdk.yml)
+      plugin_auth_sdk=true
+      ;;
+  esac
+}
+
+if [[ "${1:-}" == "--all" ]]; then
+  plugin_auth_sdk=true
+elif (($# > 0)); then
+  for path in "$@"; do
+    classify_path "$path"
+  done
+else
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && classify_path "$path"
+  done
+fi
+
+printf 'plugin_auth_sdk=%s\n' "$plugin_auth_sdk" \
+  >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -924,6 +924,17 @@ for workflow in e2e-tests.yml wework-e2e.yml; do
   fi
 done
 
+platform_e2e_workflow="$script_dir/../workflows/e2e-tests.yml"
+provider_native_step="$(
+  extract_named_workflow_step \
+    "$platform_e2e_workflow" \
+    "Run Provider-native E2E tests serially"
+)"
+if ! grep -Fq "if: matrix.shardIndex == 4" <<<"$provider_native_step"; then
+  printf 'Provider-native E2E must run on the historically fastest shard\n' >&2
+  exit 1
+fi
+
 for workflow in test.yml lint.yml; do
   workflow_path="$script_dir/../workflows/$workflow"
   if ! grep -q "merge_group:" "$workflow_path"; then

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -6,6 +6,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 classifier="$script_dir/classify-ci-changes.sh"
 desktop_classifier="$script_dir/classify-wework-desktop-e2e.sh"
+plugin_auth_classifier="$script_dir/classify-plugin-auth-sdk.sh"
 cloud_checkpoint_flows="$repo_root/wework/e2e/desktop/modules/cloud-checkpoint-flows.mjs"
 desktop_build_flows="$repo_root/wework/e2e/desktop/modules/desktop-build-flows.mjs"
 desktop_checkpoint_runner="$repo_root/wework/e2e/desktop/run-checkpoints.mjs"
@@ -76,6 +77,25 @@ assert_invalid_cloud_shards_rejected() {
 
 assert_invalid_desktop_shards_rejected
 assert_invalid_cloud_shards_rejected
+
+assert_plugin_auth_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+
+  local output
+  output="$(GITHUB_OUTPUT=/dev/stdout "$plugin_auth_classifier" "$@")"
+  if [[ "$output" != "plugin_auth_sdk=$expected" ]]; then
+    printf 'Plugin auth case "%s" failed: %s\n' "$name" "$output" >&2
+    exit 1
+  fi
+}
+
+assert_plugin_auth_case "unrelated Wework change" false \
+  "wework/src/App.tsx"
+assert_plugin_auth_case "native auth source" true \
+  "executor/src/plugin_account_auth/mod.rs"
+assert_plugin_auth_case "explicit full regression" true --all
 
 assert_checkpoint_runtime_failure_rejected() {
   local temp_dir
@@ -896,9 +916,9 @@ for workflow in e2e-tests.yml wework-e2e.yml; do
       exit 1
     fi
   elif ! grep -Fq \
-    "FORCE_ALL: \${{ github.event_name != 'pull_request'" \
+    "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'" \
     "$workflow_path"; then
-    printf '%s must force all E2E outside pull request events\n' \
+    printf '%s must reserve full E2E for scheduled, dispatched, or ci:all runs\n' \
       "$workflow" >&2
     exit 1
   fi
@@ -906,20 +926,41 @@ done
 
 for workflow in test.yml lint.yml; do
   workflow_path="$script_dir/../workflows/$workflow"
-  if ! grep -q "classify-ci-changes.sh --all" "$workflow_path"; then
-    printf '%s must classify every module for merge groups\n' "$workflow" >&2
-    exit 1
-  fi
   if ! grep -q "merge_group:" "$workflow_path"; then
-    printf '%s must run for merge queue groups\n' "$workflow" >&2
+    printf '%s must publish its required summary in merge groups\n' "$workflow" >&2
     exit 1
   fi
-  if ! grep -q "GITHUB_EVENT_NAME.*merge_group\\|github.event_name == 'merge_group'" \
-    "$workflow_path"; then
-    printf '%s must classify every module for merge groups\n' "$workflow" >&2
+  if ! grep -Fq "if: github.event_name != 'merge_group'" "$workflow_path" ||
+    ! grep -Fq "if: github.event_name == 'merge_group'" "$workflow_path" ||
+    ! grep -Fq "name: Confirm E2E-only merge queue" "$workflow_path"; then
+    printf '%s must replace module checks with one summary in merge groups\n' \
+      "$workflow" >&2
+    exit 1
+  fi
+  if ! grep -Fq "ci:all" "$workflow_path"; then
+    printf '%s must keep full regression available through ci:all\n' "$workflow" >&2
     exit 1
   fi
 done
+
+plugin_auth_workflow="$script_dir/../workflows/plugin-auth-sdk.yml"
+if workflow_has_top_level_trigger "$plugin_auth_workflow" "push"; then
+  printf 'plugin-auth-sdk.yml must not repeat merge queue validation after entering main\n' >&2
+  exit 1
+fi
+if workflow_has_top_level_trigger "$plugin_auth_workflow" "merge_group"; then
+  printf 'plugin-auth-sdk.yml must not run in the merge queue\n' >&2
+  exit 1
+fi
+plugin_auth_gated_job_count="$(
+  grep -Fc "if: needs.changes.outputs.plugin_auth_sdk == 'true'" \
+    "$plugin_auth_workflow"
+)"
+if ! grep -Fq "ci:all" "$plugin_auth_workflow" ||
+  [[ "$plugin_auth_gated_job_count" -ne 3 ]]; then
+  printf 'plugin-auth-sdk.yml must be path-scoped and full under ci:all\n' >&2
+  exit 1
+fi
 
 assert_workflow_trigger_case "block mapping push trigger" "true" $'on:\n  push:\n  pull_request:'
 assert_workflow_trigger_case "block mapping with on comment" "true" $'on: # workflow triggers\n  push:\n  pull_request:'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -521,7 +521,7 @@ jobs:
             --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Run Provider-native E2E tests serially
-        if: matrix.shardIndex == 1
+        if: matrix.shardIndex == 4
         timeout-minutes: 15
         working-directory: ./frontend
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Classify changed paths
         id: classify
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          FORCE_ALL: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
+          FORCE_ALL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:all')) }}
         run: |
           if [[ "$FORCE_ALL" == "true" ]]; then
             .github/scripts/classify-ci-changes.sh --all

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -22,6 +28,7 @@ concurrency:
 jobs:
   changes:
     name: Detect CI Changes
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.classify.outputs.backend }}
@@ -38,10 +45,11 @@ jobs:
       - name: Classify changed paths
         id: classify
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FORCE_ALL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:all') }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
+          if [[ "$FORCE_ALL" == "true" ]]; then
             .github/scripts/classify-ci-changes.sh --all
           else
             git diff --name-only "$BASE_SHA...$HEAD_SHA" |
@@ -142,6 +150,7 @@ jobs:
 
   check-settings-config:
     name: Check Settings Configuration
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
 
     steps:
@@ -186,6 +195,7 @@ jobs:
 
   check-alembic-heads:
     name: Check Alembic Multi-Head
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
 
     steps:
@@ -201,7 +211,7 @@ jobs:
     name: Lint Summary
     runs-on: ubuntu-latest
     needs: [changes, lint-backend, lint-knowledge-engine, lint-frontend, lint-wework, check-settings-config, check-alembic-heads]
-    if: always()
+    if: always() && github.event_name != 'merge_group'
 
     steps:
       - name: Check lint results
@@ -224,3 +234,12 @@ jobs:
           assert_result "${{ needs.changes.outputs.knowledge_engine }}" "${{ needs.lint-knowledge-engine.result }}" "Knowledge Engine lint"
           assert_result "${{ needs.changes.outputs.frontend }}" "${{ needs.lint-frontend.result }}" "Frontend lint"
           assert_result "${{ needs.changes.outputs.wework }}" "${{ needs.lint-wework.result }}" "Wework lint"
+
+  merge-queue-summary:
+    name: Lint Summary
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Confirm E2E-only merge queue
+        run: echo "Lint checks are completed before the merge queue"

--- a/.github/workflows/plugin-auth-sdk.yml
+++ b/.github/workflows/plugin-auth-sdk.yml
@@ -2,41 +2,45 @@ name: Plugin Auth SDK
 
 on:
   pull_request:
-    paths:
-      - "sdk/plugin-auth/**"
-      - "sdk/plugin-creator/**"
-      - "sdk/plugin-auth-go/**"
-      - "sdk/dws-auth/**"
-      - "sdk/plugin-build/**"
-      - "shared/plugin_build.py"
-      - "shared/tests/test_plugin_build.py"
-      - "executor/src/plugin_account_auth/**"
-      - "executor/src/local/plugin_creator.rs"
-      - "executor/src/process/mod.rs"
-      - "executor/tests/plugin_account_auth_contract.rs"
-      - ".github/workflows/plugin-auth-sdk.yml"
-  push:
-    branches: [main]
-    paths:
-      - "sdk/plugin-auth/**"
-      - "sdk/plugin-creator/**"
-      - "sdk/plugin-auth-go/**"
-      - "sdk/dws-auth/**"
-      - "sdk/plugin-build/**"
-      - "shared/plugin_build.py"
-      - "shared/tests/test_plugin_build.py"
-      - "executor/src/plugin_account_auth/**"
-      - "executor/src/local/plugin_creator.rs"
-      - "executor/src/process/mod.rs"
-      - "executor/tests/plugin_account_auth_contract.rs"
-      - ".github/workflows/plugin-auth-sdk.yml"
-  merge_group:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Plugin Auth SDK Changes
+    runs-on: ubuntu-latest
+    outputs:
+      plugin_auth_sdk: ${{ steps.classify.outputs.plugin_auth_sdk }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FORCE_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+        run: |
+          if [[ "$FORCE_ALL" == "true" ]]; then
+            .github/scripts/classify-plugin-auth-sdk.sh --all
+          else
+            git diff --name-only "$BASE_SHA...$HEAD_SHA" |
+              .github/scripts/classify-plugin-auth-sdk.sh
+          fi
+
   dws-native:
+    needs: changes
+    if: needs.changes.outputs.plugin_auth_sdk == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -62,6 +66,8 @@ jobs:
         run: uv run --no-project python -m unittest discover -s sdk/dws-auth/tests -v
 
   test:
+    needs: changes
+    if: needs.changes.outputs.plugin_auth_sdk == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -79,6 +85,8 @@ jobs:
         run: uv run --no-project python -m unittest discover -s sdk/plugin-creator/tests -v
 
   native:
+    needs: changes
+    if: needs.changes.outputs.plugin_auth_sdk == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   changes:
     name: Detect CI Changes
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.classify.outputs.backend }}
@@ -45,12 +46,12 @@ jobs:
       - name: Classify changed paths
         id: classify
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          FORCE_ALL: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'ci:all') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FORCE_ALL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:all') }}
         run: |
           if [[ "$FORCE_ALL" == "true" ]]; then
-            # Merge groups and ci:all force every module test.
+            # ci:all is the explicit full-regression path.
             .github/scripts/classify-ci-changes.sh --all
           else
             git diff --name-only "$BASE_SHA...$HEAD_SHA" |
@@ -550,7 +551,7 @@ jobs:
         test-wegent-cli,
         test-wegent-cli-integration,
       ]
-    if: always()
+    if: always() && github.event_name != 'merge_group'
 
     steps:
       - name: Check test results
@@ -578,3 +579,12 @@ jobs:
           assert_result "${{ needs.changes.outputs.wework }}" "${{ needs.test-wework.result }}" "Wework tests"
           assert_result "${{ needs.changes.outputs.wegent_cli }}" "${{ needs.test-wegent-cli.result }}" "wegent CLI tests"
           assert_result "${{ needs.changes.outputs.wegent_cli }}" "${{ needs.test-wegent-cli-integration.result }}" "wegent CLI integration tests"
+
+  merge-queue-summary:
+    name: Test Summary
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Confirm E2E-only merge queue
+        run: echo "Unit tests are completed before the merge queue"


### PR DESCRIPTION
## Summary

- run only Platform E2E and Wework E2E test suites in merge queue
- preserve required Test Summary and Lint Summary contexts with one fast no-op job each
- move Plugin Auth SDK cross-platform coverage out of merge queue while retaining path-scoped PR runs and full ci:all coverage
- classify merge-group Platform E2E from the actual merge diff instead of forcing the full suite

## Evidence

On September 10, 2026, merge queue run data for a Wework-only change consumed about 120 runner-minutes across Wework E2E, Platform E2E, Tests, Plugin Auth SDK, and Lint. About 73 runner-minutes came from unrelated full-repository work.

The slowest relevant observed paths were:

- Platform E2E shard: 8.8 minutes
- Wework desktop build: 4.73 minutes
- runner queue delay: up to 3-6 minutes under the previous job burst

With non-E2E suites removed from the merge queue, the observed dependency graph gives an estimated queue-free critical path of about 8.8 minutes for Wework changes and 11.45 minutes when Platform E2E is required.

## Coverage

- PR unit tests and lint remain path-scoped
- ci:all still forces full Tests, Lint, Platform E2E, Wework E2E, and Plugin Auth SDK coverage
- scheduled full Platform and Wework E2E runs remain unchanged
- Plugin Auth SDK still runs for relevant PR changes
- no E2E scenario or assertion was changed

## Verification

- actionlint -shellcheck= -pyflakes= on changed workflows
- shellcheck on changed shell scripts
- bash -n on changed shell scripts
- YAML parsing for changed workflows
- Plugin Auth classifier positive, negative, and --all cases
- merge queue E2E-only structural assertions
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI change detection for pull requests and merge queue events.
  * Added targeted classification for Plugin Auth SDK changes.
  * Plugin Auth SDK checks now run only when relevant changes occur or the `ci:all` label is applied.
  * Limited full end-to-end runs to scheduled, manually dispatched, or explicitly labeled runs.
  * Added dedicated merge queue summaries for test and lint workflows.
  * Expanded validation coverage for CI workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up shard balancing

The first merge-group run showed that shard 1/4 remained the critical path because it serialized the 4.28-minute Provider-native suite after its regular shard. Historical job timings show shard 4/4 at 3.37 minutes versus shard 1/4 at 8.8 minutes. Provider-native coverage now runs on shard 4/4, reducing the projected longest shard to about 7.65 minutes without changing test cases, assertions, parallelism, or total runner work.