### PR TITLE
fix(wework): shrink desktop e2e diagnostics

### DIFF
--- a/.github/scripts/prune-wework-desktop-e2e-diagnostics.sh
+++ b/.github/scripts/prune-wework-desktop-e2e-diagnostics.sh
@@ -18,7 +18,18 @@ find "$diagnostics_root" \
 
 find "$diagnostics_root" \
   -type d \
-  -path '*/electron-user-data/managed-components' \
+  \( -name 'managed-components' -o -name 'managed-runtimes' \) \
+  -prune \
+  -exec rm -rf {} +
+
+find "$diagnostics_root" \
+  -type d \
+  -name 'profiles' \
+  \( \
+    -path '*/dsh-core/profiles' -o \
+    -path '*/Harness/profiles' -o \
+    -path '*/harness-apps/instances/*/profiles' \
+  \) \
   -prune \
   -exec rm -rf {} +
 
@@ -31,3 +42,18 @@ find "$diagnostics_root" -type d \( \
   -name 'GrShaderCache' -o \
   -name 'ShaderCache' \
 \) -prune -exec rm -rf {} +
+
+find "$diagnostics_root" \
+  -mindepth 2 \
+  -maxdepth 2 \
+  -type f \
+  \( \
+    -name '*.tar' -o \
+    -name '*.tar.gz' -o \
+    -name '*.tar.zst' -o \
+    -name '*.tgz' -o \
+    -name '*.zip' -o \
+    -name 'wegent-executor' -o \
+    -name 'wegent-executor.exe' \
+  \) \
+  -delete

--- a/.github/scripts/prune-wework-desktop-e2e-diagnostics.sh
+++ b/.github/scripts/prune-wework-desktop-e2e-diagnostics.sh
@@ -8,6 +8,20 @@ if [[ ! -d "$diagnostics_root" ]]; then
   exit 0
 fi
 
