### PR TITLE
fix(executor-manager): harden Redis pool handling

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -979,6 +979,14 @@ jobs:
         run: |
           curl -f http://localhost:8100/health > /dev/null 2>&1 || (cat backend/chat_shell.log && exit 1)
 
+      - name: Run Executor Manager resilience E2E tests
+        working-directory: ./executor_manager
+        env:
+          E2E_REDIS_URL: redis://localhost:6379/15
+          OTEL_ENABLED: "false"
+          PYTHONPATH: ${{ github.workspace }}
+        run: uv run pytest e2e_tests/ --no-cov -v
+
       - name: Run Executor E2E tests
         env:
           PLATFORM_E2E_IMAGE: ${{ needs.prepare-platform-e2e-image.outputs.image }}

--- a/executor_manager/common/config.py
+++ b/executor_manager/common/config.py
@@ -56,6 +56,22 @@ def _get_redis_protocol() -> int:
     return protocol
 
 
+def _get_positive_int_env(name: str, default: int) -> int:
+    """Read a positive integer environment variable."""
+    value = int(os.getenv(name, str(default)))
+    if value < 1:
+        raise ValueError(f"{name} must be greater than 0")
+    return value
+
+
+def _get_positive_float_env(name: str, default: float) -> float:
+    """Read a positive floating-point environment variable."""
+    value = float(os.getenv(name, str(default)))
+    if value <= 0:
+        raise ValueError(f"{name} must be greater than 0")
+    return value
+
+
 @dataclass(frozen=True)
 class RedisConfig:
     """Redis connection configuration."""
@@ -66,8 +82,28 @@ class RedisConfig:
     # socket_timeout must be larger than BRPOP timeout to avoid timeout conflicts
     # BRPOP blocks for up to TASK_QUEUE_DEQUEUE_TIMEOUT (default 5s), so socket_timeout
     # should be significantly larger to account for the blocking operation plus buffer
-    socket_timeout: float = 30.0
-    connect_timeout: float = 5.0
+    socket_timeout: float = field(
+        default_factory=lambda: _get_positive_float_env("REDIS_SOCKET_TIMEOUT", 30.0)
+    )
+    async_socket_timeout: float = field(
+        default_factory=lambda: _get_positive_float_env(
+            "REDIS_ASYNC_SOCKET_TIMEOUT", 5.0
+        )
+    )
+    connect_timeout: float = field(
+        default_factory=lambda: _get_positive_float_env("REDIS_CONNECT_TIMEOUT", 3.0)
+    )
+    sync_max_connections: int = field(
+        default_factory=lambda: _get_positive_int_env("REDIS_SYNC_MAX_CONNECTIONS", 100)
+    )
+    async_max_connections: int = field(
+        default_factory=lambda: _get_positive_int_env(
+            "REDIS_ASYNC_MAX_CONNECTIONS", 200
+        )
+    )
+    pool_wait_timeout: float = field(
+        default_factory=lambda: _get_positive_float_env("REDIS_POOL_WAIT_TIMEOUT", 2.0)
+    )
     encoding: str = "utf-8"
     decode_responses: bool = True
     # RESP2 avoids the HELLO handshake and remains compatible with older

--- a/executor_manager/common/redis_factory.py
+++ b/executor_manager/common/redis_factory.py
@@ -11,7 +11,7 @@ eliminating duplicate connection logic across service classes.
 import asyncio
 import threading
 import time
-from typing import Callable, Optional, TypeVar
+from typing import Awaitable, Callable, Optional
 
 import redis
 import redis.asyncio as aioredis
@@ -20,8 +20,6 @@ from executor_manager.common.config import RedisConfig, get_config
 from shared.logger import setup_logger
 
 logger = setup_logger(__name__)
-
-T = TypeVar("T", redis.Redis, aioredis.Redis)
 
 
 class RedisClientFactory:
