### PR TITLE
fix(wework): stop completed tool shimmer

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -57,6 +57,35 @@ describe('ToolBlockItem', () => {
     expect(screen.getByText('3.3s')).toBeInTheDocument()
   })
 
+  test('removes the activity shimmer when a tool reaches a terminal status', () => {
+    const runningBlock: ProcessingBlock = {
+      id: 'tool-shimmer-lifecycle',
+      subtaskId: 1,
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: 'gh api repos/example/actions/runs/1' },
+      status: 'streaming',
+      createdAt: 1770000000000,
+    }
+    const { rerender } = render(<ToolBlockItem block={runningBlock} />)
+
+    expect(screen.getByText(/正在运行 gh api/)).toHaveClass('tool-activity-shimmer')
+
+    rerender(
+      <ToolBlockItem
+        block={{
+          ...runningBlock,
+          status: 'done',
+          completedAt: 1770000000678,
+        }}
+      />
+    )
+
+    const completedLabel = screen.getByText(/运行 gh api/)
+    expect(completedLabel).not.toHaveClass('tool-activity-shimmer')
+    expect(completedLabel.querySelector('.activity-shimmer-highlight')).not.toBeInTheDocument()
+  })
+
   test('hides nested shell launchers from the command summary', () => {
     render(
       <ToolBlockItem

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -53,7 +53,6 @@ const RECONNECTING_DISPLAY_DELAY_MS = 10_000
 interface ToolBlockItemProps {
   block: ProcessingBlock
   compact?: boolean
-  shimmer?: boolean
   durationStartedAt?: number
   durationEndAt?: number
   fileEditDurations?: FileEditDurationsByBlock
@@ -69,7 +68,6 @@ interface ToolBlockItemProps {
 export function ToolBlockItem({
   block,
   compact = false,
-  shimmer = false,
   durationStartedAt,
   durationEndAt,
   fileEditDurations,
@@ -123,7 +121,6 @@ export function ToolBlockItem({
     return (
       <ProcessFileChangesBlockItem
         block={block}
-        shimmer={shimmer}
         fileEditDurations={fileEditDurations}
         onExpandedChange={onExpandedChange}
       />
@@ -195,7 +192,7 @@ export function ToolBlockItem({
   const labelContent = (
     <>
       {icon}
-      {isRunning || shimmer ? (
+      {isRunning ? (
         <ActivityShimmerText variant="tool" className="min-w-0 truncate">
           {label}
         </ActivityShimmerText>
@@ -298,12 +295,10 @@ function PlanBlockItem({
 
 function ProcessFileChangesBlockItem({
   block,
-  shimmer,
   fileEditDurations,
   onExpandedChange,
 }: {
   block: Extract<ProcessingBlock, { type: 'file_changes' }>
-  shimmer: boolean
   fileEditDurations?: FileEditDurationsByBlock
   onExpandedChange?: (expanded: boolean) => void
 }) {
@@ -341,7 +336,7 @@ function ProcessFileChangesBlockItem({
                 className="group relative z-10 flex min-h-8 w-full max-w-full items-center gap-1.5 text-text-secondary disabled:cursor-default"
               >
                 <FileDiff className="h-4 w-4 shrink-0" strokeWidth={1.7} />
-                {isRunning || shimmer ? (
+                {isRunning ? (
                   <ActivityShimmerText variant="tool" className="min-w-0 truncate">
                     {fileChangeRowLabel(file, t, isRunning)}
                   </ActivityShimmerText>

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -536,11 +536,10 @@ function LiveProcessingPreview({
           overflowY: hasExpandedDetail ? 'visible' : 'auto',
         }}
       >
-        {rows.map((row, index) => (
+        {rows.map(row => (
           <LiveProcessingPreviewRow
             key={row.id}
             row={row}
-            shimmer={isProcessingRowRunning(row) && index === rows.length - 1}
             onOpenWorkspaceFile={onOpenWorkspaceFile}
             fileEditDurations={fileEditDurations}
             onExpandedChange={updateExpandedRow}
@@ -562,7 +561,6 @@ function LiveProcessingPreview({
 
 function LiveProcessingPreviewRow({
   row,
-  shimmer,
   durationStartedAt,
   durationEndAt,
   fileEditDurations,
@@ -571,7 +569,6 @@ function LiveProcessingPreviewRow({
   stateKey,
 }: {
   row: ProcessingDisplayRow
-  shimmer: boolean
   durationStartedAt?: number
   durationEndAt?: number
   fileEditDurations: FileEditDurationsByBlock
@@ -605,7 +602,6 @@ function LiveProcessingPreviewRow({
       <ToolBlockItem
         block={row.block}
         compact
-        shimmer={shimmer}
         durationStartedAt={durationStartedAt}
         durationEndAt={durationEndAt}
         fileEditDurations={fileEditDurations}
@@ -619,7 +615,6 @@ function LiveProcessingPreviewRow({
   return (
     <ToolBlockItem
       block={row.block}
-      shimmer={shimmer}
       durationStartedAt={durationStartedAt}
       durationEndAt={durationEndAt}
       fileEditDurations={fileEditDurations}
@@ -627,13 +622,6 @@ function LiveProcessingPreviewRow({
       stateKey={stateKey}
     />
   )
-}
-
-function isProcessingRowRunning(row: ProcessingDisplayRow): boolean {
-  if (row.type === 'activity_group') {
-    return row.blocks.some(block => block.status !== 'done' && block.status !== 'error')
-  }
-  return row.block.status !== 'done' && row.block.status !== 'error'
 }
 
 function countProcessingActivityKinds(rows: ProcessingDisplayRow[]) {


### PR DESCRIPTION
## Summary

- remove the redundant external `shimmer` override from tool rows
- make tool activity shimmer depend exclusively on non-terminal block status
- add a regression test covering the `streaming` to `done` transition and removal of the shimmer DOM layer

## Verification

- `pnpm --filter wework test src/components/chat/blocks/ToolBlockItem.test.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx` (82 passed)
- `pnpm --filter wework exec prettier --check src/components/chat/blocks/ToolBlockItem.tsx src/components/chat/blocks/ToolBlocksDisplay.tsx src/components/chat/blocks/ToolBlockItem.test.tsx`
- `pnpm --filter wework exec eslint src/components/chat/blocks/ToolBlockItem.tsx src/components/chat/blocks/ToolBlocksDisplay.tsx src/components/chat/blocks/ToolBlockItem.test.tsx`
- isolated Electron production build and WebView startup through `pnpm --filter wework ai:verify start`
- production bundle inspection confirms there is no terminal-status-or-external-shimmer override

## Known baseline issue

`pnpm --filter wework typecheck` is currently blocked by existing duplicate React/csstype dependency type errors in unrelated files including `dsh/ui-home-focus/src/home.tsx`, `AssistantMarkdown.tsx`, and workspace file tree components. This change introduces no type errors in the modified files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Activity shimmer effects now appear only while tool activity is running.
  - Shimmer is removed when a tool reaches a completed or other terminal status.
  - Live processing previews no longer apply shimmer to the last running row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->