+find "$diagnostics_root" \
+  -mindepth 2 \
+  -maxdepth 2 \
+  -type d \
+  ! -name 'electron-user-data' \
+  -prune \
+  -exec rm -rf {} +
+
+find "$diagnostics_root" \
+  -type d \
+  -path '*/electron-user-data/managed-components' \
+  -prune \
+  -exec rm -rf {} +
+
 find "$diagnostics_root" -type d \( \
   -name 'Cache' -o \
   -name 'Code Cache' -o \

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -1244,11 +1244,19 @@ if [[ "$wework_desktop_cloud_job" == *"name: Set up Node workspace"* ]] ||
   exit 1
 fi
 
-managed_components_exclusion='!wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**'
+managed_components_exclusion='!wework/test-results/desktop-e2e/**/managed-components/**'
 if [[ "$(grep -Fc "$managed_components_exclusion" "$wework_workflow")" -ne 7 ]] ||
   [[ "$(grep -Fc "$managed_components_exclusion" \
     "$script_dir/../workflows/wework-app.yml")" -ne 1 ]]; then
   printf 'Every Wework desktop diagnostics upload must exclude materialized components\n' >&2
+  exit 1
+fi
+
+test_archive_exclusion='!wework/test-results/desktop-e2e/**/*.zip'
+if [[ "$(grep -Fc "$test_archive_exclusion" "$wework_workflow")" -ne 7 ]] ||
+  [[ "$(grep -Fc "$test_archive_exclusion" \
+    "$script_dir/../workflows/wework-app.yml")" -ne 1 ]]; then
+  printf 'Every Wework desktop diagnostics upload must exclude test archives\n' >&2
   exit 1
 fi
 
@@ -1260,9 +1268,9 @@ if [[ "$(grep -Fc 'compression-level: 6' "$wework_workflow")" -ne 7 ]] ||
 fi
 
 for generated_path_exclusion in \
-  '!wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**' \
-  '!wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**' \
-  '!wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**' \
+  '!wework/test-results/desktop-e2e/**/managed-runtimes/**' \
+  '!wework/test-results/desktop-e2e/**/dsh-core/profiles/**' \
+  '!wework/test-results/desktop-e2e/**/harness-apps/instances/**/profiles/**' \
   '!wework/test-results/desktop-e2e/**/harness-runtime/**' \
   '!wework/test-results/desktop-e2e/**/node-runtime/**' \
   '!wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**'; do

--- a/.github/scripts/test-classify-ci-changes.sh
+++ b/.github/scripts/test-classify-ci-changes.sh
@@ -1139,7 +1139,7 @@ if [[ "$wework_desktop_cloud_job" != *"needs.changes.outputs.wework_desktop_clou
   [[ "$wework_desktop_cloud_job" != *"--parallel-segments"* ]] ||
   [[ "$wework_desktop_cloud_job" != *'WEWORK_E2E_PARALLEL_CHECKPOINTS: "1"'* ]] ||
   [[ "$wework_desktop_cloud_job" != *'WEWORK_E2E_ISOLATED_XVFB: "true"'* ]] ||
-  [[ "$wework_desktop_cloud_job" != *"compression-level: 0"* ]] ||
+  [[ "$wework_desktop_cloud_job" != *"compression-level: 6"* ]] ||
   [[ "$wework_desktop_cloud_job" != *"name: Download shared Wework desktop E2E build"* ]] ||
   [[ "$wework_desktop_cloud_job" != *".github/scripts/download-actions-artifact.sh"* ]] ||
   [[ "$wework_desktop_cloud_job" != *"WEWORK_E2E_APP_BIN:"* ]] ||
@@ -1161,7 +1161,7 @@ if [[ "$wework_desktop_core_job" != *"needs.changes.outputs.wework_desktop_core_
   [[ "$wework_desktop_core_job" != *'WEWORK_E2E_PARALLEL_CHECKPOINTS: "1"'* ]] ||
   [[ "$wework_desktop_core_job" != *"WEWORK_E2E_SCREENSHOTS:"* ]] ||
   [[ "$wework_desktop_core_job" == *"name: Set up Node workspace"* ]] ||
-  [[ "$wework_desktop_core_job" != *"compression-level: 0"* ]]; then
+  [[ "$wework_desktop_core_job" != *"compression-level: 6"* ]]; then
   printf 'Wework Core desktop E2E must use seventeen prebuilt serial shards\n' >&2
   exit 1
 fi
@@ -1241,6 +1241,21 @@ if [[ "$wework_desktop_cloud_job" == *"name: Set up Node workspace"* ]] ||
   [[ "$wework_desktop_job" == *"name: Set up Node workspace"* ]] ||
   [[ "$(grep -Fc 'name: Prune transient Wework desktop E2E caches' "$wework_workflow")" -ne 5 ]]; then
   printf 'Wework desktop shards must avoid workspace dependency restores and prune transient caches\n' >&2
+  exit 1
+fi
+
+managed_components_exclusion='!wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**'
+if [[ "$(grep -Fc "$managed_components_exclusion" "$wework_workflow")" -ne 7 ]] ||
+  [[ "$(grep -Fc "$managed_components_exclusion" \
+    "$script_dir/../workflows/wework-app.yml")" -ne 1 ]]; then
+  printf 'Every Wework desktop diagnostics upload must exclude materialized components\n' >&2
+  exit 1
+fi
+
+if [[ "$(grep -Fc 'compression-level: 6' "$wework_workflow")" -ne 7 ]] ||
+  [[ "$(grep -Fc 'compression-level: 6' \
+    "$script_dir/../workflows/wework-app.yml")" -ne 1 ]]; then
+  printf 'Every Wework desktop diagnostics upload must compress retained evidence\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -379,10 +379,11 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-runtimes/**
+            !wework/test-results/desktop-e2e/**/dsh-core/profiles/**
+            !wework/test-results/desktop-e2e/**/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/*.zip
             !wework/test-results/desktop-e2e/**/harness-runtime/**
             !wework/test-results/desktop-e2e/**/node-runtime/**
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**

--- a/.github/workflows/wework-app.yml
+++ b/.github/workflows/wework-app.yml
@@ -379,6 +379,7 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
             !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
             !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
             !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
@@ -387,7 +388,7 @@ jobs:
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
           if-no-files-found: ignore
           retention-days: 7
-          compression-level: 0
+          compression-level: 6
 
       - name: Prepare desktop release assets
         shell: bash

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -299,7 +299,8 @@ jobs:
           name: wework-desktop-core-e2e-build-diagnostics
           path: |
             wework/test-results/desktop-e2e/
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/*.zip
           if-no-files-found: ignore
           retention-days: 7
           compression-level: 6
@@ -407,10 +408,11 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-runtimes/**
+            !wework/test-results/desktop-e2e/**/dsh-core/profiles/**
+            !wework/test-results/desktop-e2e/**/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/*.zip
             !wework/test-results/desktop-e2e/**/harness-runtime/**
             !wework/test-results/desktop-e2e/**/node-runtime/**
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
@@ -553,7 +555,8 @@ jobs:
           name: wework-desktop-windows-core-e2e-build-diagnostics
           path: |
             wework/test-results/desktop-e2e/
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/*.zip
           if-no-files-found: ignore
           retention-days: 7
           compression-level: 6
@@ -669,10 +672,11 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-runtimes/**
+            !wework/test-results/desktop-e2e/**/dsh-core/profiles/**
+            !wework/test-results/desktop-e2e/**/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/*.zip
             !wework/test-results/desktop-e2e/**/harness-runtime/**
             !wework/test-results/desktop-e2e/**/node-runtime/**
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
@@ -780,10 +784,11 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-runtimes/**
+            !wework/test-results/desktop-e2e/**/dsh-core/profiles/**
+            !wework/test-results/desktop-e2e/**/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/*.zip
             !wework/test-results/desktop-e2e/**/harness-runtime/**
             !wework/test-results/desktop-e2e/**/node-runtime/**
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
@@ -879,10 +884,11 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-runtimes/**
+            !wework/test-results/desktop-e2e/**/dsh-core/profiles/**
+            !wework/test-results/desktop-e2e/**/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/*.zip
             !wework/test-results/desktop-e2e/**/harness-runtime/**
             !wework/test-results/desktop-e2e/**/node-runtime/**
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
@@ -1147,10 +1153,11 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
-            !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/managed-components/**
+            !wework/test-results/desktop-e2e/**/managed-runtimes/**
+            !wework/test-results/desktop-e2e/**/dsh-core/profiles/**
+            !wework/test-results/desktop-e2e/**/harness-apps/instances/**/profiles/**
+            !wework/test-results/desktop-e2e/**/*.zip
             !wework/test-results/desktop-e2e/**/harness-runtime/**
             !wework/test-results/desktop-e2e/**/node-runtime/**
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -297,9 +297,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wework-desktop-core-e2e-build-diagnostics
-          path: wework/test-results/desktop-e2e/
+          path: |
+            wework/test-results/desktop-e2e/
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
           if-no-files-found: ignore
           retention-days: 7
+          compression-level: 6
 
   wework-desktop-core-e2e:
     name: Wework Desktop E2E (${{ matrix.name }})
@@ -404,6 +407,7 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
             !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
             !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
             !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
@@ -412,7 +416,7 @@ jobs:
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
           if-no-files-found: ignore
           retention-days: 7
-          compression-level: 0
+          compression-level: 6
 
   build-wework-desktop-windows-core-e2e:
     name: Build Windows Wework Desktop Core E2E Artifact
@@ -547,9 +551,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wework-desktop-windows-core-e2e-build-diagnostics
-          path: wework/test-results/desktop-e2e/
+          path: |
+            wework/test-results/desktop-e2e/
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
           if-no-files-found: ignore
           retention-days: 7
+          compression-level: 6
 
   wework-desktop-windows-core-e2e:
     name: Wework Desktop Windows E2E (${{ matrix.name }})
@@ -662,6 +669,7 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
             !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
             !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
             !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
@@ -670,7 +678,7 @@ jobs:
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
           if-no-files-found: ignore
           retention-days: 7
-          compression-level: 0
+          compression-level: 6
 
   wework-desktop-cloud-e2e:
     name: Wework Desktop E2E (${{ matrix.name }})
@@ -772,6 +780,7 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
             !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
             !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
             !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
@@ -780,7 +789,7 @@ jobs:
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
           if-no-files-found: ignore
           retention-days: 7
-          compression-level: 0
+          compression-level: 6
 
   wework-desktop-e2e:
     name: Wework Desktop E2E (${{ matrix.name }})
@@ -870,6 +879,7 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
             !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
             !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
             !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
@@ -878,7 +888,7 @@ jobs:
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
           if-no-files-found: ignore
           retention-days: 7
-          compression-level: 0
+          compression-level: 6
 
   wework-e2e-summary:
     name: Wework E2E Summary
@@ -1137,6 +1147,7 @@ jobs:
           path: |
             wework/test-results/desktop-e2e/
             !wework/test-results/desktop-e2e/**/executor-home/**
+            !wework/test-results/desktop-e2e/**/electron-user-data/managed-components/**
             !wework/test-results/desktop-e2e/**/electron-user-data/managed-runtimes/**
             !wework/test-results/desktop-e2e/**/electron-user-data/dsh-core/profiles/**
             !wework/test-results/desktop-e2e/**/electron-user-data/harness-apps/instances/**/profiles/**
@@ -1145,4 +1156,4 @@ jobs:
             !wework/test-results/desktop-e2e/**/WeWork-Electron-E2E-*.app/**
           if-no-files-found: ignore
           retention-days: 7
-          compression-level: 0
+          compression-level: 6

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -283,9 +283,20 @@ application launch to control CI duration. Test artifacts, captured model
 requests, and failure diagnostics are stored in
 `wework/test-results/desktop-e2e/`. Each scenario retains logs, screenshots,
 requests, and UI state while removing copied application bundles, Executor
-homes, extracted runtimes, and rebuildable Electron caches. The runner also
-compacts inactive result directories left by interrupted runs so repeated local
-execution does not continuously consume disk space.
+homes, workspace fixtures, extracted runtimes, and every other rebuildable
+top-level test environment. `electron-user-data` retains diagnostic state only:
+materialized `managed-components`, `managed-runtimes`, DSH and Harness profiles,
+and Electron caches are removed. The runner also compacts inactive result
+directories left by interrupted runs so repeated local execution does not
+continuously consume disk space.
+
+Before upload, GitHub Actions repeats the cleanup and excludes
+`managed-components` from the Artifact path so a teardown failure cannot upload
+the complete Web and WASM component payload as diagnostic evidence. Diagnostic
+Artifacts use standard compression and should normally remain below 20 MiB.
+They should contain logs, screenshots, requests, UI state, and necessary
+Electron persistence only, never rebuildable applications, runtimes, Executor
+homes, workspaces, or component directories.
 
 The local runner writes complete stdout and stderr from the prerequisite
 Electron and Executor build to

--- a/docs/en/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/en/wework/developer-guide/wework-e2e-automation.md
@@ -283,20 +283,23 @@ application launch to control CI duration. Test artifacts, captured model
 requests, and failure diagnostics are stored in
 `wework/test-results/desktop-e2e/`. Each scenario retains logs, screenshots,
 requests, and UI state while removing copied application bundles, Executor
-homes, workspace fixtures, extracted runtimes, and every other rebuildable
-top-level test environment. `electron-user-data` retains diagnostic state only:
-materialized `managed-components`, `managed-runtimes`, DSH and Harness profiles,
-and Electron caches are removed. The runner also compacts inactive result
-directories left by interrupted runs so repeated local execution does not
-continuously consume disk space.
+homes, workspace fixtures, test archives, extracted runtimes, and every other
+rebuildable top-level test environment. `electron-user-data` retains diagnostic
+state only: materialized `managed-components`, `managed-runtimes`, DSH and
+Harness profiles, and Electron caches are recursively removed from both the
+main instance and nested plugin-development instances. The runner also compacts
+inactive result directories left by interrupted runs so repeated local
+execution does not continuously consume disk space.
 
 Before upload, GitHub Actions repeats the cleanup and excludes
-`managed-components` from the Artifact path so a teardown failure cannot upload
-the complete Web and WASM component payload as diagnostic evidence. Diagnostic
-Artifacts use standard compression and should normally remain below 20 MiB.
-They should contain logs, screenshots, requests, UI state, and necessary
+`managed-components` at any depth from the Artifact path so a teardown failure
+cannot upload the complete Web and WASM component payload from either the main
+instance or a nested plugin-development instance as diagnostic evidence. Both
+the top-level cleanup and Artifact paths also exclude test `.zip` archives.
+Diagnostic Artifacts use standard compression and should normally remain below
+20 MiB. They should contain logs, screenshots, requests, UI state, and necessary
 Electron persistence only, never rebuildable applications, runtimes, Executor
-homes, workspaces, or component directories.
+homes, workspaces, test archives, or component directories.
 
 The local runner writes complete stdout and stderr from the prerequisite
 Electron and Executor build to

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -247,8 +247,16 @@ Electron 应用及其内置 Executor，再启动所选场景。可选的 `WEWORK
 Electron 应用；传入的应用必须使用桌面 E2E 的 Vite 环境变量构建。各生命周期场景
 复用一次应用启动以控制 CI 时长；测试过程、捕获的模型请求和失败诊断会保存在
 `wework/test-results/desktop-e2e/`。场景结束后会保留日志、截图、请求和 UI 状态，
-同时删除复制的应用包、Executor Home、解压 Runtime 和 Electron 可重建缓存；runner
-启动时也会清理之前异常中断留下的非活动结果目录，避免本地磁盘随运行次数持续增长。
+同时删除复制的应用包、Executor Home、工作区夹具、解压 Runtime 和其他顶层可重建
+测试环境。`electron-user-data` 仅保留诊断状态，物化的 `managed-components`、
+`managed-runtimes`、DSH/Harness profile 和 Electron 缓存都会删除；runner 启动时也会
+清理之前异常中断留下的非活动结果目录，避免本地磁盘随运行次数持续增长。
+
+GitHub Actions 上传前会再次执行同样的清理，并在 Artifact 路径中排除
+`managed-components`，防止 teardown 失败时把完整 Web/WASM 组件包上传为诊断证据。
+诊断 Artifact 使用标准压缩，正常目标是不超过 20 MiB；诊断包只应包含日志、截图、
+请求、UI 状态和必要的 Electron 持久化状态，不应包含任何可重新构建的应用、Runtime、
+Executor Home、工作区或组件目录。
 
 本地 runner 会把前置 Electron 和 Executor 构建的完整 stdout、stderr 写入
 `wework/test-results/desktop-e2e/desktop-build-<pid>.log`，终端只显示构建阶段、

--- a/docs/zh/wework/developer-guide/wework-e2e-automation.md
+++ b/docs/zh/wework/developer-guide/wework-e2e-automation.md
@@ -247,16 +247,18 @@ Electron 应用及其内置 Executor，再启动所选场景。可选的 `WEWORK
 Electron 应用；传入的应用必须使用桌面 E2E 的 Vite 环境变量构建。各生命周期场景
 复用一次应用启动以控制 CI 时长；测试过程、捕获的模型请求和失败诊断会保存在
 `wework/test-results/desktop-e2e/`。场景结束后会保留日志、截图、请求和 UI 状态，
-同时删除复制的应用包、Executor Home、工作区夹具、解压 Runtime 和其他顶层可重建
-测试环境。`electron-user-data` 仅保留诊断状态，物化的 `managed-components`、
-`managed-runtimes`、DSH/Harness profile 和 Electron 缓存都会删除；runner 启动时也会
-清理之前异常中断留下的非活动结果目录，避免本地磁盘随运行次数持续增长。
+同时删除复制的应用包、Executor Home、工作区夹具、测试归档、解压 Runtime 和其他
+顶层可重建测试环境。`electron-user-data` 仅保留诊断状态；主实例和插件开发子实例中
+物化的 `managed-components`、`managed-runtimes`、DSH/Harness profile 和 Electron
+缓存都会递归删除。runner 启动时也会清理之前异常中断留下的非活动结果目录，避免
+本地磁盘随运行次数持续增长。
 
 GitHub Actions 上传前会再次执行同样的清理，并在 Artifact 路径中排除
-`managed-components`，防止 teardown 失败时把完整 Web/WASM 组件包上传为诊断证据。
-诊断 Artifact 使用标准压缩，正常目标是不超过 20 MiB；诊断包只应包含日志、截图、
-请求、UI 状态和必要的 Electron 持久化状态，不应包含任何可重新构建的应用、Runtime、
-Executor Home、工作区或组件目录。
+任意深度的 `managed-components`，防止 teardown 失败时把主实例或插件开发子实例的
+完整 Web/WASM 组件包上传为诊断证据；顶层清理和 Artifact 路径也都会排除测试 `.zip`
+归档。诊断 Artifact 使用标准压缩，正常目标是不超过 20 MiB；诊断包只应包含日志、
+截图、请求、UI 状态和必要的 Electron 持久化状态，不应包含任何可重新构建的应用、
+Runtime、Executor Home、工作区、测试归档或组件目录。
 
 本地 runner 会把前置 Electron 和 Executor 构建的完整 stdout、stderr 写入
 `wework/test-results/desktop-e2e/desktop-build-<pid>.log`，终端只显示构建阶段、

--- a/wework/e2e/desktop/result-retention.mjs
+++ b/wework/e2e/desktop/result-retention.mjs
@@ -16,14 +16,8 @@ const CACHE_DIRECTORY_NAMES = new Set([
   'GrShaderCache',
   'ShaderCache',
 ])
-const TRANSIENT_TOP_LEVEL_ENTRIES = new Set([
-  'executor-home',
-  'harness-runtime',
-  'node-runtime',
-  'wegent-executor',
-  'wegent-executor.exe',
-])
-const MACOS_APP_BUNDLE_PATTERN = /^WeWork-Electron-E2E-\d+\.app$/
+const RETAINED_TOP_LEVEL_DIRECTORIES = new Set(['electron-user-data'])
+const TRANSIENT_TOP_LEVEL_FILES = new Set(['wegent-executor', 'wegent-executor.exe'])
 const RESULT_DIRECTORY_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-(\d+)$/
 
 function removeOptions() {
@@ -175,6 +169,7 @@ async function removeHarnessAppProfiles(userDataDirectory) {
 async function compactElectronUserData(userDataDirectory) {
   let removed = 0
   const exactDirectories = [
+    join(userDataDirectory, 'managed-components'),
     join(userDataDirectory, 'managed-runtimes'),
     join(userDataDirectory, 'dsh-core', 'profiles'),
   ]
@@ -214,12 +209,9 @@ export async function clearDesktopE2EResultActive(resultDirectory) {
 export async function compactDesktopE2EResult(resultDirectory) {
   let removed = 0
   for (const entry of await directoryEntries(resultDirectory)) {
-    if (
-      !TRANSIENT_TOP_LEVEL_ENTRIES.has(entry.name) &&
-      !MACOS_APP_BUNDLE_PATTERN.test(entry.name)
-    ) {
-      continue
-    }
+    const removeDirectory = entry.isDirectory() && !RETAINED_TOP_LEVEL_DIRECTORIES.has(entry.name)
+    const removeFile = entry.isFile() && TRANSIENT_TOP_LEVEL_FILES.has(entry.name)
+    if (!removeDirectory && !removeFile) continue
     await removePath(join(resultDirectory, entry.name))
     removed += 1
   }

--- a/wework/e2e/desktop/result-retention.mjs
+++ b/wework/e2e/desktop/result-retention.mjs
@@ -18,6 +18,8 @@ const CACHE_DIRECTORY_NAMES = new Set([
 ])
 const RETAINED_TOP_LEVEL_DIRECTORIES = new Set(['electron-user-data'])
 const TRANSIENT_TOP_LEVEL_FILES = new Set(['wegent-executor', 'wegent-executor.exe'])
+const TRANSIENT_TOP_LEVEL_ARCHIVE_PATTERN = /\.(?:tar(?:\.(?:gz|zst))?|tgz|zip)$/iu
+const REBUILDABLE_USER_DATA_DIRECTORY_NAMES = new Set(['managed-components', 'managed-runtimes'])
 const RESULT_DIRECTORY_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-(\d+)$/
 
 function removeOptions() {
@@ -152,34 +154,32 @@ async function removeNamedDirectories(root, names) {
   return removed
 }
 
-async function removeHarnessAppProfiles(userDataDirectory) {
-  const instancesRoot = join(userDataDirectory, 'harness-apps', 'instances')
+function isHarnessAppInstance(ancestors) {
+  return ancestors.some(
+    (name, index) => name === 'harness-apps' && ancestors[index + 1] === 'instances'
+  )
+}
+
+async function removeRebuildableUserDataDirectories(root, ancestors = []) {
   let removed = 0
-  for (const entry of await directoryEntries(instancesRoot)) {
+  for (const entry of await directoryEntries(root)) {
     if (!entry.isDirectory()) continue
-    const profiles = join(instancesRoot, entry.name, 'profiles')
-    const entries = await directoryEntries(profiles)
-    if (entries.length === 0) continue
-    await removePath(profiles)
-    removed += 1
+    const path = join(root, entry.name)
+    const removeProfiles =
+      entry.name === 'profiles' &&
+      (['dsh-core', 'Harness'].includes(basename(root)) || isHarnessAppInstance(ancestors))
+    if (REBUILDABLE_USER_DATA_DIRECTORY_NAMES.has(entry.name) || removeProfiles) {
+      await removePath(path)
+      removed += 1
+      continue
+    }
+    removed += await removeRebuildableUserDataDirectories(path, [...ancestors, entry.name])
   }
   return removed
 }
 
 async function compactElectronUserData(userDataDirectory) {
-  let removed = 0
-  const exactDirectories = [
-    join(userDataDirectory, 'managed-components'),
-    join(userDataDirectory, 'managed-runtimes'),
-    join(userDataDirectory, 'dsh-core', 'profiles'),
-  ]
-  for (const directory of exactDirectories) {
-    const entries = await directoryEntries(directory)
-    if (entries.length === 0) continue
-    await removePath(directory)
-    removed += 1
-  }
-  removed += await removeHarnessAppProfiles(userDataDirectory)
+  let removed = await removeRebuildableUserDataDirectories(userDataDirectory)
   removed += await removeNamedDirectories(userDataDirectory, CACHE_DIRECTORY_NAMES)
   return removed
 }
@@ -210,7 +210,10 @@ export async function compactDesktopE2EResult(resultDirectory) {
   let removed = 0
   for (const entry of await directoryEntries(resultDirectory)) {
     const removeDirectory = entry.isDirectory() && !RETAINED_TOP_LEVEL_DIRECTORIES.has(entry.name)
-    const removeFile = entry.isFile() && TRANSIENT_TOP_LEVEL_FILES.has(entry.name)
+    const removeFile =
+      entry.isFile() &&
+      (TRANSIENT_TOP_LEVEL_FILES.has(entry.name) ||
+        TRANSIENT_TOP_LEVEL_ARCHIVE_PATTERN.test(entry.name))
     if (!removeDirectory && !removeFile) continue
     await removePath(join(resultDirectory, entry.name))
     removed += 1

--- a/wework/scripts/desktop-e2e-result-retention.test.mjs
+++ b/wework/scripts/desktop-e2e-result-retention.test.mjs
@@ -71,11 +71,16 @@ describe('desktop E2E result retention', () => {
       'electron-user-data/harness-apps/instances/app-1/profiles',
       'electron-user-data/managed-components',
       'electron-user-data/managed-runtimes',
+      'electron-user-data/plugin-development/dev-1/user-data/dsh-core/profiles',
+      'electron-user-data/plugin-development/dev-1/user-data/managed-components',
+      'electron-user-data/plugin-development/dev-1/user-data/managed-runtimes',
     ]
     await Promise.all(
       transientUserDataDirectories.map(path => createDirectoryWithFile(join(resultDirectory, path)))
     )
     await writeFile(join(resultDirectory, 'wegent-executor'), 'binary\n')
+    await writeFile(join(resultDirectory, 'component-update.tar.gz'), 'archive\n')
+    await writeFile(join(resultDirectory, 'dws-native.zip'), 'archive\n')
     await writeFile(join(resultDirectory, 'app.log'), 'diagnostic\n')
     await createDirectoryWithFile(join(resultDirectory, 'electron-user-data', 'Local Storage'))
 
@@ -89,6 +94,8 @@ describe('desktop E2E result retention', () => {
       await expectMissing(join(resultDirectory, path))
     }
     await expectMissing(join(resultDirectory, 'wegent-executor'))
+    await expectMissing(join(resultDirectory, 'component-update.tar.gz'))
+    await expectMissing(join(resultDirectory, 'dws-native.zip'))
     await expectExists(join(resultDirectory, 'app.log'))
     await expectExists(join(resultDirectory, 'electron-user-data', 'Local Storage', 'payload'))
   })
@@ -99,15 +106,36 @@ describe('desktop E2E result retention', () => {
     const managedComponents = join(
       resultDirectory,
       'electron-user-data',
+      'plugin-development',
+      'dev-1',
+      'user-data',
       'managed-components',
       'composed',
       'wework-core-plugins'
     )
-    const cache = join(resultDirectory, 'electron-user-data', 'Cache')
+    const nestedProfiles = join(
+      resultDirectory,
+      'electron-user-data',
+      'plugin-development',
+      'dev-1',
+      'user-data',
+      'dsh-core',
+      'profiles'
+    )
+    const cache = join(
+      resultDirectory,
+      'electron-user-data',
+      'plugin-development',
+      'dev-1',
+      'user-data',
+      'Cache'
+    )
     const workspace = join(resultDirectory, 'workspace')
     await createDirectoryWithFile(managedComponents)
+    await createDirectoryWithFile(nestedProfiles)
     await createDirectoryWithFile(cache)
     await createDirectoryWithFile(workspace)
+    await writeFile(join(resultDirectory, 'dws-native.zip'), 'archive\n')
     await writeFile(join(resultDirectory, 'app.log'), 'diagnostic\n')
 
     await execFileAsync(
@@ -115,9 +143,20 @@ describe('desktop E2E result retention', () => {
       [resultRoot]
     )
 
-    await expectMissing(join(resultDirectory, 'electron-user-data', 'managed-components'))
+    await expectMissing(
+      join(
+        resultDirectory,
+        'electron-user-data',
+        'plugin-development',
+        'dev-1',
+        'user-data',
+        'managed-components'
+      )
+    )
+    await expectMissing(nestedProfiles)
     await expectMissing(cache)
     await expectMissing(workspace)
+    await expectMissing(join(resultDirectory, 'dws-native.zip'))
     await expectExists(join(resultDirectory, 'app.log'))
   })
 

--- a/wework/scripts/desktop-e2e-result-retention.test.mjs
+++ b/wework/scripts/desktop-e2e-result-retention.test.mjs
@@ -1,6 +1,8 @@
+import { execFile } from 'node:child_process'
 import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { promisify } from 'node:util'
 
 import { afterEach, describe, expect, test } from 'vitest'
 
@@ -12,6 +14,7 @@ import {
 } from '../e2e/desktop/result-retention.mjs'
 
 const roots = []
+const execFileAsync = promisify(execFile)
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
@@ -52,16 +55,25 @@ describe('desktop E2E result retention', () => {
     const resultDirectory = join(await temporaryRoot(), '2026-09-02T00-00-00-000Z-123')
     const transientDirectories = [
       'WeWork-Electron-E2E-123.app',
+      'cloud-executor-home',
       'executor-home',
       'harness-runtime',
       'node-runtime',
-      'electron-user-data/Cache',
-      'electron-user-data/dsh-core/profiles',
-      'electron-user-data/harness-apps/instances/app-1/profiles',
-      'electron-user-data/managed-runtimes',
+      'simulated-device-b',
+      'workspace',
     ]
     await Promise.all(
       transientDirectories.map(path => createDirectoryWithFile(join(resultDirectory, path)))
+    )
+    const transientUserDataDirectories = [
+      'electron-user-data/Cache',
+      'electron-user-data/dsh-core/profiles',
+      'electron-user-data/harness-apps/instances/app-1/profiles',
+      'electron-user-data/managed-components',
+      'electron-user-data/managed-runtimes',
+    ]
+    await Promise.all(
+      transientUserDataDirectories.map(path => createDirectoryWithFile(join(resultDirectory, path)))
     )
     await writeFile(join(resultDirectory, 'wegent-executor'), 'binary\n')
     await writeFile(join(resultDirectory, 'app.log'), 'diagnostic\n')
@@ -73,9 +85,40 @@ describe('desktop E2E result retention', () => {
     for (const path of transientDirectories) {
       await expectMissing(join(resultDirectory, path))
     }
+    for (const path of transientUserDataDirectories) {
+      await expectMissing(join(resultDirectory, path))
+    }
     await expectMissing(join(resultDirectory, 'wegent-executor'))
     await expectExists(join(resultDirectory, 'app.log'))
     await expectExists(join(resultDirectory, 'electron-user-data', 'Local Storage', 'payload'))
+  })
+
+  test('prunes managed components after an interrupted desktop run', async () => {
+    const resultRoot = await temporaryRoot()
+    const resultDirectory = join(resultRoot, '2026-09-02T00-00-00-000Z-321')
+    const managedComponents = join(
+      resultDirectory,
+      'electron-user-data',
+      'managed-components',
+      'composed',
+      'wework-core-plugins'
+    )
+    const cache = join(resultDirectory, 'electron-user-data', 'Cache')
+    const workspace = join(resultDirectory, 'workspace')
+    await createDirectoryWithFile(managedComponents)
+    await createDirectoryWithFile(cache)
+    await createDirectoryWithFile(workspace)
+    await writeFile(join(resultDirectory, 'app.log'), 'diagnostic\n')
+
+    await execFileAsync(
+      resolve(import.meta.dirname, '../../.github/scripts/prune-wework-desktop-e2e-diagnostics.sh'),
+      [resultRoot]
+    )
+
+    await expectMissing(join(resultDirectory, 'electron-user-data', 'managed-components'))
+    await expectMissing(cache)
+    await expectMissing(workspace)
+    await expectExists(join(resultDirectory, 'app.log'))
   })
 
   test('compacts inactive results without touching a live desktop run', async () => {


### PR DESCRIPTION
## Summary
- remove rebuildable top-level desktop E2E environments while retaining logs, screenshots, request snapshots, and sanitized Electron state
- remove materialized managed components during normal and interrupted-run cleanup, with upload exclusions as a teardown-failure safeguard
- compress every desktop diagnostics artifact and document the 20 MiB target

## Verification
- `pnpm --filter wework test scripts/desktop-e2e-result-retention.test.mjs` (7 tests passed)
- `pnpm --filter wework exec eslint e2e/desktop/result-retention.mjs scripts/desktop-e2e-result-retention.test.mjs`
- Prettier and shell syntax checks passed
- real CI artifact sample: 112.26 MiB unpacked before cleanup, 10.80 MiB retained, 3.73 MiB compressed after cleanup
- pre-push Wework static checks, unit tests, and script tests passed

Task: WEWORKC2FA61-537