### PR TITLE
fix(dingtalk): coalesce card updates and correlate service traces

### DIFF
--- a/backend/app/services/channels/dingtalk/card.py
+++ b/backend/app/services/channels/dingtalk/card.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK card rendering with bounded, checked HTTP updates."""
+
+import uuid
+from typing import Any
+
+import requests
+from dingtalk_stream import AIMarkdownCardInstance
+from dingtalk_stream.utils import DINGTALK_OPENAPI_ENDPOINT
+
+
+class DingTalkMarkdownCard(AIMarkdownCardInstance):
+    """Retain SDK rendering while propagating update errors to the emitter."""
+
+    def _put(self, path: str, payload: dict[str, Any]) -> None:
+        token = self.dingtalk_client.get_access_token()
+        if not token:
+            raise RuntimeError("Cannot update DingTalk card without an access token")
+        # SDK update methods swallow failures and omit timeouts. Terminal delivery
+        # must only succeed when its HTTP request succeeds.
+        with requests.put(
+            f"{DINGTALK_OPENAPI_ENDPOINT}{path}",
+            headers=self.get_request_header(token),
+            json=payload,
+            timeout=(5, 10),
+        ) as response:
+            response.raise_for_status()
+
+    def put_card_data(
+        self, card_instance_id: str, card_data: dict, **kwargs: Any
+    ) -> None:
+        self._put(
+            "/v1.0/card/instances",
+            {
+                "outTrackId": card_instance_id,
+                "cardData": {"cardParamMap": card_data},
+                **kwargs,
+            },
+        )
+
+    def streaming(
+        self,
+        card_instance_id: str,
+        content_key: str,
+        content_value: str,
+        append: bool,
+        finished: bool,
+        failed: bool,
+    ) -> None:
+        self._put(
+            "/v1.0/card/streaming",
+            {
+                "outTrackId": card_instance_id,
+                "guid": str(uuid.uuid4()),
+                "key": content_key,
+                "content": content_value,
+                "isFull": not append,
+                "isFinalize": finished,
+                "isError": failed,
+            },
+        )

--- a/backend/app/services/channels/dingtalk/emitter.py
+++ b/backend/app/services/channels/dingtalk/emitter.py
@@ -519,10 +519,11 @@ class StreamingResponseEmitter(ResultEmitter):
         state = _CompactProgressState.from_dict(self._progress.to_dict())
         if self._progress_state_key:
             cached = await cache_manager.get(self._progress_state_key)
-            state = _CompactProgressState.from_dict(cached)
-            if state.mode == "progress":
-                for update in updates:
-                    update(state)
+            if cached is not None:
+                state = _CompactProgressState.from_dict(cached)
+                if state.mode == "progress":
+                    for update in updates:
+                        update(state)
         if content:
             state.mode = "answer"
         # Keep local projection current, including events received during the read.

--- a/backend/app/services/channels/dingtalk/emitter.py
+++ b/backend/app/services/channels/dingtalk/emitter.py
@@ -8,6 +8,8 @@ import asyncio
 import logging
 import re
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
@@ -15,6 +17,7 @@ from app.core.cache import cache_manager
 from app.services.channels.emitter import SyncResponseEmitter
 from app.services.execution.emitters import ResultEmitter
 from shared.models import EventType, ExecutionEvent
+from shared.telemetry.decorators import trace_async
 from shared.utils.sensitive_data_masker import mask_string
 
 if TYPE_CHECKING:
@@ -265,7 +268,7 @@ def _project_text_block(
 class StreamingResponseEmitter(ResultEmitter):
     """Render compact progress and the final answer into one DingTalk AI Card."""
 
-    MIN_UPDATE_INTERVAL = 0.8
+    MIN_UPDATE_INTERVAL = 0.5
     MAX_FINAL_CONTENT_LENGTH = 4000
     MAX_ERROR_CONTENT_LENGTH = 300
     FINAL_TRUNCATION_SUFFIX = "\n\n…（内容已截断，请在 Wework 查看完整结果）"
@@ -278,11 +281,11 @@ class StreamingResponseEmitter(ResultEmitter):
         incoming_message: "ChatbotMessage",
         existing_card_instance_id: Optional[str] = None,
     ):
-        from dingtalk_stream import AIMarkdownCardInstance
+        from app.services.channels.dingtalk.card import DingTalkMarkdownCard
 
         self._dingtalk_client = dingtalk_client
         self._incoming_message = incoming_message
-        self._card = AIMarkdownCardInstance(dingtalk_client, incoming_message)
+        self._card = DingTalkMarkdownCard(dingtalk_client, incoming_message)
         self._card.set_order(["msgContent"])
         self._full_content = ""
         self._pending_content = ""
@@ -292,6 +295,15 @@ class StreamingResponseEmitter(ResultEmitter):
         self._progress = _CompactProgressState()
         self._update_lock = asyncio.Lock()
         self._reconnected = bool(existing_card_instance_id)
+        self._initialized = False
+        self._dirty = False
+        self._finishing = False
+        self._closed = False
+        self._flush_task: Optional[asyncio.Task[None]] = None
+        self._flush_error: Optional[Exception] = None
+        self._lease_renewal: Optional[asyncio.Task[None]] = None
+        self._flush_now = asyncio.Event()
+        self._pending_progress: list[Callable[[_CompactProgressState], None]] = []
 
         if existing_card_instance_id:
             self._card.card_instance_id = existing_card_instance_id
@@ -304,16 +316,22 @@ class StreamingResponseEmitter(ResultEmitter):
         return self._card.card_instance_id if self._card else None
 
     @property
-    def _progress_state_key(self) -> Optional[str]:
+    def _answer_key(self) -> Optional[str]:
         if not self._shared_content_key:
             return None
-        return f"{self._shared_content_key}{self.PROGRESS_STATE_SUFFIX}"
+        return f"{self._shared_content_key}:{self.card_instance_id}"
+
+    @property
+    def _progress_state_key(self) -> Optional[str]:
+        if not self._answer_key:
+            return None
+        return f"{self._answer_key}{self.PROGRESS_STATE_SUFFIX}"
 
     @property
     def _display_lock_key(self) -> Optional[str]:
-        if not self._shared_content_key:
+        if not self._answer_key:
             return None
-        return f"{self._shared_content_key}{self.DISPLAY_LOCK_SUFFIX}"
+        return f"{self._answer_key}{self.DISPLAY_LOCK_SUFFIX}"
 
     def set_shared_content_key(self, key: str) -> None:
         """Enable Redis-backed answer and progress state sharing."""
@@ -324,7 +342,7 @@ class StreamingResponseEmitter(ResultEmitter):
             return True
         try:
             logger.info("[StreamingEmitter] Starting AI card...")
-            self._card.ai_start()
+            await self._call_card("ai_start")
             if not self._card.card_instance_id:
                 logger.error("[StreamingEmitter] AI card has no instance ID")
                 return False
@@ -345,7 +363,7 @@ class StreamingResponseEmitter(ResultEmitter):
             if cached is not None:
                 self._progress = _CompactProgressState.from_dict(cached)
 
-    async def _save_progress_state(self) -> None:
+    async def _save_progress_state(self, state: Optional[dict] = None) -> None:
         key = self._progress_state_key
         if not key:
             return
@@ -353,7 +371,7 @@ class StreamingResponseEmitter(ResultEmitter):
 
         saved = await cache_manager.set(
             key,
-            self._progress.to_dict(),
+            state if state is not None else self._progress.to_dict(),
             expire=CHANNEL_TASK_CALLBACK_TTL,
         )
         if not saved:
@@ -364,17 +382,15 @@ class StreamingResponseEmitter(ResultEmitter):
 
         redis_client = await cache_manager._get_client()
         try:
-            await redis_client.append(self._shared_content_key, content.encode("utf-8"))
-            await redis_client.expire(
-                self._shared_content_key, CHANNEL_TASK_CALLBACK_TTL
-            )
+            await redis_client.append(self._answer_key, content.encode("utf-8"))
+            await redis_client.expire(self._answer_key, CHANNEL_TASK_CALLBACK_TTL)
         finally:
             await redis_client.aclose()
 
     async def _redis_get_answer(self) -> str:
         redis_client = await cache_manager._get_client()
         try:
-            raw = await redis_client.get(self._shared_content_key)
+            raw = await redis_client.get(self._answer_key)
             return raw.decode("utf-8") if raw else ""
         finally:
             await redis_client.aclose()
@@ -382,7 +398,7 @@ class StreamingResponseEmitter(ResultEmitter):
     async def _redis_cleanup(self) -> None:
         if not self._shared_content_key:
             return
-        keys = [self._shared_content_key]
+        keys = [self._answer_key]
         keys.extend(
             key for key in (self._progress_state_key, self._display_lock_key) if key
         )
@@ -396,7 +412,7 @@ class StreamingResponseEmitter(ResultEmitter):
             logger.exception("[StreamingEmitter] Failed to clean shared card state")
 
     async def _may_update_display(self, force: bool) -> bool:
-        if force:
+        if force or self.MIN_UPDATE_INTERVAL <= 0:
             return True
         if self._display_lock_key:
             redis_client = await cache_manager._get_client()
@@ -410,7 +426,7 @@ class StreamingResponseEmitter(ResultEmitter):
                 return bool(allowed)
             finally:
                 await redis_client.aclose()
-        return time.time() - self._last_update_time >= self.MIN_UPDATE_INTERVAL
+        return time.monotonic() - self._last_update_time >= self.MIN_UPDATE_INTERVAL
 
     async def _write_card(self, content: str, *, force: bool = False) -> bool:
         if self._finished or not self._card.card_instance_id or not content:
@@ -418,8 +434,8 @@ class StreamingResponseEmitter(ResultEmitter):
         if not await self._may_update_display(force):
             return False
         try:
-            self._card.ai_streaming(content, append=False)
-            self._last_update_time = time.time()
+            await self._call_card("ai_streaming", content, append=False)
+            self._last_update_time = time.monotonic()
             return True
         except Exception:
             logger.exception("[StreamingEmitter] Failed to update AI card")
@@ -432,54 +448,232 @@ class StreamingResponseEmitter(ResultEmitter):
             return
         await self._write_card(self._progress.render(), force=force)
 
+    async def _initialize(self) -> bool:
+        if self._initialized:
+            return True
+        async with self._update_lock:
+            if not self._initialized:
+                if not await self._ensure_card_started():
+                    return False
+                await self._load_progress_state()
+                self._initialized = True
+        return True
+
+    def _schedule_update(self) -> None:
+        if self._flush_error is not None:
+            return
+        self._dirty = True
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = asyncio.create_task(self._run_updates())
+
+    @trace_async(span_name="dingtalk.flush_updates", tracer_name=__name__)
+    async def _run_updates(self) -> None:
+        try:
+            while self._dirty and not self._finishing:
+                delay = max(
+                    0,
+                    self.MIN_UPDATE_INTERVAL
+                    - (time.monotonic() - self._last_update_time),
+                )
+                if delay and not self._flush_now.is_set():
+                    try:
+                        await asyncio.wait_for(self._flush_now.wait(), timeout=delay)
+                    except asyncio.TimeoutError:
+                        pass
+                self._flush_now.clear()
+                if self._finishing:
+                    break
+                async with self._update_lock:
+                    async with self._shared_write():
+                        if not self._finished:
+                            await self._flush_pending()
+        except Exception as exc:
+            # A failed APPEND may already have reached Redis. Do not replay it or
+            # finalize from potentially incomplete content; DONE has the snapshot.
+            self._flush_error = exc
+            logger.exception("[StreamingEmitter] Failed to flush card update")
+        finally:
+            self._flush_task = None
+
+    async def flush(self) -> None:
+        """Wait for the latest coalesced display state to be persisted and sent."""
+        self._flush_now.set()
+        if self._flush_task is not None:
+            await asyncio.shield(self._flush_task)
+
+    async def _stop_updates(self) -> None:
+        """Drop pending displays and let an in-flight write finish before terminal."""
+        if self._closed and not self._finished:
+            raise RuntimeError("Cannot finish a closed DingTalk emitter")
+        self._finishing = True
+        await self.flush()
+        self._pending_progress.clear()
+        if not await self._initialize():
+            raise RuntimeError("Failed to initialize DingTalk card")
+
+    async def _flush_pending(self) -> None:
+        self._dirty = False
+        updates, self._pending_progress = self._pending_progress, []
+        content, self._pending_content = self._pending_content, ""
+        started = time.monotonic()
+        state = _CompactProgressState.from_dict(self._progress.to_dict())
+        if self._progress_state_key:
+            cached = await cache_manager.get(self._progress_state_key)
+            state = _CompactProgressState.from_dict(cached)
+            if state.mode == "progress":
+                for update in updates:
+                    update(state)
+        if content:
+            state.mode = "answer"
+        # Keep local projection current, including events received during the read.
+        self._progress = _CompactProgressState.from_dict(state.to_dict())
+        if self._progress.mode == "progress":
+            for update in self._pending_progress:
+                update(self._progress)
+        if self._pending_content:
+            self._progress.mode = "answer"
+        await self._save_progress_state(state.to_dict())
+        if self._shared_content_key:
+            if content:
+                await self._redis_append_answer(content)
+            if state.mode == "answer":
+                self._full_content = await self._redis_get_answer()
+        else:
+            self._full_content += content
+        logger.info(
+            "[StreamingEmitter] persist card=%s duration_ms=%.2f content_len=%d",
+            self.card_instance_id,
+            (time.monotonic() - started) * 1000,
+            len(content),
+        )
+        if not self._finishing:
+            display = (
+                self._truncate_final(self._full_content)
+                if state.mode == "answer"
+                else state.render()
+            )
+            await self._write_card(display)
+        # Also throttle batches when another worker owns the display interval.
+        self._last_update_time = time.monotonic()
+
     async def _update_progress(
         self, updater: Callable[[_CompactProgressState], None]
     ) -> None:
-        async with self._update_lock:
-            if self._finished or not await self._ensure_card_started():
-                return
-            await self._load_progress_state()
-            if self._progress.mode != "progress":
-                return
-            updater(self._progress)
-            await self._save_progress_state()
-            await self._render_current_mode()
+        if self._finished or self._finishing or self._closed:
+            return
+        if not await self._initialize() or self._progress.mode != "progress":
+            return
+        if self._finished or self._finishing or self._closed:
+            return
+        updater(self._progress)
+        self._pending_progress.append(updater)
+        self._schedule_update()
 
     async def _current_answer(self) -> str:
-        if self._shared_content_key:
-            return await self._redis_get_answer()
-        return f"{self._full_content}{self._pending_content}"
-
-    async def _send_answer_update(self, content: str) -> None:
-        if self._shared_content_key:
-            await self._redis_append_answer(content)
-            if not await self._may_update_display(False):
-                return
-            self._full_content = await self._redis_get_answer()
-        else:
-            self._pending_content += content
-            if not await self._may_update_display(False):
-                return
-            self._full_content += self._pending_content
-            self._pending_content = ""
-        await self._write_card_without_throttle(
-            self._truncate_final(self._full_content)
+        if self._flush_error is not None:
+            raise RuntimeError(
+                "Card persistence failed; authoritative result required"
+            ) from self._flush_error
+        content = (
+            await self._redis_get_answer()
+            if self._shared_content_key
+            else self._full_content
         )
+        return f"{content}{self._pending_content}"
 
-    async def _write_card_without_throttle(self, content: str) -> None:
-        if not content:
-            return
+    @trace_async(span_name="dingtalk.card_request", tracer_name=__name__)
+    async def _call_card(self, method: str, *args: Any, **kwargs: Any) -> None:
+        """Keep synchronous SDK I/O off the event loop and preserve write order."""
+        self._check_writer_lease()
+        started = time.monotonic()
+        call = asyncio.create_task(
+            asyncio.to_thread(getattr(self._card, method), *args, **kwargs)
+        )
+        cancelled = False
         try:
-            self._card.ai_streaming(content, append=False)
-            self._last_update_time = time.time()
-        except Exception:
-            logger.exception("[StreamingEmitter] Failed to stream answer")
+            while not call.done():
+                try:
+                    await asyncio.shield(call)
+                except asyncio.CancelledError:
+                    # Repeated cancellation still cannot stop the SDK thread.
+                    # Keep the lock until the actual network request has exited.
+                    cancelled = True
+            call.result()
+            if cancelled:
+                raise asyncio.CancelledError
+        finally:
+            logger.info(
+                "[StreamingEmitter] card_request method=%s card=%s duration_ms=%.2f",
+                method,
+                self.card_instance_id,
+                (time.monotonic() - started) * 1000,
+            )
 
-    def _truncate_final(self, content: str) -> str:
+    @property
+    def _terminal_key(self) -> str:
+        # A task may have multiple turns; scope terminal state to the actual card.
+        return f"{self._answer_key}:terminal"
+
+    def _check_writer_lease(self) -> None:
+        if self._lease_renewal is not None and self._lease_renewal.done():
+            self._lease_renewal.result()
+
+    @asynccontextmanager
+    async def _shared_write(self) -> AsyncIterator[None]:
+        """Serialize reconstructed workers and reject updates after completion."""
+        if not self._shared_content_key:
+            yield
+            return
+        client = await cache_manager._get_client()
+        try:
+            lock = client.lock(
+                f"{self._terminal_key}:writer", timeout=60, blocking_timeout=60
+            )
+            async with lock:
+                renewal = asyncio.create_task(self._renew_writer_lock(lock))
+                self._lease_renewal = renewal
+                try:
+                    if await client.get(self._terminal_key):
+                        self._finished = True
+                        self._dirty = False
+                    yield
+                    self._check_writer_lease()
+                finally:
+                    renewal.cancel()
+                    await asyncio.gather(renewal, return_exceptions=True)
+                    self._lease_renewal = None
+        finally:
+            await client.aclose()
+
+    async def _renew_writer_lock(self, lock: Any) -> None:
+        """Keep the lease while a synchronous SDK request is still in flight."""
+        try:
+            while True:
+                await asyncio.sleep(20)
+                await lock.extend(60, replace_ttl=True)
+        except Exception:
+            logger.exception("[StreamingEmitter] Failed to renew card writer lease")
+            raise
+
+    async def _mark_finished(self) -> None:
+        self._check_writer_lease()
+        if self._shared_content_key:
+            from app.services.channels.callback import CHANNEL_TASK_CALLBACK_TTL
+
+            saved = await cache_manager.set(
+                self._terminal_key, True, expire=CHANNEL_TASK_CALLBACK_TTL
+            )
+            if not saved:
+                raise RuntimeError("Failed to persist card terminal marker")
+        self._check_writer_lease()
+        self._finished = True
+
+    def _truncate_final(self, content: str, *, max_length: Optional[int] = None) -> str:
+        limit = self.MAX_FINAL_CONTENT_LENGTH if max_length is None else max_length
         suffix = self.FINAL_TRUNCATION_SUFFIX
-        if len(content) <= self.MAX_FINAL_CONTENT_LENGTH:
+        if len(content) <= limit:
             return content
-        return f"{content[: self.MAX_FINAL_CONTENT_LENGTH - len(suffix)]}{suffix}"
+        return f"{content[: limit - len(suffix)]}{suffix}"
 
     async def emit(self, event: ExecutionEvent) -> None:
         event_type = (
@@ -528,13 +722,18 @@ class StreamingResponseEmitter(ResultEmitter):
         **kwargs: Any,
     ) -> None:
         logger.info("[StreamingEmitter] start task=%s subtask=%s", task_id, subtask_id)
+        if self._finished or self._finishing or self._closed:
+            return
+        if not await self._initialize():
+            return
         async with self._update_lock:
-            if not await self._ensure_card_started():
-                return
-            await self._load_progress_state()
-            await self._save_progress_state()
-            if not self._reconnected:
-                await self._render_current_mode(force=True)
+            async with self._shared_write():
+                if self._finished or self._finishing or self._closed:
+                    return
+                await self._load_progress_state()
+                await self._save_progress_state()
+                if not self._reconnected:
+                    await self._render_current_mode(force=True)
 
     async def emit_thinking(
         self,
@@ -632,28 +831,35 @@ class StreamingResponseEmitter(ResultEmitter):
         offset: int,
         **kwargs: Any,
     ) -> None:
-        if not content:
+        if not content or self._finished or self._finishing or self._closed:
             return
-        async with self._update_lock:
-            if self._finished or not await self._ensure_card_started():
-                return
-            await self._load_progress_state()
-            self._progress.mode = "answer"
-            await self._save_progress_state()
-            await self._send_answer_update(content)
+        if not await self._initialize():
+            return
+        if self._finished or self._finishing or self._closed:
+            return
+        self._progress.mode = "answer"
+        self._pending_content += content
+        self._schedule_update()
 
     async def _final_content(self, result: Optional[dict]) -> str:
-        content = await self._current_answer()
         if isinstance(result, dict):
-            if result.get("silent_exit_reason") == "waiting_for_user_input":
-                return self._truncate_final(content or _WAITING_FOR_INPUT_CONTENT)
-            if result.get("value_origin") in {"process_fallback", "empty"}:
-                return self._truncate_final(content or _EMPTY_FINAL_CONTENT)
-            for field_name in ("value", "output"):
-                result_value = result.get(field_name)
-                if isinstance(result_value, str) and result_value:
-                    content = result_value
-                    break
+            authoritative = result.get(
+                "silent_exit_reason"
+            ) != "waiting_for_user_input" and result.get("value_origin") not in {
+                "process_fallback",
+                "empty",
+            }
+            if authoritative:
+                for field_name in ("value", "output"):
+                    value = result.get(field_name)
+                    if isinstance(value, str) and value:
+                        return self._truncate_final(value)
+        content = await self._current_answer()
+        if (
+            isinstance(result, dict)
+            and result.get("silent_exit_reason") == "waiting_for_user_input"
+        ):
+            return self._truncate_final(content or _WAITING_FOR_INPUT_CONTENT)
         return self._truncate_final(content or _EMPTY_FINAL_CONTENT)
 
     async def emit_done(
@@ -663,33 +869,34 @@ class StreamingResponseEmitter(ResultEmitter):
         result: Optional[dict] = None,
         **kwargs: Any,
     ) -> None:
-        async with self._update_lock:
+        await self._stop_updates()
+        async with self._update_lock, self._shared_write():
             if self._finished:
                 logger.warning("[StreamingEmitter] emit_done called after finish")
                 return
-            try:
-                if not await self._ensure_card_started():
-                    return
-                await self._load_progress_state()
-                self._progress.mode = "answer"
-                await self._save_progress_state()
-                final_content = await self._final_content(result)
-                self._pending_content = ""
-                self._full_content = final_content
-                logger.info(
-                    "[StreamingEmitter] done task=%s subtask=%s content_len=%s",
-                    task_id,
-                    subtask_id,
-                    len(final_content),
-                )
-                self._card.ai_streaming(final_content, append=False)
-                await asyncio.sleep(0.1)
-                self._card.ai_finish(final_content)
-                self._finished = True
-            except Exception:
-                logger.exception("[StreamingEmitter] Failed to finish AI card")
-            finally:
-                await self._redis_cleanup()
+            final_content = await self._final_content(result)
+            logger.info(
+                "[StreamingEmitter] done task=%s subtask=%s content_len=%s",
+                task_id,
+                subtask_id,
+                len(final_content),
+            )
+            await self._finish_card(final_content)
+
+    async def _finish_card(self, content: str, *, failed: bool = False) -> None:
+        """Only discard recovery state after terminal delivery and fencing succeed."""
+        await self._call_card("ai_streaming", content, append=False)
+        if failed:
+            await self._call_card("ai_fail")
+        else:
+            await asyncio.sleep(0.1)
+            await self._call_card("ai_finish", content)
+        await self._mark_finished()
+        self._progress.mode = "answer"
+        self._full_content = content
+        self._pending_content = ""
+        self._dirty = False
+        await self._redis_cleanup()
 
     async def emit_error(
         self,
@@ -698,7 +905,8 @@ class StreamingResponseEmitter(ResultEmitter):
         error: str,
         **kwargs: Any,
     ) -> None:
-        async with self._update_lock:
+        await self._stop_updates()
+        async with self._update_lock, self._shared_write():
             if self._finished:
                 return
             logger.warning(
@@ -707,29 +915,12 @@ class StreamingResponseEmitter(ResultEmitter):
                 subtask_id,
                 mask_string(error),
             )
-            try:
-                if await self._ensure_card_started():
-                    # ai_fail() alone only flips the card to FAILED and leaves the
-                    # body empty, which DingTalk renders as a blank card. Write the
-                    # error into the card body first so users can see why it failed.
-                    error_text = _compact_text(error, self.MAX_ERROR_CONTENT_LENGTH)
-                    content = (
-                        f"❌ 任务执行失败：{error_text}"
-                        if error_text
-                        else "❌ 任务执行失败"
-                    )
-                    try:
-                        self._card.ai_streaming(content, append=False)
-                    except Exception:
-                        logger.exception(
-                            "[StreamingEmitter] Failed to stream error content"
-                        )
-                    self._card.ai_fail()
-                    self._finished = True
-            except Exception:
-                logger.exception("[StreamingEmitter] Failed to mark AI card failed")
-            finally:
-                await self._redis_cleanup()
+            # ai_fail alone leaves a blank body; deliver the error text first.
+            error_text = _compact_text(error, self.MAX_ERROR_CONTENT_LENGTH)
+            content = (
+                f"❌ 任务执行失败：{error_text}" if error_text else "❌ 任务执行失败"
+            )
+            await self._finish_card(content, failed=True)
 
     async def emit_cancelled(
         self,
@@ -737,24 +928,28 @@ class StreamingResponseEmitter(ResultEmitter):
         subtask_id: int,
         **kwargs: Any,
     ) -> None:
-        async with self._update_lock:
+        await self._stop_updates()
+        async with self._update_lock, self._shared_write():
             if self._finished:
                 return
-            try:
-                if not await self._ensure_card_started():
-                    return
-                answer = (await self._current_answer()).rstrip()
-                content = f"{answer}\n\n⚠️ 任务已取消" if answer else "⚠️ 任务已取消"
-                content = self._truncate_final(content)
-                self._card.ai_streaming(content, append=False)
-                await asyncio.sleep(0.1)
-                self._card.ai_finish(content)
-                self._finished = True
-            except Exception:
-                logger.exception("[StreamingEmitter] Failed to cancel AI card")
-            finally:
-                await self._redis_cleanup()
+            answer = (await self._current_answer()).rstrip()
+            suffix = "\n\n⚠️ 任务已取消"
+            content = (
+                self._truncate_final(
+                    answer, max_length=self.MAX_FINAL_CONTENT_LENGTH - len(suffix)
+                )
+                + suffix
+                if answer
+                else suffix.strip()
+            )
+            await self._finish_card(content)
 
     async def close(self) -> None:
-        if self._shared_content_key and not self._finished:
-            await self._redis_cleanup()
+        self._closed = True
+        await self.flush()
+        # Terminal failure may leave buffered text. Persist it for reconstruction;
+        # closing a local worker must not delete another worker's recovery state.
+        if self._pending_content and not self._finished and self._flush_error is None:
+            async with self._update_lock, self._shared_write():
+                if not self._finished:
+                    await self._flush_pending()

--- a/backend/app/services/channels/dingtalk/handler.py
+++ b/backend/app/services/channels/dingtalk/handler.py
@@ -41,6 +41,8 @@ from app.services.execution.emitters import ResultEmitter
 from app.services.subscription.notification_service import (
     subscription_notification_service,
 )
+from shared.telemetry.context import request_context
+from shared.telemetry.decorators import trace_async
 
 if TYPE_CHECKING:
     from dingtalk_stream.stream import DingTalkStreamClient
@@ -379,6 +381,23 @@ class WegentChatbotHandler(dingtalk_stream.ChatbotHandler):
         Returns:
             Tuple of (status, message) for acknowledgment
         """