@@ -37,6 +35,7 @@ class RedisClientFactory:
     _sync_client: Optional[redis.Redis] = None
     _async_client: Optional[aioredis.Redis] = None
     _lock = threading.Lock()
+    _async_lock = asyncio.Lock()
     _config: Optional[RedisConfig] = None
 
     @classmethod
@@ -49,33 +48,78 @@ class RedisClientFactory:
     @classmethod
     def _create_sync_client(cls, config: RedisConfig) -> redis.Redis:
         """Create a synchronous Redis client instance."""
-        return redis.from_url(
+        logger.info(
+            "[RedisClientFactory] Creating Sync Redis pool: "
+            f"max_connections={config.sync_max_connections}, "
+            f"wait_timeout={config.pool_wait_timeout}s, "
+            f"socket_timeout={config.socket_timeout}s, "
+            f"connect_timeout={config.connect_timeout}s"
+        )
+        pool = redis.BlockingConnectionPool.from_url(
             config.url,
+            max_connections=config.sync_max_connections,
+            timeout=config.pool_wait_timeout,
             encoding=config.encoding,
             decode_responses=config.decode_responses,
             socket_timeout=config.socket_timeout,
             socket_connect_timeout=config.connect_timeout,
             protocol=config.protocol,
         )
+        return redis.Redis(connection_pool=pool)
 
     @classmethod
     def _create_async_client(cls, config: RedisConfig) -> aioredis.Redis:
         """Create an async Redis client instance."""
-        return aioredis.from_url(
+        logger.info(
+            "[RedisClientFactory] Creating Async Redis pool: "
+            f"max_connections={config.async_max_connections}, "
+            f"wait_timeout={config.pool_wait_timeout}s, "
+            f"socket_timeout={config.async_socket_timeout}s, "
+            f"connect_timeout={config.connect_timeout}s"
+        )
+        pool = aioredis.BlockingConnectionPool.from_url(
             config.url,
+            max_connections=config.async_max_connections,
+            timeout=config.pool_wait_timeout,
             encoding=config.encoding,
             decode_responses=config.decode_responses,
+            socket_timeout=config.async_socket_timeout,
+            socket_connect_timeout=config.connect_timeout,
             protocol=config.protocol,
         )
+        return aioredis.Redis(connection_pool=pool)
+
+    @staticmethod
+    def _close_sync_client(client: redis.Redis) -> None:
+        """Close a synchronous client and every connection owned by its pool."""
+        try:
+            client.close()
+            client.connection_pool.disconnect()
+        except Exception as error:
+            logger.warning(
+                "[RedisClientFactory] Failed to close Sync Redis client: "
+                f"{type(error).__name__}: {error}"
+            )
+
+    @staticmethod
+    async def _close_async_client(client: aioredis.Redis) -> None:
+        """Close an asynchronous client and every connection owned by its pool."""
+        try:
+            await client.aclose(close_connection_pool=True)
+        except Exception as error:
+            logger.warning(
+                "[RedisClientFactory] Failed to close Async Redis client: "
+                f"{type(error).__name__}: {error}"
+            )
 
     @classmethod
     def _retry_sync(
         cls,
-        create_fn: Callable[[], T],
-        verify_fn: Callable[[T], None],
+        create_fn: Callable[[], redis.Redis],
+        verify_fn: Callable[[redis.Redis], None],
         verify_connection: bool,
         client_type: str,
-    ) -> Optional[T]:
+    ) -> Optional[redis.Redis]:
         """Execute sync client creation with retry logic.
 
         Args:
@@ -91,6 +135,7 @@ class RedisClientFactory:
         last_error: Optional[Exception] = None
 
         for attempt in range(config.max_retries):
+            client: Optional[redis.Redis] = None
             try:
                 client = create_fn()
 
@@ -107,12 +152,16 @@ class RedisClientFactory:
                     )
                 return client
 
-            except Exception as e:
-                last_error = e
+            except Exception as error:
+                last_error = error
+                if client is not None:
+                    cls._close_sync_client(client)
                 if attempt < config.max_retries - 1:
                     logger.warning(
-                        f"[RedisClientFactory] {client_type} connection attempt {attempt + 1}/{config.max_retries} "
-                        f"failed: {e}, retrying in {config.retry_delay}s..."
+                        f"[RedisClientFactory] {client_type} connection attempt "
+                        f"{attempt + 1}/{config.max_retries} failed: "
+                        f"{type(error).__name__}: {error}, retrying in "
+                        f"{config.retry_delay}s..."
                     )
                     time.sleep(config.retry_delay)
 
@@ -124,11 +173,11 @@ class RedisClientFactory:
     @classmethod
     async def _retry_async(
         cls,
-        create_fn: Callable[[], T],
-        verify_fn: Callable[[T], any],
+        create_fn: Callable[[], aioredis.Redis],
+        verify_fn: Callable[[aioredis.Redis], Awaitable[object]],
         verify_connection: bool,
         client_type: str,
-    ) -> Optional[T]:
+    ) -> Optional[aioredis.Redis]:
         """Execute async client creation with retry logic.
 
         Args:
@@ -144,6 +193,7 @@ class RedisClientFactory:
         last_error: Optional[Exception] = None
 
         for attempt in range(config.max_retries):
+            client: Optional[aioredis.Redis] = None
             try:
                 client = create_fn()
 
@@ -160,12 +210,16 @@ class RedisClientFactory:
                     )
                 return client
 
