### PR TITLE
fix(wework): anchor board hover conversations at bottom

### DIFF
--- a/wework/e2e/desktop/scenarios/board-focus-view.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/board-focus-view.scenario.mjs
@@ -179,6 +179,10 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
         text: '专注视图',
         timeoutMs: uiTimeoutMs,
       })
+      await control.command('waitFor', '[data-testid="cloud-todo-board-loading"]', {
+        visible: false,
+        timeoutMs: uiTimeoutMs,
+      })
 
       await control.command('click', '[data-testid="cloud-todo-column-empty-add-inbox"]')
       await control.command('waitFor', '[data-testid="cloud-todo-column-quick-create-inbox"]', {
@@ -344,6 +348,21 @@ export function createDesktopScenario({ captureScreenshot, uiTimeoutMs, workspac
         visible: true,
         timeoutMs: uiTimeoutMs,
       })
+      const [popupScrollMetrics] = JSON.parse(
+        await control.command(
+          'getElementMetrics',
+          `${progressPopup} [data-testid="right-workspace-chat-scroll-area"]`
+        )
+      )
+      assert.equal(
+        popupScrollMetrics.scrollOrigin,
+        'bottom',
+        `The progress popup did not use bottom-origin scrolling: ${JSON.stringify(popupScrollMetrics)}`
+      )
+      assert.ok(
+        Math.abs(popupScrollMetrics.scrollTop) <= 2,
+        `The progress popup did not start at position zero: ${JSON.stringify(popupScrollMetrics)}`
+      )
       const popupText = await control.command('getText', progressPopup)
       assert.ok(popupText.includes("'正在验证运行中卡片'"))
       assert.ok(

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -1363,6 +1363,11 @@ export function createDesktopScenario({
         `${moonshotPopupConversation} [data-testid="right-workspace-chat-scroll-area"]`
       )
     )
+    assert.equal(
+      popupScrollMetrics.scrollOrigin,
+      'bottom',
+      `The board popup did not use the task conversation bottom-origin scroll model: ${JSON.stringify(popupScrollMetrics)}`
+    )
     const popupDistanceFromBottom =
       popupScrollMetrics.scrollOrigin === 'bottom'
         ? Math.max(

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -124,6 +124,28 @@ describe('ScrollableMessageArea', () => {
     expect(screen.getByTestId('chat-message-scroll-area-content')).not.toHaveClass('justify-end')
   })
 
+  test('uses scroll position zero as the bottom for an internal bottom-origin preview', () => {
+    render(
+      <ScrollableMessageArea
+        scrollOrigin="bottom"
+        messages={[
+          {
+            id: 'bottom-origin-preview',
+            role: 'assistant',
+            content: '最新消息直接出现在底部',
+            status: 'done',
+            createdAt: '2026-09-10T00:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    expect(scroller).toHaveAttribute('data-scroll-origin', 'bottom')
+    expect(scroller).toHaveClass('flex', 'flex-col-reverse', '[overflow-anchor:none]')
+    expect(scroller.scrollTop).toBeCloseTo(0)
+  })
+
   test('updates the message list layout when only the layout class changes', () => {
     const messages = [
       {

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -125,6 +125,7 @@ interface ScrollableMessageAreaProps {
   onLoadTurnNavigationItem?: (item: RuntimeTurnNavigationItem) => Promise<void> | void
   onLoadTranscriptGap?: (gap: RuntimeTranscriptGap) => Promise<void> | void
   initialScrollPosition?: 'restore' | 'latest'
+  scrollOrigin?: 'top' | 'bottom'
 }
 
 export const ScrollableMessageArea = memo(function ScrollableMessageArea(
@@ -213,6 +214,7 @@ function areScrollableMessageAreaPropsEqual(
       : null,
     previous.onLoadTranscriptGap !== next.onLoadTranscriptGap ? 'onLoadTranscriptGap' : null,
     previous.initialScrollPosition !== next.initialScrollPosition ? 'initialScrollPosition' : null,
+    previous.scrollOrigin !== next.scrollOrigin ? 'scrollOrigin' : null,
   ].filter((key): key is string => key !== null)
 
   return changed.length === 0
@@ -265,11 +267,12 @@ function ScrollableMessagePaneContent({
   onLoadTurnNavigationItem,
   onLoadTranscriptGap,
   initialScrollPosition = 'restore',
+  scrollOrigin = 'top',
 }: ScrollableMessageAreaProps) {
   const { t } = useTranslation('common')
   const internalScrollRef = useRef<HTMLDivElement>(null)
   const scrollRef = externalScrollRef ?? internalScrollRef
-  const bottomOrigin = externalScrollRef !== undefined
+  const bottomOrigin = externalScrollRef !== undefined || scrollOrigin === 'bottom'
   const activeScrollRefRef = useRef(scrollRef)
   const contentRef = useRef<HTMLDivElement>(null)
   const stickyFooterRef = useRef<HTMLDivElement>(null)
@@ -1335,9 +1338,13 @@ function ScrollableMessagePaneContent({
       <div
         ref={internalScrollRef}
         data-testid={scrollTestId}
+        data-scroll-origin={bottomOrigin ? 'bottom' : 'top'}
         className={cn(
           'h-full overflow-y-auto',
           stickyFooter && 'flex flex-col',
+          bottomOrigin &&
+            externalScrollRef === undefined &&
+            'flex flex-col-reverse [overflow-anchor:none]',
           (turnNavigationLoading || turnNavigationTargetMessageId || autoScrollSuspended) &&
             '[overflow-anchor:none]',
           scrollerClassName

--- a/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
+++ b/wework/src/components/layout/workspace-panels/TemporaryChatPanel.tsx
@@ -91,6 +91,7 @@ interface TemporaryChatPanelProps {
   projectWorkBarTrailingContext?: ReactNode
   onRestoreConversation?: () => void
   initialScrollPosition?: 'restore' | 'latest'
+  scrollOrigin?: 'top' | 'bottom'
 }
 
 export function TemporaryChatPanel({
@@ -117,6 +118,7 @@ export function TemporaryChatPanel({
   projectWorkBarTrailingContext,
   onRestoreConversation,
   initialScrollPosition = 'restore',
+  scrollOrigin = 'top',
 }: TemporaryChatPanelProps) {
   const { t } = useTranslation('common')
   const {
@@ -774,6 +776,7 @@ export function TemporaryChatPanel({
           onLoadFullTranscript={loadFullTranscript}
           loadingFullTranscript={loadingFullTranscript}
           initialScrollPosition={initialScrollPosition}
+          scrollOrigin={scrollOrigin}
         />
       )}
       <div

--- a/wework/src/features/todo/CloudTodoBoardCard.test.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@/components/layout/workspace-panels/TemporaryChatPanel', () => ({
     sendEphemeral,
     collapseComposerWhenIdle,
     runtimeContext,
-    initialScrollPosition,
+    scrollOrigin,
   }: {
     initialAddress: {
       deviceId: string
@@ -38,7 +38,7 @@ vi.mock('@/components/layout/workspace-panels/TemporaryChatPanel', () => ({
     sendEphemeral: boolean
     collapseComposerWhenIdle: boolean
     runtimeContext?: { cloudProjectId?: string }
-    initialScrollPosition?: 'restore' | 'latest'
+    scrollOrigin?: 'top' | 'bottom'
   }) => (
     <section
       data-testid={testId}
@@ -48,7 +48,7 @@ vi.mock('@/components/layout/workspace-panels/TemporaryChatPanel', () => ({
       data-collapse-composer={String(collapseComposerWhenIdle)}
       data-cloud-project-id={runtimeContext?.cloudProjectId}
       data-model-name={initialAddress.runtimeHandle?.modelSelection?.modelName}
-      data-initial-scroll-position={initialScrollPosition}
+      data-scroll-origin={scrollOrigin}
     >
       Shared task conversation
     </section>
@@ -506,7 +506,7 @@ describe('CloudTodoBoardCard', () => {
     expect(conversation).toHaveAttribute('data-send-ephemeral', 'false')
     expect(conversation).toHaveAttribute('data-collapse-composer', 'true')
     expect(conversation).toHaveAttribute('data-cloud-project-id', String(item.cloud_project_id))
-    expect(conversation).toHaveAttribute('data-initial-scroll-position', 'latest')
+    expect(conversation).toHaveAttribute('data-scroll-origin', 'bottom')
   })
 
   it('marks an unread task as read after its conversation preview stays open for 3 seconds', async () => {

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -738,7 +738,7 @@ function RuntimeTaskProgressSummary({
             runtimeContext={{ cloudProjectId: String(item.cloud_project_id) }}
             sendEphemeral={false}
             collapseComposerWhenIdle
-            initialScrollPosition="latest"
+            scrollOrigin="bottom"
             emptyStateText={t('todo.task_progress_empty', '暂无任务进展详情')}
             placeholder={t('workbench.task_activity_inline_placeholder')}
           />

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -112,7 +112,7 @@ vi.mock('@/components/layout/workspace-panels/TemporaryChatPanel', () => ({
     testId,
     initialAddress,
     collapseComposerWhenIdle,
-    initialScrollPosition,
+    scrollOrigin,
   }: {
     testId: string
     initialAddress?: {
@@ -121,7 +121,7 @@ vi.mock('@/components/layout/workspace-panels/TemporaryChatPanel', () => ({
       runtimeHandle?: { modelSelection?: { modelName?: string } }
     } | null
     collapseComposerWhenIdle?: boolean
-    initialScrollPosition?: 'restore' | 'latest'
+    scrollOrigin?: 'top' | 'bottom'
   }) => (
     <div
       data-testid={testId}
@@ -129,7 +129,7 @@ vi.mock('@/components/layout/workspace-panels/TemporaryChatPanel', () => ({
       data-task-id={initialAddress?.taskId}
       data-model-name={initialAddress?.runtimeHandle?.modelSelection?.modelName}
       data-collapse-composer={String(collapseComposerWhenIdle)}
-      data-initial-scroll-position={initialScrollPosition}
+      data-scroll-origin={scrollOrigin}
     >
       <div
         data-testid={testId.replace('popup-conversation', 'popup-scroll')}
@@ -1297,8 +1297,8 @@ describe('CloudTodoWorkspace', () => {
       'true'
     )
     expect(screen.getByTestId('cloud-todo-card-popup-conversation-WEG-1')).toHaveAttribute(
-      'data-initial-scroll-position',
-      'latest'
+      'data-scroll-origin',
+      'bottom'
     )
     expect(screen.getByTestId('cloud-todo-card-popup-conversation-WEG-1')).toHaveAttribute(
       'data-model-name',


### PR DESCRIPTION
## Summary
- make board hover task conversations use the same bottom-origin scroll model as the main task view
- remove the post-mount latest-position correction that exposed a visible scroll-to-bottom transition
- wait for the local board loading state before the focused desktop E2E creates its first issue

## Verification
- `pnpm --filter wework test src/components/chat/ScrollableMessageArea.test.tsx src/features/todo/CloudTodoBoardCard.test.tsx`
- `pnpm --filter wework exec prettier --check ...`
- focused ESLint and Node syntax checks
- `pnpm --filter wework e2e:desktop --segment board-focus-view`

Closes WORK-492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Task progress conversations now open with bottom-origin scrolling, keeping the latest messages in view.
  - Chat panels support configurable top- or bottom-origin scrolling.

- **Bug Fixes**
  - Improved loading synchronization before creating cards on todo boards.
  - Improved scrolling behavior and positioning in progress and task conversation popups.

- **Tests**
  - Added coverage validating bottom-origin scrolling, initial scroll position, and related layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->