+        request_id = next(
+            (
+                value.strip()
+                for key, value in callback.headers.extensions.items()
+                if key.lower() == "x-request-id"
+                and isinstance(value, str)
+                and value.strip()
+            ),
+            None,
+        )
+        # Each callback is a request; the long-lived stream may carry a startup ID.
+        with request_context(request_id):
+            return await self._process_message(callback)
+
+    @trace_async(span_name="dingtalk.process_message", tracer_name=__name__)
+    async def _process_message(self, callback: CallbackMessage) -> tuple[str, str]:
+        """Handle the callback within its own request context."""
         try:
             # Parse the incoming message
             incoming_message = ChatbotMessage.from_dict(callback.data)

--- a/backend/app/services/channels/dingtalk/handler.py
+++ b/backend/app/services/channels/dingtalk/handler.py
@@ -387,6 +387,7 @@ class WegentChatbotHandler(dingtalk_stream.ChatbotHandler):
                 for key, value in callback.headers.extensions.items()
                 if key.lower() == "x-request-id"
                 and isinstance(value, str)
+                and value.isprintable()
                 and value.strip()
             ),
             None,

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -20,6 +20,7 @@ OpenAI Responses API compatible endpoint.
 import asyncio
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, Any, List, Optional
 
 from shared.telemetry.decorators import (
@@ -1278,6 +1279,12 @@ class ExecutionDispatcher:
         metadata = openai_request.get("metadata", {})
         request_id, request_id_source = self._resolve_request_id(request, metadata)
         metadata["request_id"] = request_id
+        from shared.telemetry.context.propagation import (
+            get_trace_context_for_propagation,
+        )
+        from shared.telemetry.context.span import set_request_context
+
+        set_request_context(request_id)
         openai_request["metadata"] = metadata
 
         # Get tools from openai_request (includes MCP servers converted to tools)
@@ -1305,6 +1312,8 @@ class ExecutionDispatcher:
             },
         )
         event_count = 0