-            except Exception as e:
-                last_error = e
+            except Exception as error:
+                last_error = error
+                if client is not None:
+                    await cls._close_async_client(client)
                 if attempt < config.max_retries - 1:
                     logger.warning(
-                        f"[RedisClientFactory] {client_type} connection attempt {attempt + 1}/{config.max_retries} "
-                        f"failed: {e}, retrying in {config.retry_delay}s..."
+                        f"[RedisClientFactory] {client_type} connection attempt "
+                        f"{attempt + 1}/{config.max_retries} failed: "
+                        f"{type(error).__name__}: {error}, retrying in "
+                        f"{config.retry_delay}s..."
                     )
                     await asyncio.sleep(config.retry_delay)
 
@@ -184,16 +238,10 @@ class RedisClientFactory:
         Returns:
             Redis client if successful, None if connection failed
         """
-        # Check if existing client is still connected
+        # Redis reconnects individual sockets on demand. Reuse the process-wide
+        # pool instead of adding a PING to each service lookup.
         if cls._sync_client is not None:
-            try:
-                cls._sync_client.ping()
-                return cls._sync_client
-            except Exception:
-                logger.warning(
-                    "[RedisClientFactory] Connection lost, attempting reconnect..."
-                )
-                cls._sync_client = None
+            return cls._sync_client
 
         with cls._lock:
             # Double-check after acquiring lock
@@ -225,29 +273,48 @@ class RedisClientFactory:
         Returns:
             Async Redis client if successful, None if connection failed
         """
-        # Check if existing client is still connected
+        # The async lock prevents a startup burst from creating several pools.
         if cls._async_client is not None:
-            try:
-                await cls._async_client.ping()
+            return cls._async_client
+
+        async with cls._async_lock:
+            if cls._async_client is not None:
                 return cls._async_client
-            except Exception:
-                logger.warning(
-                    "[RedisClientFactory] Async connection lost, attempting reconnect..."
-                )
-                cls._async_client = None
 
-        config = cls._get_config()
-        client = await cls._retry_async(
-            create_fn=lambda: cls._create_async_client(config),
-            verify_fn=lambda c: c.ping(),
-            verify_connection=verify_connection,
-            client_type="Async",
-        )
+            config = cls._get_config()
+            client = await cls._retry_async(
+                create_fn=lambda: cls._create_async_client(config),
+                verify_fn=lambda c: c.ping(),
+                verify_connection=verify_connection,
+                client_type="Async",
+            )
 
-        if client is not None:
-            cls._async_client = client
+            if client is not None:
+                cls._async_client = client
 
-        return client
+            return client
+
+    @classmethod
+    async def initialize(cls) -> bool:
+        """Warm both process-wide clients before request handling starts."""
+        sync_client = await asyncio.to_thread(cls.get_sync_client)
+        async_client = await cls.get_async_client()
+        return sync_client is not None and async_client is not None
+
+    @classmethod
+    async def close(cls) -> None:
+        """Close process-wide clients during application shutdown."""
+        async with cls._async_lock:
+            async_client = cls._async_client
+            cls._async_client = None
+            if async_client is not None:
+                await cls._close_async_client(async_client)
+
+        with cls._lock:
+            sync_client = cls._sync_client
+            cls._sync_client = None
+            if sync_client is not None:
+                cls._close_sync_client(sync_client)
 
     @classmethod
     def create_client(cls, verify_connection: bool = True) -> Optional[redis.Redis]:
@@ -279,6 +346,7 @@ class RedisClientFactory:
         with cls._lock:
             cls._sync_client = None
             cls._async_client = None
+            cls._async_lock = asyncio.Lock()
             cls._config = None
 
     @classmethod

--- a/executor_manager/e2e_tests/test_redis_pool.py
+++ b/executor_manager/e2e_tests/test_redis_pool.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import time
+import uuid
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+import redis
+import redis.asyncio as aioredis
+
+from executor_manager.common.config import reset_config
+from executor_manager.common.redis_factory import RedisClientFactory
+from executor_manager.routers.routers import app
+from executor_manager.services.heartbeat_manager import HeartbeatManager
+
+
+@pytest.fixture
+async def real_redis_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncGenerator[str, None]:
+    redis_url = os.getenv("E2E_REDIS_URL")
+    if not redis_url:
+        pytest.fail("E2E_REDIS_URL must point to a dedicated real Redis database")
+
+    monkeypatch.setenv("REDIS_URL", redis_url)
+    monkeypatch.setenv("REDIS_SYNC_MAX_CONNECTIONS", "2")
+    monkeypatch.setenv("REDIS_ASYNC_MAX_CONNECTIONS", "2")
+    monkeypatch.setenv("REDIS_POOL_WAIT_TIMEOUT", "0.2")
+    monkeypatch.setenv("REDIS_CONNECT_TIMEOUT", "1")
+    monkeypatch.setenv("REDIS_ASYNC_SOCKET_TIMEOUT", "1")
+    reset_config()
+    RedisClientFactory.reset()
+    HeartbeatManager._instance = None
+
+    try:
+        yield redis_url
+    finally:
+        await RedisClientFactory.close()
+        HeartbeatManager._instance = None
+        reset_config()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_real_pool_exhaustion_returns_503_and_recovers(
+    real_redis_pool: str,
+) -> None:
+    assert await RedisClientFactory.initialize()
+    sync_client = RedisClientFactory._sync_client
+    async_client = RedisClientFactory._async_client
+    assert sync_client is not None
+    assert async_client is not None
+    assert isinstance(sync_client.connection_pool, redis.BlockingConnectionPool)
+    assert isinstance(async_client.connection_pool, aioredis.BlockingConnectionPool)
+    assert sync_client.connection_pool.max_connections == 2
+    assert async_client.connection_pool.max_connections == 2
+    assert async_client.connection_pool.timeout == 0.2
+
+    pool = async_client.connection_pool
+    held_connections = [
+        await pool.get_connection(),
+        await pool.get_connection(),
+    ]
+    heartbeat_id = f"redis-pool-e2e-{uuid.uuid4().hex}"
+    heartbeat_key = f"task:heartbeat:{heartbeat_id}"
+    control_client = aioredis.from_url(real_redis_pool, decode_responses=True)
+
+    try:
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 12345))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://executor-manager",
+        ) as http_client:
+            started_at = time.monotonic()
+            exhausted_response = await http_client.post(
+                f"/executor-manager/tasks/{heartbeat_id}/heartbeat"
+            )
+            exhausted_elapsed = time.monotonic() - started_at
+
+            assert exhausted_response.status_code == 503
+            assert exhausted_response.headers["Retry-After"] == "1"
+            assert exhausted_elapsed < 1.0
+
+            await pool.release(held_connections.pop())
+            recovered_response = await http_client.post(
+                f"/executor-manager/tasks/{heartbeat_id}/heartbeat"
+            )
+
+            assert recovered_response.status_code == 200
+            assert recovered_response.json() == {
+                "status": "ok",
+                "task_id": heartbeat_id,
+            }
+
+        heartbeat_ttl = await control_client.ttl(heartbeat_key)
+        assert 0 < heartbeat_ttl <= 60
+    finally:
+        await control_client.delete(heartbeat_key)
+        await control_client.aclose()
+        for connection in held_connections:
+            await pool.release(connection)