+        emit_total_ms = 0.0
+        emit_max_ms = 0.0
         cancelled = False
         cancel_source = ""
         terminal_event_type = ""
@@ -1326,6 +1335,10 @@ class ExecutionDispatcher:
                     instructions=openai_request.get("instructions"),
                     tools=tools if tools else None,
                     stream=True,
+                    extra_headers={
+                        **get_trace_context_for_propagation(),
+                        "X-Request-ID": request_id,
+                    },
                     extra_body={
                         "metadata": openai_request.get("metadata", {}),
                         "model_config": openai_request.get("model_config", {}),
@@ -1378,6 +1391,7 @@ class ExecutionDispatcher:
 
                     async def consume_stream() -> None:
                         nonlocal event_count, terminal_event_type
+                        nonlocal emit_total_ms, emit_max_ms
                         add_span_event(
                             "sse.openai_event_iteration_start",
                             {
@@ -1443,7 +1457,15 @@ class ExecutionDispatcher:
                                     event_type,
                                     parsed_event.type,
                                 )
-                                await emitter.emit(parsed_event)
+                                emit_started = time.perf_counter()
+                                try:
+                                    await emitter.emit(parsed_event)
+                                finally:
+                                    emit_ms = (
+                                        time.perf_counter() - emit_started
+                                    ) * 1000
+                                    emit_total_ms += emit_ms
+                                    emit_max_ms = max(emit_max_ms, emit_ms)
 
                             if event_type in (
                                 ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value,
@@ -1538,7 +1560,8 @@ class ExecutionDispatcher:
             logger.info(
                 "[ExecutionDispatcher] SSE stream completed: task_id=%d, "
                 "subtask_id=%d, total_events=%d, cancelled=%s, "
-                "cancel_source=%s, terminal_event_type=%s, request_id=%s",
+                "cancel_source=%s, terminal_event_type=%s, request_id=%s, "
+                "emit_total_ms=%.2f, emit_max_ms=%.2f",
                 request.task_id,
                 request.subtask_id,
                 event_count,
@@ -1546,6 +1569,8 @@ class ExecutionDispatcher:
                 cancel_source or "none",
                 terminal_event_type or "none",
                 request_id,
+                emit_total_ms,
+                emit_max_ms,
             )
             add_span_event(
                 "sse.openai_event_iteration_complete",

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -1239,8 +1239,34 @@ class ExecutionDispatcher:
             await self._dispatch_image_generation(request, emitter)
             return
 
-        # Default: route to chat_shell via OpenAI client
+        from shared.telemetry.context import request_context
+
+        openai_request = OpenAIRequestConverter.from_execution_request(request)
+        metadata = openai_request.get("metadata", {})
+        request_id, request_id_source = self._resolve_request_id(request, metadata)
+        metadata["request_id"] = request_id
+        openai_request["metadata"] = metadata
+
+        with request_context(request_id):
+            await self._dispatch_chat_shell_sse(
+                request, target, emitter, openai_request, request_id_source
+            )
+
+    async def _dispatch_chat_shell_sse(
+        self,
+        request: ExecutionRequest,
+        target: ExecutionTarget,
+        emitter: ResultEmitter,
+        openai_request: dict[str, Any],
+        request_id_source: str,
+    ) -> None:
+        """Stream a Chat Shell response within the caller's scoped request context."""
         from app.services.chat.storage.session import session_manager
+        from shared.telemetry.context.propagation import (
+            get_trace_context_for_propagation,
+        )
+
+        request_id = openai_request["metadata"]["request_id"]
 
         # OpenAI client appends /responses to base_url, so we need to include /v1
         # e.g., base_url=http://127.0.0.1:8100/v1 -> POST http://127.0.0.1:8100/v1/responses
@@ -1270,22 +1296,6 @@ class ExecutionDispatcher:
             api_key="dummy",  # Not used by chat_shell but required by client
             timeout=300.0,
         )
-
-        # Convert ExecutionRequest to OpenAI format
-        openai_request = OpenAIRequestConverter.from_execution_request(request)
-
-        # Ensure request_id is set in metadata for backend -> chat_shell correlation.
-        # Preserve existing request_id if provided by upstream backend request context.
-        metadata = openai_request.get("metadata", {})
-        request_id, request_id_source = self._resolve_request_id(request, metadata)
-        metadata["request_id"] = request_id
-        from shared.telemetry.context.propagation import (
-            get_trace_context_for_propagation,
-        )
-        from shared.telemetry.context.span import set_request_context
-
-        set_request_context(request_id)
-        openai_request["metadata"] = metadata
 
         # Get tools from openai_request (includes MCP servers converted to tools)
         tools = openai_request.get("tools", [])

--- a/backend/tests/e2e/dingtalk_ai_card_conversation.py
+++ b/backend/tests/e2e/dingtalk_ai_card_conversation.py
@@ -35,6 +35,7 @@ from app.services.channels.device_selection import (
     DeviceType,
     device_selection_manager,
 )
+from app.services.channels.dingtalk import card as card_module
 from app.services.channels.dingtalk.callback import dingtalk_callback_service
 from app.services.channels.dingtalk.handler import DingTalkChannelHandler
 from app.services.channels.handler import CHANNEL_CONV_TASK_PREFIX, MessageContext
@@ -181,6 +182,9 @@ class DingTalkConversationHarness(DingTalkChannelHandler):
             ),
             source="DingTalk CI E2E private-thinking probe",
         )
+        # Verify the progress stage before completion intentionally supersedes it.
+        active_emitter = dingtalk_callback_service._active_emitters[callback_key]
+        await active_emitter.flush()
         await self._forward_runtime_event(
             local_task_id,
             "response.completed",
@@ -334,9 +338,9 @@ async def run() -> None:
         previous_device_selection_ttl = await cache_client.ttl(device_selection_key)
     finally:
         await cache_client.aclose()
-    original_card_class = dingtalk_stream.AIMarkdownCardInstance
+    original_card_class = card_module.DingTalkMarkdownCard
     original_get_channel_manager = channel_manager_module.get_channel_manager
-    dingtalk_stream.AIMarkdownCardInstance = FakeAICardInstance
+    card_module.DingTalkMarkdownCard = FakeAICardInstance
     channel_manager_module.get_channel_manager = lambda: SimpleNamespace(
         get_channel=lambda channel_id: (
             SimpleNamespace(_client=handler._dingtalk_client)
@@ -385,7 +389,7 @@ async def run() -> None:
             WAITING_STATUS
         ]
     finally:
-        dingtalk_stream.AIMarkdownCardInstance = original_card_class
+        card_module.DingTalkMarkdownCard = original_card_class
         channel_manager_module.get_channel_manager = original_get_channel_manager
         await _cleanup(
             user_id=user_id,

--- a/backend/tests/services/channels/dingtalk/test_card_delivery.py
+++ b/backend/tests/services/channels/dingtalk/test_card_delivery.py
@@ -1,0 +1,66 @@
+"""Exercise actual SDK card transitions with mocked HTTP responses."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import requests
+from dingtalk_stream.card_replier import AICardStatus
+
+from app.services.channels.dingtalk.emitter import StreamingResponseEmitter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["http_429", "http_500", "timeout", "token"])
+async def test_sdk_delivery_failure_reaches_the_caller(monkeypatch, failure):
+    def put(*args, **kwargs):
+        if failure == "timeout":
+            raise requests.ReadTimeout("card update timed out")
+        response = requests.Response()
+        response.status_code = 429 if failure == "http_429" else 500
+        response._content = b"{}"
+        response._content_consumed = True
+        return response
+
+    monkeypatch.setattr(requests, "put", put)
+    client = SimpleNamespace(
+        get_access_token=Mock(return_value=None if failure == "token" else "test-token")
+    )
+    emitter = StreamingResponseEmitter(
+        client, SimpleNamespace(hosting_context=None), "card-1"
+    )
+
+    with pytest.raises((requests.RequestException, RuntimeError)):
+        await emitter.emit_done(1, 2, {"value": "final"})
+    assert not emitter._finished
+    await emitter.close()
+
+
+@pytest.mark.asyncio
+async def test_sdk_updates_have_timeout_and_keep_full_final_payload(monkeypatch):
+    calls = []
+
+    def put(url, **kwargs):
+        calls.append((url, kwargs))
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b"{}"
+        response._content_consumed = True
+        return response
+
+    monkeypatch.setattr(requests, "put", put)
+    emitter = StreamingResponseEmitter(
+        SimpleNamespace(get_access_token=lambda: "test-token"),
+        SimpleNamespace(hosting_context=None),
+        "card-1",
+    )
+    await emitter.emit_done(1, 2, {"value": "final"})
+
+    assert emitter._finished
+    assert all(call[1].get("timeout") == (5, 10) for call in calls)
+    stream = next(kwargs["json"] for url, kwargs in calls if url.endswith("/streaming"))
+    assert stream["isFull"] is True
+    assert stream["content"] == "final"
+    final = calls[-1][1]["json"]["cardData"]["cardParamMap"]
+    assert final["msgContent"] == "final"
+    assert final["flowStatus"] == AICardStatus.FINISHED

--- a/backend/tests/services/channels/dingtalk/test_emitter.py
+++ b/backend/tests/services/channels/dingtalk/test_emitter.py
@@ -4,11 +4,12 @@
 
 """Unit tests for compact DingTalk AI Card progress."""
 
+import asyncio
 from unittest.mock import AsyncMock
 
-import dingtalk_stream
 import pytest
 
+from app.services.channels.dingtalk import card as card_module
 from app.services.channels.dingtalk import emitter as emitter_module
 from app.services.channels.dingtalk.emitter import StreamingResponseEmitter
 from shared.models import EventType, ExecutionEvent
@@ -43,6 +44,9 @@ class FakeRedis:
     def __init__(self, cache):
         self.cache = cache
 
+    def lock(self, key, **kwargs):
+        return self.cache.locks.setdefault(key, asyncio.Lock())
+
     async def append(self, key, value):
         self.cache.raw[key] = self.cache.raw.get(key, b"") + value
 
@@ -50,7 +54,7 @@ class FakeRedis:
         return True
 
     async def get(self, key):
-        return self.cache.raw.get(key)
+        return self.cache.raw.get(key) or self.cache.structured.get(key)
 
     async def set(self, key, value, nx=False, px=None):
         if nx and key in self.cache.raw:
@@ -73,6 +77,7 @@ class FakeRedis:
 class FakeCache:
     def __init__(self):
         self.raw: dict[str, bytes] = {}
+        self.locks: dict[str, asyncio.Lock] = {}
         self.structured: dict[str, object] = {}
 
     async def _get_client(self):
@@ -99,7 +104,7 @@ def card_factory(monkeypatch: pytest.MonkeyPatch):
         cards.append(card)
         return card
 
-    monkeypatch.setattr(dingtalk_stream, "AIMarkdownCardInstance", create_card)
+    monkeypatch.setattr(card_module, "DingTalkMarkdownCard", create_card)
     return cards
 
 
@@ -121,6 +126,7 @@ async def test_start_and_thinking_render_safe_compact_status(emitter, card_facto
             content="private chain of thought that must not leave Wework",
         )
     )
+    await emitter.flush()
 
     card = card_factory[0]
     assert "正在理解需求" in card.updates[0]
@@ -141,6 +147,7 @@ async def test_reasoning_summary_updates_live_compact_status(emitter, card_facto
                 data={"thinking_kind": "reasoning_summary"},
             )
         )
+        await emitter.flush()
 
     card = card_factory[0]
     assert "正在分析：正在检查" in card.updates[-2]
@@ -168,6 +175,7 @@ async def test_reconnected_card_projects_first_progress_event_without_throttling
             data={"thinking_kind": "reasoning_summary"},
         )
     )
+    await emitter.flush()
 
     assert card_factory[0].updates
     assert "正在检查跨 worker 状态" in card_factory[0].updates[-1]
@@ -181,7 +189,9 @@ async def test_dispatch_status_stays_in_progress_mode(emitter, card_factory):
         subtask_id=2,
         content="任务已发送到设备 device-1\n\n状态: 正在执行",
     )
+    await emitter.flush()
     await emitter.emit_thinking(task_id=1, subtask_id=2)
+    await emitter.flush()
 
     card = card_factory[0]
     assert "任务已发送到设备 device-1 状态: 正在执行" in card.updates[-2]
@@ -203,6 +213,7 @@ async def test_progress_window_is_bounded_and_omits_tool_payloads(
             tool_input={"path": "/secret/input"},
         )
     )
+    await emitter.flush()
     await emitter.emit(
         ExecutionEvent.create(
             EventType.TOOL_RESULT,
@@ -213,6 +224,7 @@ async def test_progress_window_is_bounded_and_omits_tool_payloads(
             data={"status": "completed"},
         )
     )
+    await emitter.flush()
     for index in range(3):
         await emitter.emit(
             ExecutionEvent.create(
@@ -230,6 +242,7 @@ async def test_progress_window_is_bounded_and_omits_tool_payloads(
                 },
             )
         )
+        await emitter.flush()
 
     rendered = card_factory[0].updates[-1]
     assert rendered.splitlines() == [
@@ -264,6 +277,7 @@ async def test_reasoning_block_is_generic_and_process_text_masks_secrets(
             },
         )
     )
+    await emitter.flush()
     await emitter.emit(
         ExecutionEvent.create(
             EventType.BLOCK_CREATED,
@@ -279,6 +293,7 @@ async def test_reasoning_block_is_generic_and_process_text_masks_secrets(
             },
         )
     )
+    await emitter.flush()
 
     all_updates = "".join(card_factory[0].updates)
     assert "raw private reasoning" not in all_updates
@@ -307,6 +322,7 @@ async def test_block_update_reuses_tool_name_without_exposing_output(
             },
         )
     )
+    await emitter.flush()
     await emitter.emit(
         ExecutionEvent.create(
             EventType.BLOCK_UPDATED,
@@ -321,6 +337,7 @@ async def test_block_update_reuses_tool_name_without_exposing_output(
             },
         )
     )
+    await emitter.flush()
 
     rendered = card_factory[0].updates[-1]
     assert "工具完成：Bash" in rendered
@@ -347,6 +364,7 @@ async def test_interactive_block_points_user_back_to_wework(emitter, card_factor
             },
         )
     )
+    await emitter.flush()
 
     rendered = card_factory[0].updates[-1]
     assert "等待你在 Wework 中确认" in rendered
@@ -376,7 +394,9 @@ async def test_answer_stream_and_terminal_result_replace_progress(
 ):
     await emitter.emit_start(task_id=1, subtask_id=2)
     await emitter.emit_thinking(task_id=1, subtask_id=2)
+    await emitter.flush()
     await emitter.emit_chunk(task_id=1, subtask_id=2, content="部分回答", offset=4)
+    await emitter.flush()
 
     card = card_factory[0]
     assert card.updates[-1] == "部分回答"
@@ -405,6 +425,7 @@ async def test_process_fallback_is_not_rendered_as_final_answer(emitter, card_fa
             data={"thinking_kind": "reasoning_summary"},
         )
     )
+    await emitter.flush()
 
     await emitter.emit_done(
         task_id=1,
@@ -458,6 +479,7 @@ async def test_structured_terminal_output_does_not_replace_streamed_answer(
 ):
     await emitter.emit_start(task_id=1, subtask_id=2)
     await emitter.emit_chunk(task_id=1, subtask_id=2, content="最终回答", offset=4)
+    await emitter.flush()
     await emitter.emit_done(
         task_id=1,
         subtask_id=2,
@@ -489,6 +511,7 @@ async def test_shared_progress_survives_worker_reconstruction_and_cleans_up(
             data={"status": "completed"},
         )
     )
+    await first.flush()
 
     second = StreamingResponseEmitter(
         object(),
@@ -513,8 +536,9 @@ async def test_shared_progress_survives_worker_reconstruction_and_cleans_up(
             },
         )
     )
+    await second.flush()
 
-    state_key = "channel:streaming_content:task-1:progress"
+    state_key = "channel:streaming_content:task-1:card-1:progress"
     assert cache.structured[state_key]["recent"] == [
         "工具完成：Read",
         "检查完成",
@@ -526,7 +550,7 @@ async def test_shared_progress_survives_worker_reconstruction_and_cleans_up(
         result={"value": "完成"},
     )
     assert state_key not in cache.structured
-    assert "channel:streaming_content:task-1" not in cache.raw
+    assert "channel:streaming_content:task-1:card-1" not in cache.raw
 
 
 @pytest.mark.asyncio
@@ -549,6 +573,7 @@ async def test_display_throttle_does_not_drop_shared_progress(
             data={"status": "completed"},
         )
     )
+    await emitter.flush()
 
-    state = cache.structured["channel:streaming_content:task-2:progress"]
+    state = cache.structured["channel:streaming_content:task-2:card-1:progress"]
     assert state["recent"] == ["工具完成：Read"]

--- a/backend/tests/services/channels/dingtalk/test_emitter_lifecycle.py
+++ b/backend/tests/services/channels/dingtalk/test_emitter_lifecycle.py
@@ -7,9 +7,40 @@ import pytest
 
 from app.services.channels.dingtalk import emitter as emitter_module
 from app.services.channels.dingtalk.emitter import StreamingResponseEmitter
+from shared.models import EventType, ExecutionEvent
 from tests.services.channels.dingtalk.test_emitter import FakeCache, card_factory
 from tests.services.channels.dingtalk.test_streaming_backpressure import block_update
 from tests.services.channels.test_terminal_result_delivery import FakeCallbackService
+
+
+@pytest.mark.asyncio
+async def test_missing_shared_progress_preserves_local_projection(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object(), "card-1")
+    emitter.set_shared_content_key("shared-card")
+    emitter.MIN_UPDATE_INTERVAL = 0
+    await emitter.emit_start(1, 2)
+    await emitter.emit(
+        ExecutionEvent.create(
+            EventType.TOOL_RESULT,
+            task_id=1,
+            subtask_id=2,
+            tool_name="Read",
+            data={"status": "completed"},
+        )
+    )
+    await emitter.flush()
+    del cache.structured[emitter._progress_state_key]
+    await emitter.emit_thinking(1, 2, "检查配置", is_reasoning_summary=True)
+    await emitter.flush()
+
+    state = cache.structured[emitter._progress_state_key]
+    assert state["recent"] == ["工具完成：Read"]
+    assert card_factory[0].updates[-1].count("检查配置") == 1
+    await emitter.close()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/channels/dingtalk/test_emitter_lifecycle.py
+++ b/backend/tests/services/channels/dingtalk/test_emitter_lifecycle.py
@@ -1,0 +1,258 @@
+"""Boundary tests for buffered card updates and terminal delivery."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.services.channels.dingtalk import emitter as emitter_module
+from app.services.channels.dingtalk.emitter import StreamingResponseEmitter
+from tests.services.channels.dingtalk.test_emitter import FakeCache, card_factory
+from tests.services.channels.dingtalk.test_streaming_backpressure import block_update
+from tests.services.channels.test_terminal_result_delivery import FakeCallbackService
+
+
+@pytest.mark.asyncio
+async def test_cancellation_remains_visible_when_answer_is_truncated(card_factory):
+    emitter = StreamingResponseEmitter(object(), object())
+    emitter.MIN_UPDATE_INTERVAL = 3600
+    await emitter.emit_start(1, 2)
+    await emitter.emit_chunk(1, 2, "长文本" * 2000, 0)
+    await emitter.emit_cancelled(1, 2)
+    content = card_factory[0].finished[0]
+    assert len(content) <= emitter.MAX_FINAL_CONTENT_LENGTH
+    assert content.endswith("⚠️ 任务已取消")
+    assert emitter.FINAL_TRUNCATION_SUFFIX in content
+
+
+@pytest.mark.asyncio
+async def test_callback_keeps_registration_and_recoverable_state_on_failure(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    monkeypatch.setattr("app.services.channels.callback.cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object(), "card-1")
+    emitter.set_shared_content_key("channel:streaming_content:1")
+    emitter.MIN_UPDATE_INTERVAL = 3600
+    await emitter.emit_start(1, 2)
+    await emitter.emit_chunk(1, 2, "buffered", 0)
+    card_factory[0].ai_finish = Mock(side_effect=RuntimeError("delivery failed"))
+    service = FakeCallbackService(emitter)
+    service._active_emitters[1] = emitter
+    service.get_callback_info = AsyncMock(return_value=object())
+    service.delete_callback_info = AsyncMock()
+
+    sent = await service.send_task_result(1, 2, content="")
+
+    assert sent is False
+    service.delete_callback_info.assert_not_awaited()
+    assert emitter._closed
+    assert cache.raw["channel:streaming_content:1:card-1"] == b"buffered"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event", ["chunk", "thinking"])
+async def test_close_rejects_event_that_was_waiting_for_initialization(
+    card_factory, event
+):
+    emitter = StreamingResponseEmitter(object(), object())
+    await emitter.emit_start(1, 2)
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def initialize():
+        entered.set()
+        await release.wait()
+        return True
+
+    emitter._initialize = initialize
+    emit = (
+        emitter.emit_chunk(1, 2, "late", 0)
+        if event == "chunk"
+        else emitter.emit_thinking(1, 2)
+    )
+    pending = asyncio.create_task(emit)
+    await entered.wait()
+    await emitter.close()
+    release.set()
+    await pending
+    assert emitter._pending_content == ""
+    assert emitter._pending_progress == []
+    assert emitter._flush_task is None
+
+
+@pytest.mark.asyncio
+async def test_failed_terminal_preserves_answer_for_retry(monkeypatch, card_factory):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object())
+    emitter.set_shared_content_key("shared-card")
+    emitter.MIN_UPDATE_INTERVAL = 3600
+    await emitter.emit_start(1, 2)
+    await emitter.emit_chunk(1, 2, "buffered", 0)
+    card = card_factory[0]
+    finish = card.ai_finish
+    card.ai_finish = Mock(side_effect=RuntimeError("delivery failed"))
+
+    with pytest.raises(RuntimeError, match="delivery failed"):
+        await emitter.emit_done(1, 2)
+    assert not emitter._finished
+    assert await emitter._current_answer() == "buffered"
+    assert await cache.get(emitter._progress_state_key) is not None
+
+    card.ai_finish = finish
+    await emitter.emit_done(1, 2)
+    assert card.finished == ["buffered"]
+
+
+@pytest.mark.asyncio
+async def test_close_preserves_flushed_state_for_reconstructed_worker(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    first = StreamingResponseEmitter(object(), object(), "card-1")
+    first.set_shared_content_key("shared-card")
+    await first.emit_start(1, 2)
+    await first.emit_chunk(1, 2, "kept for recovery", 0)
+    await first.close()
+
+    second = StreamingResponseEmitter(object(), object(), "card-1")
+    second.set_shared_content_key("shared-card")
+    await second.emit_done(1, 2)
+    assert card_factory[1].finished == ["kept for recovery"]
+
+
+@pytest.mark.asyncio
+async def test_old_card_completion_does_not_clear_next_turn_state(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    first = StreamingResponseEmitter(object(), object(), "card-1")
+    second = StreamingResponseEmitter(object(), object(), "card-2")
+    for worker in (first, second):
+        worker.set_shared_content_key("same-task")
+        await worker.emit_start(1, 2)
+    await second.emit_chunk(1, 3, "next turn", 0)
+    await second.flush()
+    await first.emit_done(1, 2, {"value": "old turn"})
+    await second.emit_done(1, 3)
+    assert card_factory[1].finished == ["next turn"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_marker_failure_is_not_reported_as_success(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object(), "card-1")
+    emitter.set_shared_content_key("shared-card")
+    await emitter.emit_start(1, 2)
+    cache.set = AsyncMock(return_value=False)
+    with pytest.raises(RuntimeError, match="terminal"):
+        await emitter.emit_done(1, 2, {"value": "final"})
+    assert not emitter._finished
+    assert await cache.get(emitter._progress_state_key) is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("persisted", [False, True])
+async def test_ambiguous_persistence_requires_authoritative_completion(
+    monkeypatch, card_factory, persisted
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object(), "card-1")
+    emitter.set_shared_content_key("shared-card")
+    await emitter.emit_start(1, 2)
+    append = emitter._redis_append_answer
+
+    async def fail(content):
+        if persisted:
+            await append(content)
+        raise TimeoutError("ambiguous Redis write")
+
+    emitter._redis_append_answer = fail
+    await emitter.emit_chunk(1, 2, "partial", 0)
+    await emitter.flush()
+    with pytest.raises(RuntimeError, match="persist"):
+        await emitter.emit_done(1, 2)
+    assert card_factory[0].finished == []
+    await emitter.emit_done(1, 2, {"value": "authoritative answer"})
+    assert card_factory[0].finished == ["authoritative answer"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_keeps_lock_until_sdk_request_finishes(
+    card_factory,
+):
+    emitter = StreamingResponseEmitter(object(), object())
+    await emitter.emit_start(1, 2)
+    card = card_factory[0]
+    started, release = block_update(card, asyncio.get_running_loop(), "in flight")
+
+    async def write():
+        async with emitter._update_lock:
+            await emitter._call_card("ai_streaming", "in flight", append=False)
+
+    pending = asyncio.create_task(write())
+    terminal = None
+    try:
+        await asyncio.wait_for(started.wait(), 1)
+        pending.cancel()
+        await asyncio.sleep(0)
+        pending.cancel()
+        await asyncio.sleep(0)
+        assert not pending.done()
+        terminal = asyncio.create_task(emitter.emit_done(1, 2, {"value": "final"}))
+        await asyncio.sleep(0)
+        assert not terminal.done()
+        release.set()
+        results = await asyncio.gather(pending, terminal, return_exceptions=True)
+        assert isinstance(results[0], asyncio.CancelledError)
+        assert results[1] is None
+        assert card.updates[1:] == ["in flight", "final"]
+    finally:
+        release.set()
+        await asyncio.gather(
+            *(task for task in (pending, terminal) if task), return_exceptions=True
+        )
+        await emitter.close()
+
+
+@pytest.mark.asyncio
+async def test_lost_writer_lease_stops_remaining_terminal_requests(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object(), "card-1")
+    emitter.set_shared_content_key("shared-card")
+    await emitter.emit_start(1, 2)
+    lost, renewal_failed = asyncio.Event(), asyncio.Event()
+
+    async def renew(_lock):
+        await lost.wait()
+        renewal_failed.set()
+        raise RuntimeError("writer lease lost")
+
+    emitter._renew_writer_lock = renew
+    card = card_factory[0]
+    started, release = block_update(card, asyncio.get_running_loop(), "final")
+    terminal = asyncio.create_task(emitter.emit_done(1, 2, {"value": "final"}))
+    try:
+        await asyncio.wait_for(started.wait(), 1)
+        lost.set()
+        await renewal_failed.wait()
+        release.set()
+        with pytest.raises(RuntimeError, match="writer lease lost"):
+            await terminal
+        assert card.finished == []
+        assert not emitter._finished
+        assert await cache.get(emitter._terminal_key) is None
+    finally:
+        release.set()
+        await asyncio.gather(terminal, return_exceptions=True)
+        await emitter.close()

--- a/backend/tests/services/channels/dingtalk/test_handler_request_id.py
+++ b/backend/tests/services/channels/dingtalk/test_handler_request_id.py
@@ -91,6 +91,24 @@ async def test_ingress_logs_and_outbound_request_share_id(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "unsafe_id",
+    ["req\ninjected", "req\rinjected", "req\tinjected", "req\x00", "req\x7f"],
+)
+async def test_callback_rejects_request_ids_with_control_characters(unsafe_id):
+    observed = []
+
+    async def receive(context):
+        observed.append(span.get_request_id())
+
+    handler = WegentChatbotHandler(on_message=receive)
+    result = await handler.process(_callback(headers={"X-Request-ID": unsafe_id}))
+
+    assert result == (AckMessage.STATUS_OK, "OK")
+    assert re.fullmatch(r"[0-9a-f]{8}", observed[0])
+
+
+@pytest.mark.asyncio
 async def test_generated_id_reaches_execution_request(monkeypatch):
     from app.services.chat.trigger import unified
     from shared.models import ExecutionRequest

--- a/backend/tests/services/channels/dingtalk/test_handler_request_id.py
+++ b/backend/tests/services/channels/dingtalk/test_handler_request_id.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request correlation starts at the DingTalk Stream callback boundary."""
+
+import asyncio
+import logging
+import re
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from dingtalk_stream import AckMessage, CallbackMessage
+
+from app.core.logging import RequestIdFilter
+from app.services.channels.dingtalk.handler import WegentChatbotHandler
+from shared.telemetry.context import span
+from shared.utils.http_client import traced_async_client
+
+
+@pytest.fixture(autouse=True)
+def isolated_request_context(monkeypatch, caplog):
+    token = span._request_id_var.set(None)
+    request_filter = RequestIdFilter()
+    caplog.handler.addFilter(request_filter)
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        "app.services.channels.dingtalk.handler.cache_manager.setnx",
+        AsyncMock(return_value=True),
+    )
+    try:
+        yield
+    finally:
+        caplog.handler.removeFilter(request_filter)
+        span._request_id_var.reset(token)
+
+
+def _callback(message_id: str = "message-1", headers=None) -> CallbackMessage:
+    callback = CallbackMessage()
+    callback.headers.extensions = headers or {}
+    callback.data = {
+        "msgId": message_id,
+        "msgtype": "text",
+        "text": {"content": "hello"},
+        "senderNick": "Alice",
+    }
+    return callback
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("custom_callback", [False, True])
+@pytest.mark.parametrize("incoming_id", [None, "upstream-request-1"])
+async def test_ingress_logs_and_outbound_request_share_id(
+    custom_callback, incoming_id, monkeypatch, caplog
+):
+    observed = {}
+
+    async def receive(*args):
+        observed["id"] = span.get_request_id()
+        observed["thread_id"] = await asyncio.to_thread(span.get_request_id)
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            observed["header"] = request.headers["X-Request-ID"]
+            return httpx.Response(200)
+
+        async with traced_async_client(
+            transport=httpx.MockTransport(respond)
+        ) as client:
+            await client.get("http://backend/api/internal/chat/history/task-1")
+
+    handler = WegentChatbotHandler(on_message=receive if custom_callback else None)
+    if not custom_callback:
+        monkeypatch.setattr(handler, "_process_with_channel_handler", receive)
+    headers = {"x-ReQuEsT-Id": f" {incoming_id} "} if incoming_id else {}
+
+    # Stream tasks can inherit the request that started the channel.
+    span.set_request_context("channel-start-request")
+    result = await handler.process(_callback(headers=headers))
+
+    assert result == (AckMessage.STATUS_OK, "OK")
+    request_id = observed["id"]
+    if incoming_id:
+        assert request_id == incoming_id
+    else:
+        assert re.fullmatch(r"[0-9a-f]{8}", request_id)
+    assert observed["header"] == observed["thread_id"] == request_id
+    received = next(r for r in caplog.records if "Received message:" in r.getMessage())
+    assert received.request_id == request_id
+    assert span.get_request_id() == "channel-start-request"
+
+
+@pytest.mark.asyncio
+async def test_generated_id_reaches_execution_request(monkeypatch):
+    from app.services.chat.trigger import unified
+    from shared.models import ExecutionRequest
+
+    builder = MagicMock()
+    builder.build.return_value = ExecutionRequest(task_id=1, subtask_id=2)
+    monkeypatch.setattr(unified, "SessionLocal", MagicMock())
+    monkeypatch.setattr("app.services.execution.TaskRequestBuilder", lambda db: builder)
+    observed = {}
+
+    async def receive(context):
+        observed["id"] = span.get_request_id()
+        observed["request"] = await unified.build_execution_request(
+            task=MagicMock(id=1, json={}),
+            assistant_subtask=MagicMock(id=2),
+            team=MagicMock(),
+            user=MagicMock(id=7),
+            message=context["content"],
+        )
+
+    result = await WegentChatbotHandler(on_message=receive).process(_callback())
+
+    assert result == (AckMessage.STATUS_OK, "OK")
+    assert observed["request"].request_id == observed["id"]
+    assert observed["id"] != "req_2"
+    assert span.get_request_id() is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_and_sequential_messages_have_independent_ids():
+    observed = {}
+    ready = asyncio.Event()
+
+    async def receive(context):
+        message_id = context["callback_data"]["msgId"]
+        request_id = span.get_request_id()
+        observed[message_id] = request_id
+        if len(observed) >= 2:
+            ready.set()
+        await ready.wait()
+        assert span.get_request_id() == request_id
+
+    handler = WegentChatbotHandler(on_message=receive)
+    await asyncio.wait_for(
+        asyncio.gather(
+            handler.process(_callback("a")), handler.process(_callback("b"))
+        ),
+        timeout=2,
+    )
+    await handler.process(_callback("c", {"X-Request-ID": " "}))
+
+    assert len(set(observed.values())) == 3
+    assert all(re.fullmatch(r"[0-9a-f]{8}", value) for value in observed.values())
+    assert span.get_request_id() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["duplicate", "error", "parse_error", "cancel"])
+async def test_context_is_restored_on_early_exit(outcome, monkeypatch, caplog):
+    callback = _callback(headers={"X-Request-ID": "message-request"})
+    handler = WegentChatbotHandler(on_message=AsyncMock())
+    if outcome == "duplicate":
+        monkeypatch.setattr(
+            "app.services.channels.dingtalk.handler.cache_manager.setnx",
+            AsyncMock(return_value=False),
+        )
+    elif outcome == "parse_error":
+        callback.data = None
+    else:
+        handler._on_message.side_effect = (
+            asyncio.CancelledError() if outcome == "cancel" else RuntimeError("failed")
+        )
+
+    if outcome == "cancel":
+        with pytest.raises(asyncio.CancelledError):
+            await handler.process(callback)
+    else:
+        result = await handler.process(callback)
+        expected = (
+            AckMessage.STATUS_OK
+            if outcome == "duplicate"
+            else AckMessage.STATUS_SYSTEM_EXCEPTION
+        )
+        assert result[0] == expected
+    records = [r for r in caplog.records if "[DingTalkHandler]" in r.getMessage()]
+    assert records
+    assert all(r.request_id == "message-request" for r in records)
+    assert span.get_request_id() is None
+
+
+@pytest.mark.asyncio
+async def test_background_work_retains_message_id_after_callback_returns():
+    release = asyncio.Event()
+    tasks = []
+    observed = {}
+
+    async def background():
+        await release.wait()
+        return span.get_request_id()
+
+    async def receive(context):
+        observed["id"] = span.get_request_id()
+        tasks.append(asyncio.create_task(background()))
+
+    try:
+        result = await WegentChatbotHandler(on_message=receive).process(_callback())
+        assert result == (AckMessage.STATUS_OK, "OK")
+        assert span.get_request_id() is None
+    finally:
+        release.set()
+        results = await asyncio.gather(*tasks)
+    assert results == [observed["id"]]

--- a/backend/tests/services/channels/dingtalk/test_streaming_backpressure.py
+++ b/backend/tests/services/channels/dingtalk/test_streaming_backpressure.py
@@ -1,0 +1,206 @@
+"""Regression tests for slow card delivery and authoritative completion."""
+
+import asyncio
+import threading
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.channels.dingtalk import emitter as emitter_module
+from app.services.channels.dingtalk.emitter import StreamingResponseEmitter
+from shared.models import EventType, ExecutionEvent
+from tests.services.channels.dingtalk.test_emitter import FakeCache, card_factory
+
+
+def block_update(card, loop, content):
+    started = asyncio.Event()
+    release = threading.Event()
+    original = card.ai_streaming
+
+    def streaming(value, append=False):
+        if value == content:
+            loop.call_soon_threadsafe(started.set)
+            if not release.wait(5):
+                raise AssertionError("test did not release blocked card request")
+        original(value, append=append)
+
+    card.ai_streaming = streaming
+    return started, release
+
+
+@pytest.mark.asyncio
+async def test_slow_card_does_not_block_ingestion_and_done_replaces_pending(
+    card_factory,
+):
+    emitter = StreamingResponseEmitter(object(), object())
+    emitter.MIN_UPDATE_INTERVAL = 0
+    await emitter.emit_start(1, 2)
+    card = card_factory[0]
+    started, release = block_update(card, asyncio.get_running_loop(), "first")
+    try:
+        await emitter.emit_chunk(1, 2, "first", 0)
+        await asyncio.wait_for(started.wait(), 1)
+
+        async def consume_remaining():
+            for offset in range(100):
+                await emitter.emit_chunk(1, 2, "pending", offset)
+
+        await asyncio.wait_for(consume_remaining(), 1)
+        done = asyncio.create_task(emitter.emit_done(1, 2, {"value": "final"}))
+        await asyncio.sleep(0)
+        assert not done.done()
+        release.set()
+        await asyncio.wait_for(done, 2)
+        await emitter.emit_chunk(1, 2, "late", 100)
+        await emitter.emit_done(1, 2, {"value": "duplicate"})
+
+        assert card.updates[1:] == ["first", "final"]
+        assert card.finished == ["final"]
+        assert emitter._flush_task is None
+    finally:
+        release.set()
+        await emitter.close()
+
+
+@pytest.mark.asyncio
+async def test_burst_is_persisted_and_sent_once(monkeypatch, card_factory):
+    cache = FakeCache()
+    cache.get = AsyncMock(wraps=cache.get)
+    cache.set = AsyncMock(wraps=cache.set)
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    emitter = StreamingResponseEmitter(object(), object())
+    emitter.set_shared_content_key("card-burst")
+    emitter.MIN_UPDATE_INTERVAL = 3600
+    await emitter.emit_start(1, 2)
+    before = (cache.get.await_count, cache.set.await_count)
+    for offset in range(100):
+        await emitter.emit_chunk(1, 2, "文", offset)
+    assert (cache.get.await_count, cache.set.await_count) == before
+    await emitter.flush()
+    assert card_factory[0].updates[1:] == ["文" * 100]
+    assert cache.raw["card-burst:card-1"] == ("文" * 100).encode()
+    await emitter.close()
+
+
+@pytest.mark.asyncio
+async def test_default_window_coalesces_chunks_without_early_card_updates(card_factory):
+    emitter = StreamingResponseEmitter(object(), object(), "card-1")
+    await emitter.emit_start(1, 2)
+    card = card_factory[0]
+    loop = asyncio.get_running_loop()
+    first_sent, second_sent = asyncio.Event(), asyncio.Event()
+    sent_at = []
+    original = card.ai_streaming
+
+    def streaming(content, append=False):
+        original(content, append=append)
+        sent_at.append(time.monotonic())
+        event = first_sent if len(sent_at) == 1 else second_sent
+        loop.call_soon_threadsafe(event.set)
+
+    card.ai_streaming = streaming
+    try:
+        await emitter.emit_chunk(1, 2, "first", 0)
+        await asyncio.wait_for(first_sent.wait(), timeout=5)
+        for offset in range(100):
+            await emitter.emit_chunk(1, 2, "文", offset)
+        await asyncio.wait_for(second_sent.wait(), timeout=5)
+        assert card.updates == ["first", "first" + "文" * 100]
+        assert sent_at[1] - sent_at[0] >= 0.5
+    finally:
+        await emitter.close()
+
+
+@pytest.mark.asyncio
+async def test_cancel_keeps_unflushed_answer(card_factory):
+    emitter = StreamingResponseEmitter(object(), object())
+    emitter.MIN_UPDATE_INTERVAL = 3600
+    await emitter.emit_start(1, 2)
+    await emitter.emit_chunk(1, 2, "已生成的内容", 0)
+    await emitter.emit_cancelled(1, 2)
+    assert card_factory[0].finished == ["已生成的内容\n\n⚠️ 任务已取消"]
+    assert emitter._flush_task is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_on_reconstructed_worker_fences_old_pending_updates(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    first = StreamingResponseEmitter(object(), object())
+    first.set_shared_content_key("shared-card")
+    first.MIN_UPDATE_INTERVAL = 0
+    await first.emit_start(1, 2)
+    started, release = block_update(
+        card_factory[0], asyncio.get_running_loop(), "first"
+    )
+    second = StreamingResponseEmitter(object(), object(), "card-1")
+    second.set_shared_content_key("shared-card")
+    try:
+        await first.emit_chunk(1, 2, "first", 0)
+        await asyncio.wait_for(started.wait(), 1)
+        await first.emit_chunk(1, 2, "pending", 1)
+        done = asyncio.create_task(second.emit_done(1, 2, {"value": "final"}))
+        await asyncio.sleep(0)
+        assert not done.done()
+        release.set()
+        await asyncio.wait_for(done, 2)
+        await first.flush()
+        assert card_factory[0].updates[1:] == ["first"]
+        assert card_factory[1].finished == ["final"]
+
+        recovered = StreamingResponseEmitter(object(), object(), "card-1")
+        recovered.set_shared_content_key("shared-card")
+        await recovered.emit_done(1, 2, {"value": "duplicate"})
+        assert card_factory[2].updates == []
+        assert card_factory[2].finished == []
+    finally:
+        release.set()
+        await first.close()
+        await second.close()
+
+
+@pytest.mark.asyncio
+async def test_next_turn_card_is_not_blocked_by_previous_terminal(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    first = StreamingResponseEmitter(object(), object(), "card-1")
+    first.set_shared_content_key("same-task")
+    await first.emit_done(1, 2, {"value": "first"})
+    second = StreamingResponseEmitter(object(), object(), "card-2")
+    second.set_shared_content_key("same-task")
+    await second.emit_done(1, 3, {"value": "second"})
+    assert card_factory[1].finished == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_resident_workers_merge_progress_from_the_latest_shared_state(
+    monkeypatch, card_factory
+):
+    cache = FakeCache()
+    monkeypatch.setattr(emitter_module, "cache_manager", cache)
+    workers = [StreamingResponseEmitter(object(), object(), "card-1") for _ in range(2)]
+    for worker in workers:
+        worker.set_shared_content_key("shared-progress")
+        await worker.emit_start(1, 2)
+    for worker, tool in zip(workers, ("Read", "Bash")):
+        await worker.emit(
+            ExecutionEvent.create(
+                EventType.TOOL_RESULT,
+                task_id=1,
+                subtask_id=2,
+                tool_name=tool,
+                data={"status": "completed"},
+            )
+        )
+        await worker.flush()
+    assert cache.structured["shared-progress:card-1:progress"]["recent"] == [
+        "工具完成：Read",
+        "工具完成：Bash",
+    ]
+    for worker in workers:
+        await worker.close()

--- a/backend/tests/services/execution/test_dispatcher_sse_request_id.py
+++ b/backend/tests/services/execution/test_dispatcher_sse_request_id.py
@@ -13,6 +13,7 @@ import pytest
 from app.services.execution.dispatcher import ExecutionDispatcher
 from app.services.execution.router import CommunicationMode, ExecutionTarget
 from shared.models import EventType
+from shared.telemetry.context import get_request_id, request_context
 
 
 class _FakeEvent:
@@ -203,6 +204,49 @@ async def test_dispatch_sse_generates_request_id_when_missing():
         == calls["extra_body"]["metadata"]["request_id"]
     )
     assert calls["extra_body"]["metadata"]["request_id"] == "req_77"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [None, RuntimeError, asyncio.CancelledError])
+async def test_sequential_sse_dispatches_restore_caller_context(failure):
+    dispatcher = ExecutionDispatcher()
+    target = ExecutionTarget(
+        mode=CommunicationMode.SSE,
+        url="http://chat-shell",
+        namespace=None,
+        event="task:execute",
+        room=None,
+    )
+    calls = {}
+    emitter = AsyncMock()
+    session_manager = AsyncMock()
+    session_manager.register_stream.return_value = asyncio.Event()
+    session_manager.is_cancelled.return_value = False
+
+    async def unregister(subtask_id):
+        assert get_request_id() == f"dispatch-{subtask_id}"
+        if failure:
+            raise failure("cleanup interrupted")
+
+    session_manager.unregister_stream.side_effect = unregister
+    with (
+        request_context("caller-context"),
+        patch.dict("sys.modules", {"openai": _build_fake_openai_module(calls)}),
+        patch(
+            "app.services.execution.dispatcher.OpenAIRequestConverter.from_execution_request",
+            side_effect=lambda request: {"model": "test-model", "input": "hello"},
+        ),
+        patch("app.services.chat.storage.session.session_manager", session_manager),
+    ):
+        for number in (1, 2):
+            request = _make_request(number, f"dispatch-{number}")
+            if failure:
+                with pytest.raises(failure, match="cleanup interrupted"):
+                    await dispatcher._dispatch_sse(request, target, emitter)
+            else:
+                await dispatcher._dispatch_sse(request, target, emitter)
+            assert get_request_id() == "caller-context"
+            assert calls["extra_headers"]["X-Request-ID"] == f"dispatch-{number}"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/execution/test_dispatcher_sse_request_id.py
+++ b/backend/tests/services/execution/test_dispatcher_sse_request_id.py
@@ -58,12 +58,14 @@ def _build_fake_openai_module(calls: dict, events=None):
             tools,
             stream,
             extra_body,
+            extra_headers,
         ):
             calls["model"] = model
             calls["input"] = input
             calls["instructions"] = instructions
             calls["tools"] = tools
             calls["stream"] = stream
+            calls["extra_headers"] = extra_headers
             calls["extra_body"] = extra_body
             return _FakeStream(events)
 
@@ -118,6 +120,10 @@ async def test_dispatch_sse_keeps_existing_metadata_request_id():
     ):
         await dispatcher._dispatch_sse(request, target, emitter)
 
+    assert (
+        calls["extra_headers"]["X-Request-ID"]
+        == calls["extra_body"]["metadata"]["request_id"]
+    )
     assert calls["extra_body"]["metadata"]["request_id"] == "metadata-request-id"
 
 
@@ -153,6 +159,10 @@ async def test_dispatch_sse_uses_request_request_id_when_metadata_missing():
     ):
         await dispatcher._dispatch_sse(request, target, emitter)
 
+    assert (
+        calls["extra_headers"]["X-Request-ID"]
+        == calls["extra_body"]["metadata"]["request_id"]
+    )
     assert calls["extra_body"]["metadata"]["request_id"] == "backend-request-id"
 
 
@@ -188,6 +198,10 @@ async def test_dispatch_sse_generates_request_id_when_missing():
     ):
         await dispatcher._dispatch_sse(request, target, emitter)
 
+    assert (
+        calls["extra_headers"]["X-Request-ID"]
+        == calls["extra_body"]["metadata"]["request_id"]
+    )
     assert calls["extra_body"]["metadata"]["request_id"] == "req_77"
 
 

--- a/backend/tests/test_trace_correlation.py
+++ b/backend/tests/test_trace_correlation.py
@@ -1,0 +1,86 @@
+"""Exercise the real service middleware and HTTPX propagation in process."""
+
+import httpx
+import pytest
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from shared.telemetry.context.span import get_request_id
+from shared.telemetry.http import internal_http_event_hooks
+from shared.utils.http_client import traced_async_client
+
+
+@pytest.mark.asyncio
+async def test_chat_shell_to_backend_uses_one_trace_and_distinct_spans():
+    from app.main import create_app as create_backend
+    from chat_shell.main import create_app as create_chat_shell
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    backend = create_backend()
+    chat_shell = create_chat_shell()
+    FastAPIInstrumentor.instrument_app(backend, tracer_provider=provider)
+    FastAPIInstrumentor.instrument_app(chat_shell, tracer_provider=provider)
+
+    @backend.get("/__trace_probe")
+    async def probe():
+        context = trace.get_current_span().get_span_context()
+        return {
+            "trace_id": f"{context.trace_id:032x}",
+            "span_id": f"{context.span_id:016x}",
+            "request_id": get_request_id(),
+        }
+
+    async with traced_async_client(
+        base_url="http://backend",
+        transport=httpx.ASGITransport(app=backend),
+        event_hooks=internal_http_event_hooks(),
+        headers={"X-Service-Name": "chat-shell"},
+    ) as internal:
+        HTTPXClientInstrumentor.instrument_client(internal, tracer_provider=provider)
+
+        @chat_shell.get("/__trace_forward")
+        async def forward():
+            context = trace.get_current_span().get_span_context()
+            response = await internal.get("/__trace_probe")
+            return {
+                "local_trace": f"{context.trace_id:032x}",
+                "local_span": f"{context.span_id:016x}",
+                "backend": response.json(),
+                "backend_header": response.headers.get("X-Request-ID"),
+            }
+
+        async with httpx.AsyncClient(
+            base_url="http://chat-shell", transport=httpx.ASGITransport(app=chat_shell)
+        ) as client:
+            response = await client.get(
+                "/__trace_forward",
+                headers={
+                    "X-Request-ID": "req-412317010590",
+                    "traceparent": "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+                },
+            )
+    assert response.status_code == 200
+    expected_trace = "1234567890abcdef1234567890abcdef"
+    body = response.json()
+    assert response.headers["X-Request-ID"] == "req-412317010590"
+    assert body["backend_header"] == "req-412317010590"
+    assert body["local_trace"] == expected_trace
+    assert body["backend"]["trace_id"] == expected_trace
+    assert body["backend"]["request_id"] == "req-412317010590"
+    assert body["local_span"] != "1234567890abcdef"
+    assert body["backend"]["span_id"] != body["local_span"]
+    spans = exporter.get_finished_spans()
+    backend_span = next(
+        s for s in spans if f"{s.context.span_id:016x}" == body["backend"]["span_id"]
+    )
+    client_span = next(
+        s for s in spans if s.context.span_id == backend_span.parent.span_id
+    )
+    assert f"{client_span.parent.span_id:016x}" == body["local_span"]
+    provider.shutdown()

--- a/chat_shell/chat_shell/main.py
+++ b/chat_shell/chat_shell/main.py
@@ -261,8 +261,8 @@ def create_app(
         if request.url.path == "/":
             return await call_next(request)
 
-        # Generate request ID
-        request_id = str(uuid.uuid4())[:8]
+        # Preserve the upstream correlation ID at the HTTP entry point.
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())[:8]
         request.state.request_id = request_id
         start_time = time.time()
 
@@ -277,17 +277,7 @@ def create_app(
             request.url.path,
         )
 
-        # Extract and attach trace context from headers
-        # BaseHTTPMiddleware runs in a new async task, so contextvars from
-        # OTEL ASGI middleware are not propagated. We need to manually extract
-        # and attach the trace context to enable distributed tracing.
-        from opentelemetry import context as otel_context
-        from opentelemetry.propagate import extract
-
-        headers_dict = dict(request.headers)
-        extracted_ctx = extract(headers_dict)
-        token = otel_context.attach(extracted_ctx)
-
+        # The OTel ASGI middleware owns extraction and span lifetime.
         # Set request context for logging (works even without OTEL)
         from shared.telemetry.context import (
             set_request_context,
@@ -355,6 +345,7 @@ def create_app(
         # Process request
         try:
             response = await call_next(request)
+            response.headers.setdefault("X-Request-ID", request_id)
             process_time = (time.time() - start_time) * 1000
 
             # For streaming responses, wrap the body iterator to log after completion
@@ -371,8 +362,6 @@ def create_app(
                         logger.info(
                             f"response: {request.method} {request.url.path} {response.status_code} {total_time:.2f}ms {request_id} (streamed)"
                         )
-                        # Detach trace context after streaming completes
-                        otel_context.detach(token)
 
                 response.body_iterator = logging_body_iterator()
             else:
@@ -380,13 +369,10 @@ def create_app(
                 logger.info(
                     f"response: {request.method} {request.url.path} {response.status_code} {process_time:.2f}ms {request_id}"
                 )
-                # Detach trace context for non-streaming responses
-                otel_context.detach(token)
 
             return response
         except Exception:
-            # Detach trace context on error
-            otel_context.detach(token)
+            logger.exception("request failed: %s %s", request.method, request.url.path)
             raise
 
     # Include v1 response router

--- a/chat_shell/chat_shell/services/guidance.py
+++ b/chat_shell/chat_shell/services/guidance.py
@@ -15,6 +15,8 @@ import httpx
 from langchain_core.messages import HumanMessage
 
 from chat_shell.core.config import settings
+from shared.telemetry.http import internal_http_event_hooks
+from shared.utils.http_client import traced_async_client
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,8 @@ class RemoteGuidanceQueueClient:
             }
             if self.auth_token:
                 headers["Authorization"] = f"Bearer {self.auth_token}"
-            self._client = httpx.AsyncClient(
+            self._client = traced_async_client(
+                event_hooks=internal_http_event_hooks(),
                 base_url=self.base_url,
                 headers=headers,
                 timeout=self.timeout,

--- a/chat_shell/chat_shell/storage/remote.py
+++ b/chat_shell/chat_shell/storage/remote.py
@@ -20,6 +20,8 @@ from chat_shell.storage.interfaces import (
     ToolResultStoreInterface,
 )
 from shared.telemetry.context import get_request_id
+from shared.telemetry.http import internal_http_event_hooks
+from shared.utils.http_client import traced_async_client
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +71,8 @@ class RemoteHistoryStore(HistoryStoreInterface):
             if self.auth_token:
                 headers["Authorization"] = f"Bearer {self.auth_token}"
 
-            self._client = httpx.AsyncClient(
+            self._client = traced_async_client(
+                event_hooks=internal_http_event_hooks(),
                 base_url=self.base_url,
                 headers=headers,
                 timeout=self.timeout,
@@ -115,7 +118,6 @@ class RemoteHistoryStore(HistoryStoreInterface):
         url = f"/chat/history/{session_id}"
         full_url = f"{self.base_url}{url}"
         request_id = get_request_id()
-        request_headers = {"X-Request-ID": request_id} if request_id else None
         logger.info(
             "[RemoteHistoryStore_TRACE] get_history_start session_id=%s "
             "before_message_id=%s limit=%s is_group_chat=%s request_id=%s "
@@ -138,7 +140,6 @@ class RemoteHistoryStore(HistoryStoreInterface):
                 "GET",
                 url,
                 params=params,
-                headers=request_headers,
             )
             build_ms = (time.perf_counter() - build_start) * 1000
 
@@ -171,17 +172,12 @@ class RemoteHistoryStore(HistoryStoreInterface):
             messages = [Message.from_dict(m) for m in data.get("messages", [])]
             parse_ms = (time.perf_counter() - parse_start) * 1000
             total_ms = (time.perf_counter() - total_start) * 1000
-            http_elapsed_ms = (
-                response.elapsed.total_seconds() * 1000
-                if response.elapsed is not None
-                else None
-            )
             logger.info(
                 "[RemoteHistoryStore_PERF] get_history session_id=%s "
                 "before_message_id=%s limit=%s is_group_chat=%s status=%d "
                 "message_count=%d request_id=%s client_reused=%s client_ms=%.2f "
                 "build_ms=%.2f headers_ms=%.2f body_read_ms=%.2f request_ms=%.2f "
-                "http_elapsed_ms=%s parse_ms=%.2f total_ms=%.2f content_length=%s "
+                "parse_ms=%.2f total_ms=%.2f content_length=%s "
                 "body_bytes=%d http_version=%s wall_start_utc=%s",
                 session_id,
                 before_message_id,
@@ -196,7 +192,6 @@ class RemoteHistoryStore(HistoryStoreInterface):
                 headers_ms,
                 body_read_ms,
                 request_ms,
-                f"{http_elapsed_ms:.2f}" if http_elapsed_ms is not None else "",
                 parse_ms,
                 total_ms,
                 response.headers.get("content-length", "unknown"),
@@ -403,7 +398,8 @@ class RemoteToolResultStore(ToolResultStoreInterface):
             if self.auth_token:
                 headers["Authorization"] = f"Bearer {self.auth_token}"
 
-            self._client = httpx.AsyncClient(
+            self._client = traced_async_client(
+                event_hooks=internal_http_event_hooks(),
                 base_url=self.base_url,
                 headers=headers,
                 timeout=self.timeout,

--- a/chat_shell/tests/services/test_internal_http_correlation.py
+++ b/chat_shell/tests/services/test_internal_http_correlation.py
@@ -1,0 +1,55 @@
+"""Verify correlation hooks are used by every internal history/guidance call."""
+
+import httpx
+import pytest
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext
+
+from chat_shell.services.guidance import RemoteGuidanceQueueClient
+from chat_shell.storage.remote import RemoteHistoryStore
+from shared.telemetry.context.span import _request_id_var
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auth_token", ["", "internal-test-token"])
+async def test_history_patch_and_guidance_preserve_request_and_trace(
+    monkeypatch, auth_token
+):
+    requests = []
+
+    def handle(request):
+        requests.append(request)
+        return httpx.Response(200, json={"messages": [], "item": None, "success": True})
+
+    original_client = httpx.AsyncClient
+
+    def client(**kwargs):
+        return original_client(**kwargs, transport=httpx.MockTransport(handle))
+
+    monkeypatch.setattr(httpx, "AsyncClient", client)
+    history = RemoteHistoryStore("http://backend/api/internal", auth_token=auth_token)
+    guidance = RemoteGuidanceQueueClient(
+        "http://backend/api/internal", auth_token=auth_token
+    )
+    token = _request_id_var.set("req-412317010590")
+    context = SpanContext(123, 456, False)
+    try:
+        with trace.use_span(NonRecordingSpan(context)):
+            await history.get_history("task-412317010581")
+            await history.update_message("task-412317010581", "412317010589", "继续")
+            await guidance.consume(412317010581, 412317010590)
+            await guidance.expire(412317010581, 412317010590)
+    finally:
+        _request_id_var.reset(token)
+        await history.close()
+        if guidance._client is not None:
+            await guidance._client.aclose()
+    assert [request.method for request in requests] == ["GET", "PATCH", "POST", "POST"]
+    assert all(r.headers["X-Request-ID"] == "req-412317010590" for r in requests)
+    expected_authorization = f"Bearer {auth_token}" if auth_token else None
+    assert all(
+        r.headers.get("Authorization") == expected_authorization for r in requests
+    )
+    assert all(
+        r.headers["traceparent"] == f"00-{123:032x}-{456:016x}-00" for r in requests
+    )

--- a/shared/telemetry/context/__init__.py
+++ b/shared/telemetry/context/__init__.py
@@ -62,6 +62,7 @@ def __getattr__(name: str):
         "init_request_context",
         "is_websocket_context",
         "record_stream_error",
+        "request_context",
         "restore_context_vars",
         "set_agent_context",
         "set_bot_context",
@@ -126,6 +127,7 @@ __all__ = [
     "get_server_ip",
     "is_websocket_context",
     "init_request_context",
+    "request_context",
     # WebSocket context
     "set_websocket_context",
     # Context copy/restore (for new event loops or threads)

--- a/shared/telemetry/context/span.py
+++ b/shared/telemetry/context/span.py
@@ -16,8 +16,9 @@ when telemetry is disabled (e.g., in standalone mode).
 """
 
 import logging
+from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional
 
 from shared.telemetry.context.attributes import SpanAttributes
 
@@ -582,6 +583,20 @@ def init_request_context() -> str:
     request_id = str(uuid.uuid4())[:8]
     set_request_context(request_id)
     return request_id
+
+
+@contextmanager
+def request_context(request_id: Optional[str] = None) -> Iterator[str]:
+    """Scope a supplied or generated request ID and restore the caller on exit."""
+    token = _request_id_var.set(request_id)
+    try:
+        if request_id:
+            set_request_context(request_id)
+        else:
+            request_id = init_request_context()
+        yield request_id
+    finally:
+        _request_id_var.reset(token)
 
 
 def set_repository_context(

--- a/shared/telemetry/http.py
+++ b/shared/telemetry/http.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-request correlation and transport timings for internal HTTP clients."""
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+async def trace_internal_request(request: httpx.Request) -> None:
+    """Measure a request after the traced client has injected correlation headers."""
+    started = time.perf_counter()
+    request.extensions["internal_request_started"] = started
+    logger.info(
+        "[InternalHTTP] request method=%s path=%s request_id=%s",
+        request.method,
+        request.url.path,
+        request.headers.get("X-Request-ID", "-"),
+    )
+
+    phases: dict[str, float] = {}
+
+    async def transport_trace(event: str, info: dict[str, Any]) -> None:
+        phase, _, state = event.rpartition(".")
+        if not phase.endswith(("connect_tcp", "start_tls", "receive_response_headers")):
+            return
+        now = time.perf_counter()
+        if state == "started":
+            phases[phase] = now
+        elif state in {"complete", "failed"}:
+            logger.info(
+                "[InternalHTTP] phase=%s state=%s method=%s path=%s "
+                "request_id=%s duration_ms=%.2f total_ms=%.2f error_type=%s",
+                phase,
+                state,
+                request.method,
+                request.url.path,
+                request.headers.get("X-Request-ID", "-"),
+                (now - phases.get(phase, started)) * 1000,
+                (now - started) * 1000,
+                type(info["exception"]).__name__ if info.get("exception") else "-",
+            )
+
+    request.extensions.setdefault("trace", transport_trace)
+
+
+async def trace_internal_response(response: httpx.Response) -> None:
+    """Log receipt of headers without buffering streaming response bodies."""
+    request = response.request
+    started = request.extensions.get("internal_request_started")
+    if started is None:
+        return
+    logger.info(
+        "[InternalHTTP] response method=%s path=%s status=%s request_id=%s "
+        "headers_ms=%.2f",
+        request.method,
+        request.url.path,
+        response.status_code,
+        request.headers.get("X-Request-ID", "-"),
+        (time.perf_counter() - started) * 1000,
+    )
+
+
+def internal_http_event_hooks() -> dict[str, list[Callable[..., Awaitable[None]]]]:
+    """Return fresh hooks for each client, with all state scoped to each request."""
+    return {"request": [trace_internal_request], "response": [trace_internal_response]}

--- a/shared/tests/telemetry/test_http_correlation.py
+++ b/shared/tests/telemetry/test_http_correlation.py
@@ -1,0 +1,108 @@
+"""HTTP and log correlation across concurrent requests and unsampled spans."""
+
+import asyncio
+import logging
+
+import httpx
+import pytest
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+from shared.logger import RequestIdFilter
+from shared.telemetry.context.span import _request_id_var
+from shared.telemetry.http import internal_http_event_hooks
+from shared.utils.http_client import _inject_trace_headers, traced_async_client
+
+
+def span(trace_id=123, span_id=456):
+    return NonRecordingSpan(SpanContext(trace_id, span_id, False, TraceFlags(0)))
+
+
+@pytest.mark.parametrize("active_span", [trace.INVALID_SPAN, span()])
+def test_request_id_logging_is_independent_of_otel(active_span):
+    record = logging.LogRecord("test", logging.INFO, __file__, 1, "test", (), None)
+    token = _request_id_var.set("request-1")
+    try:
+        with trace.use_span(active_span):
+            RequestIdFilter().filter(record)
+            assert record.request_id == "request-1"
+    finally:
+        _request_id_var.reset(token)
+
+
+def test_request_id_is_sent_when_trace_injection_fails(monkeypatch):
+    import shared.telemetry.context as context
+
+    def unavailable(_headers):
+        raise ImportError("optional telemetry is unavailable")
+
+    monkeypatch.setattr(context, "inject_trace_context_to_headers", unavailable)
+    token = _request_id_var.set("request-without-otel")
+    try:
+        assert _inject_trace_headers({})["X-Request-ID"] == "request-without-otel"
+    finally:
+        _request_id_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_pooled_client_keeps_concurrent_request_contexts_separate():
+    seen = []
+
+    async def handle(request):
+        await asyncio.sleep(0)
+        seen.append(
+            (request.headers.get("X-Request-ID"), request.headers.get("traceparent"))
+        )
+        return httpx.Response(200, json={})
+
+    async with traced_async_client(
+        transport=httpx.MockTransport(handle),
+        event_hooks=internal_http_event_hooks(),
+    ) as client:
+
+        async def send(number):
+            token = _request_id_var.set(f"request-{number}")
+            try:
+                with trace.use_span(span(number, number + 10)):
+                    await client.get("http://backend/internal/history")
+            finally:
+                _request_id_var.reset(token)
+
+        await asyncio.gather(*(send(number) for number in range(1, 11)))
+        with trace.use_span(trace.INVALID_SPAN):
+            token = _request_id_var.set(None)
+            try:
+                await client.get("http://backend/internal/history")
+            finally:
+                _request_id_var.reset(token)
+    assert set(seen[:-1]) == {
+        (f"request-{number}", f"00-{number:032x}-{number + 10:016x}-00")
+        for number in range(1, 11)
+    }
+    assert seen[-1] == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_connection_failure_logs_phase_and_request_id(caplog):
+    async def fail(request):
+        callback = request.extensions["trace"]
+        await callback("connection.connect_tcp.started", {})
+        error = httpx.ConnectTimeout("timed out", request=request)
+        await callback("connection.connect_tcp.failed", {"exception": error})
+        raise error
+
+    token = _request_id_var.set("request-timeout")
+    try:
+        with caplog.at_level(logging.INFO):
+            async with traced_async_client(
+                transport=httpx.MockTransport(fail),
+                event_hooks=internal_http_event_hooks(),
+            ) as client:
+                with pytest.raises(httpx.ConnectTimeout):
+                    await client.get("http://backend/internal/history")
+    finally:
+        _request_id_var.reset(token)
+    message = next(r.message for r in caplog.records if "state=failed" in r.message)
+    assert "phase=connection.connect_tcp" in message
+    assert "error_type=ConnectTimeout" in message
+    assert "request_id=request-timeout" in message

--- a/shared/utils/http_client.py
+++ b/shared/utils/http_client.py
@@ -43,18 +43,17 @@ logger = logging.getLogger(__name__)
 def _inject_trace_headers(headers: dict) -> dict:
     """Inject W3C trace context and X-Request-ID into headers dict.
 
-    Safe to call even when OTEL is not enabled — will simply be a no-op.
+    Request ID propagation works independently of optional OTel instrumentation.
     """
     try:
-        from shared.telemetry.context import (
-            get_request_id,
-            inject_trace_context_to_headers,
-        )
+        from shared.telemetry.context.span import get_request_id
 
-        headers = inject_trace_context_to_headers(headers)
         request_id = get_request_id()
         if request_id:
             headers["X-Request-ID"] = request_id
+        from shared.telemetry.context import inject_trace_context_to_headers
+
+        headers = inject_trace_context_to_headers(headers)
     except Exception as e:
         logger.debug(f"Failed to inject trace context headers: {e}")
     return headers


### PR DESCRIPTION
Slow synchronous DingTalk card requests currently block event ingestion, while per-event Redis writes amplify the delay. This change coalesces progress and answer updates in a background writer and uses the authoritative completion result to finish the card.

- Keep SDK I/O off the event loop, serialize writes across reconstructed workers, and retain recovery state when terminal delivery fails.
- Check card HTTP failures and timeouts, isolate card state between conversation turns, and prevent late updates from overwriting completion.
- Carry request IDs and trace context through DingTalk callbacks, Backend, and Chat Shell, with timings for card delivery, event emission, and internal HTTP transport.
- Remove redundant test flushes while retaining coverage for batching, cancellation, recovery, and trace correlation.

Validation: 138 focused Backend tests passed; 32 related Chat Shell/shared tests passed. Black, isort, and diff checks passed. The existing CI DingTalk conversation E2E is updated for buffered progress; live DingTalk delivery has not been exercised locally.

Review follow-up: preserve local progress when the shared snapshot is absent, restore the caller request context after successful/failed/cancelled SSE cleanup, and reject control characters in callback request IDs. Nine regression cases reproduced these issues before the fixes and now pass.

The suggestion to remove service credentials from HTTP clients is not adopted: these clients already use authenticated internal HTTP in the supported Compose deployment (`docker-compose.yml:229-231`) and Chat Shell image. This PR preserves that authentication contract; silently dropping the token would break internal API access. Changing deployment transport to TLS is a separate infrastructure change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DingTalk AI card delivery reliability, including clearer handling of timeouts, failed updates, cancellations, and completion states.
  - Streaming responses now batch rapid updates more smoothly without blocking incoming content.
  - Preserved buffered responses during shutdown or temporary delivery failures.
  - Prevented stale updates from previous conversations from affecting later turns.

- **Improvements**
  - Request IDs and tracing now flow consistently across chat requests and internal service calls.
  - Request IDs are echoed in responses for easier troubleshooting.
  - Added more detailed timing information for streaming and internal network requests.
  - Improved recovery across concurrent and reconstructed streaming sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->