--- a/executor_manager/main.py
+++ b/executor_manager/main.py
@@ -18,6 +18,7 @@ from contextlib import asynccontextmanager
 
 import uvicorn
 
+from executor_manager.common.redis_factory import RedisClientFactory
 from executor_manager.services.sandbox import get_sandbox_manager
 from routers.routers import app  # Import the FastAPI app defined in routes.py
 
@@ -89,6 +90,12 @@ async def lifespan(app):
     task_consumer = None
     offline_consumer = None
 
+    redis_ready = await RedisClientFactory.initialize()
+    if not redis_ready:
+        logger.error(
+            "Redis initialization did not complete; services will retry lazily"
+        )
+
     # Start task queue consumers for async processing
     # Start both online (immediate) and offline (21:00-08:00) consumers
     logger.info(f"Starting task queue consumers for pool '{service_pool}'")
@@ -132,6 +139,9 @@ async def lifespan(app):
     if sandbox_manager:
         logger.info("Stopping SandboxManager...")
         await sandbox_manager.stop_gc_task()
+
+    await RedisClientFactory.close()
+    logger.info("Redis clients closed")
 
     # Shutdown OpenTelemetry
     if otel_config.enabled:

--- a/executor_manager/pyproject.toml
+++ b/executor_manager/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pyjwt==2.8.0",
     "pytz==2024.1",
     "pyyaml==6.0.1",
-    "redis>=5.0.0",
+    "redis==8.1.0",
     "requests==2.31.0",
     "requests-oauthlib==2.0.0",
     "starlette>=0.49.1",

--- a/executor_manager/routers/routers.py
+++ b/executor_manager/routers/routers.py
@@ -1522,6 +1522,11 @@ async def task_heartbeat(task_id: str, http_request: Request):
 
     if not success:
         logger.warning(f"[TaskAPI] Failed to update heartbeat for task {task_id}")
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to update heartbeat",
+            headers={"Retry-After": "1"},
+        )
 
     return {"status": "ok", "task_id": task_id}
 

--- a/executor_manager/routers/sandbox.py
+++ b/executor_manager/routers/sandbox.py
@@ -516,8 +516,9 @@ async def sandbox_heartbeat(sandbox_id: str, http_request: Request):
             f"[SandboxAPI] Failed to update heartbeat for sandbox {sandbox_id}"
         )
         raise HTTPException(
-            status_code=500,
+            status_code=503,
             detail="Failed to update heartbeat",
+            headers={"Retry-After": "1"},
         )
 
     # Get sandbox info to check if Claude configuration should be returned

--- a/executor_manager/services/heartbeat_manager.py
+++ b/executor_manager/services/heartbeat_manager.py
@@ -43,7 +43,7 @@ TASK_HEARTBEAT_KEY = "task:heartbeat:{id}"
 # Heartbeat configuration
 # Key TTL should be slightly longer than heartbeat interval to avoid false positives
 HEARTBEAT_KEY_TTL = int(
-    os.getenv("HEARTBEAT_KEY_TTL", "20")
+    os.getenv("HEARTBEAT_KEY_TTL", "60")
 )  # TTL for heartbeat key (seconds)
 HEARTBEAT_TIMEOUT = int(
     os.getenv("HEARTBEAT_TIMEOUT", "30")
@@ -147,8 +147,12 @@ class HeartbeatManager:
                 f"[HeartbeatManager] Heartbeat updated: type={heartbeat_type.value}, id={heartbeat_id}"
             )
             return True
-        except Exception as e:
-            logger.error(f"[HeartbeatManager] Failed to update heartbeat: {e}")
+        except Exception as error:
+            logger.exception(
+                "[HeartbeatManager] Failed to update heartbeat: "
+                f"error_type={type(error).__name__}, "
+                f"heartbeat_type={heartbeat_type.value}, error={error}"
+            )
             return False
 
     async def check_heartbeat(

--- a/executor_manager/tests/common/test_redis_factory.py
+++ b/executor_manager/tests/common/test_redis_factory.py
@@ -2,25 +2,134 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+
+import pytest
+
 from executor_manager.common.config import RedisConfig
 from executor_manager.common.redis_factory import RedisClientFactory
 
 
-def test_create_sync_client_uses_resp2_protocol_by_default(mocker):
-    """Redis clients must remain compatible with Redis servers without HELLO."""
-    from_url = mocker.patch("executor_manager.common.redis_factory.redis.from_url")
+def test_create_sync_client_uses_bounded_blocking_pool(mocker):
+    """Sync Redis commands should wait briefly instead of failing at capacity."""
+    pool = mocker.MagicMock()
+    from_url = mocker.patch(
+        "executor_manager.common.redis_factory.redis.BlockingConnectionPool.from_url",
+        return_value=pool,
+    )
+    redis_client = mocker.patch("executor_manager.common.redis_factory.redis.Redis")
     config = RedisConfig(url="redis://redis:6379/0")
 
     RedisClientFactory._create_sync_client(config)
 
-    assert from_url.call_args.kwargs["protocol"] == 2
+    from_url.assert_called_once_with(
+        "redis://redis:6379/0",
+        max_connections=100,
+        timeout=2.0,
+        encoding="utf-8",
+        decode_responses=True,
+        socket_timeout=30.0,
+        socket_connect_timeout=3.0,
+        protocol=2,
+    )
+    redis_client.assert_called_once_with(connection_pool=pool)
 
 
-def test_create_async_client_uses_resp2_protocol_by_default(mocker):
-    """Async Redis clients must use the same protocol as sync clients."""
-    from_url = mocker.patch("executor_manager.common.redis_factory.aioredis.from_url")
+def test_create_async_client_uses_larger_bounded_blocking_pool(mocker):
+    """Heartbeat traffic should use the larger async pool and short I/O timeout."""
+    pool = mocker.MagicMock()
+    from_url = mocker.patch(
+        "executor_manager.common.redis_factory.aioredis.BlockingConnectionPool.from_url",
+        return_value=pool,
+    )
+    redis_client = mocker.patch("executor_manager.common.redis_factory.aioredis.Redis")
     config = RedisConfig(url="redis://redis:6379/0")
 
     RedisClientFactory._create_async_client(config)
 
-    assert from_url.call_args.kwargs["protocol"] == 2
+    from_url.assert_called_once_with(
+        "redis://redis:6379/0",
+        max_connections=200,
+        timeout=2.0,
+        encoding="utf-8",
+        decode_responses=True,
+        socket_timeout=5.0,
+        socket_connect_timeout=3.0,
+        protocol=2,
+    )
+    redis_client.assert_called_once_with(connection_pool=pool)
+
+
+def test_redis_pool_limits_can_be_overridden(monkeypatch):
+    monkeypatch.setenv("REDIS_SYNC_MAX_CONNECTIONS", "120")
+    monkeypatch.setenv("REDIS_ASYNC_MAX_CONNECTIONS", "240")
+    monkeypatch.setenv("REDIS_POOL_WAIT_TIMEOUT", "1.5")
+
+    config = RedisConfig()
+
+    assert config.sync_max_connections == 120
+    assert config.async_max_connections == 240
+    assert config.pool_wait_timeout == 1.5
+
+
+def test_redis_pool_limits_must_be_positive(monkeypatch):
+    monkeypatch.setenv("REDIS_ASYNC_MAX_CONNECTIONS", "0")
+
+    with pytest.raises(
+        ValueError, match="REDIS_ASYNC_MAX_CONNECTIONS must be greater than 0"
+    ):
+        RedisConfig()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_initialization_creates_one_client(mocker):
+    client = mocker.MagicMock()
+    client.ping = mocker.AsyncMock(return_value=True)
+    create_client = mocker.patch.object(
+        RedisClientFactory,
+        "_create_async_client",
+        return_value=client,
+    )
+
+    clients = await asyncio.gather(
+        *(RedisClientFactory.get_async_client() for _ in range(20))
+    )
+
+    assert clients == [client] * 20
+    create_client.assert_called_once()
+    client.ping.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_failed_async_verification_closes_candidate(mocker):
+    client = mocker.MagicMock()
+    client.ping = mocker.AsyncMock(side_effect=ConnectionError("unavailable"))
+    client.aclose = mocker.AsyncMock()
+    mocker.patch.object(
+        RedisClientFactory,
+        "_create_async_client",
+        return_value=client,
+    )
+    RedisClientFactory._config = RedisConfig(max_retries=1)
+
+    result = await RedisClientFactory.get_async_client()
+
+    assert result is None
+    client.aclose.assert_awaited_once_with(close_connection_pool=True)
+
+
+@pytest.mark.asyncio
+async def test_close_releases_cached_connection_pools(mocker):
+    sync_client = mocker.MagicMock()
+    async_client = mocker.MagicMock()
+    async_client.aclose = mocker.AsyncMock()
+    RedisClientFactory._sync_client = sync_client
+    RedisClientFactory._async_client = async_client
+
+    await RedisClientFactory.close()
+
+    sync_client.close.assert_called_once_with()
+    sync_client.connection_pool.disconnect.assert_called_once_with()
+    async_client.aclose.assert_awaited_once_with(close_connection_pool=True)
+    assert RedisClientFactory._sync_client is None
+    assert RedisClientFactory._async_client is None

--- a/executor_manager/tests/routers/test_heartbeat_routes.py
+++ b/executor_manager/tests/routers/test_heartbeat_routes.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from executor_manager.routers import routers
+from executor_manager.routers import sandbox as sandbox_router
+
+
+@pytest.mark.asyncio
+async def test_task_heartbeat_returns_retryable_error_when_redis_update_fails(mocker):
+    heartbeat_manager = mocker.MagicMock()
+    heartbeat_manager.update_heartbeat = mocker.AsyncMock(return_value=False)
+    mocker.patch(
+        "executor_manager.services.heartbeat_manager.get_heartbeat_manager",
+        return_value=heartbeat_manager,
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await routers.task_heartbeat(
+            "task-1",
+            SimpleNamespace(client=SimpleNamespace(host="127.0.0.1")),
+        )
+
+    assert raised.value.status_code == 503
+    assert raised.value.headers == {"Retry-After": "1"}
+
+
+@pytest.mark.asyncio
+async def test_sandbox_heartbeat_returns_retryable_error_when_redis_update_fails(
+    mocker,
+):
+    heartbeat_manager = mocker.MagicMock()
+    heartbeat_manager.update_heartbeat = mocker.AsyncMock(return_value=False)
+    mocker.patch(
+        "executor_manager.services.heartbeat_manager.get_heartbeat_manager",
+        return_value=heartbeat_manager,
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await sandbox_router.sandbox_heartbeat(
+            "sandbox-1",
+            SimpleNamespace(client=SimpleNamespace(host="127.0.0.1")),
+        )
+
+    assert raised.value.status_code == 503
+    assert raised.value.headers == {"Retry-After": "1"}

--- a/executor_manager/uv.lock
+++ b/executor_manager/uv.lock
@@ -506,7 +506,7 @@ requires-dist = [
     { name = "pyjwt", specifier = "==2.8.0" },
     { name = "pytz", specifier = "==2024.1" },
     { name = "pyyaml", specifier = "==6.0.1" },
-    { name = "redis", specifier = ">=5.0.0" },
+    { name = "redis", specifier = "==8.1.0" },
     { name = "requests", specifier = "==2.31.0" },
     { name = "requests-oauthlib", specifier = "==2.0.0" },
     { name = "socksio", specifier = ">=1.0.0" },
@@ -1473,14 +1473,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.1.0"
+version = "8.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/c8/983d5c6579a411d8a99bc5823cc5712768859b5ce2c8afe1a65b37832c81/redis-7.1.0.tar.gz", hash = "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c", size = 4796669, upload-time = "2025-11-19T15:54:39.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/f0/8956f8a86b20d7bb9d6ac0187cf4cd54d8065bc9a1a09eb8011d4d326596/redis-7.1.0-py3-none-any.whl", hash = "sha256:23c52b208f92b56103e17c5d06bdc1a6c2c0b3106583985a76a18f83b265de2b", size = 354159, upload-time = "2025-11-19T15:54:38.064Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace fail-fast Redis pools with bounded blocking pools shared for the process lifetime
- make sync/async pool limits, pool wait timeout, and socket/connect timeouts configurable
- initialize and close Redis clients with the Executor Manager lifespan
- return retryable HTTP 503 responses when heartbeat persistence is temporarily unavailable
- extend the heartbeat TTL to tolerate short scheduling or Redis stalls
- add unit coverage plus a real-Redis exhaustion/recovery E2E test invoked by GitHub CI

## Default configuration

| Variable | Default |
| --- | ---: |
| `REDIS_SYNC_MAX_CONNECTIONS` | 100 |
| `REDIS_ASYNC_MAX_CONNECTIONS` | 200 |
| `REDIS_POOL_WAIT_TIMEOUT` | 2s |
| `REDIS_CONNECT_TIMEOUT` | 3s |
| `REDIS_ASYNC_SOCKET_TIMEOUT` | 5s |
| `REDIS_SOCKET_TIMEOUT` | 30s |
| `HEARTBEAT_KEY_TTL` | 60s |

## Verification

- `uv lock --check`
- Black and isort checks for all changed Python files
- `OTEL_ENABLED=false PYTHONPATH=.. uv run pytest tests/` — 276 passed
- dedicated local Redis: `E2E_REDIS_URL=redis://127.0.0.1:16379/15 OTEL_ENABLED=false PYTHONPATH=.. uv run pytest e2e_tests/ --no-cov -v` — 1 passed
- GitHub Actions workflow YAML parse
- binary full-index patch reverse-apply check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Heartbeat failures now return a retryable 503 response with a one-second retry interval instead of indicating success.
  * Improved connection handling helps maintain service availability during temporary Redis connectivity or capacity issues.
  * Heartbeat records remain available longer by default, improving resilience during short interruptions.

* **Improvements**
  * Redis connection pools now support configurable timeouts and capacity limits.
  * Application startup and shutdown now initialize and close shared Redis connections cleanly.

* **Tests**
  * Added coverage for connection-pool exhaustion, recovery, initialization, cleanup, and retryable heartbeat failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->