### PR TITLE
fix(wework): make board hover actions single-click

### DIFF
--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -453,12 +453,16 @@ export function createDesktopScenario({
   let workflowTaskBindings = []
   let resolveFirstContinuationStarted
   let releaseFirstContinuation
+  let resolveMoonshotFollowUpStarted
   let releaseMoonshotFollowUp
   const firstContinuationStarted = new Promise(resolve => {
     resolveFirstContinuationStarted = resolve
   })
   const firstContinuationRelease = new Promise(resolve => {
     releaseFirstContinuation = resolve
+  })
+  const moonshotFollowUpStarted = new Promise(resolve => {
+    resolveMoonshotFollowUpStarted = resolve
   })
   const moonshotFollowUpRelease = new Promise(resolve => {
     releaseMoonshotFollowUp = resolve
@@ -1406,6 +1410,11 @@ export function createDesktopScenario({
     )
     assert.ok(!popupModelLabel.includes(DEFAULT_MODEL_LABEL))
     await control.command('click', moonshotPopupSend, { visible: true })
+    await withTimeout(
+      moonshotFollowUpStarted,
+      uiTimeoutMs,
+      'The board popup follow-up did not start streaming'
+    )
     const followUpRequests = await waitForValue(
       () => Promise.resolve(upstreamResponseRequests.slice(followUpRequestOffset)),
       requests =>
@@ -1427,40 +1436,51 @@ export function createDesktopScenario({
         timeoutMs: uiTimeoutMs,
         visible: false,
       })
+      await control.command('waitFor', moonshotOverrideCard, {
+        stableMs: 500,
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
+      await control.command('pointerMove', 'body')
       await control.command('hover', moonshotOverrideCard, { visible: true })
       await control.command('waitFor', moonshotProgressPopup, {
         timeoutMs: uiTimeoutMs,
         visible: true,
       })
-      await control.command(
-        'click',
-        `[data-testid="cloud-todo-card-progress-pin-${moonshotOverrideIssue.id}"]`,
-        { visible: true }
-      )
+      const moonshotPopupPause = `${moonshotPopupConversation} [data-testid="pause-response-button"]`
+      await control.command('waitFor', moonshotPopupPause, {
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
+      await captureScreenshot(control, 'project-automation-board-hover-running-stop-ready.png')
+      await control.command('pointerDown', moonshotPopupPause)
+      await control.command('click', moonshotPopupPause, { visible: true })
+      const moonshotPopupStoppedNotice = `${moonshotPopupConversation} [data-testid="assistant-stopped-notice"]`
+      await control.command('waitFor', moonshotPopupStoppedNotice, {
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
       await waitForValue(
         () => control.command('getAttribute', moonshotProgressPopup, { value: 'data-pinned' }),
         value => value === 'true',
-        'The board popup did not stay pinned in place',
+        'The board popup did not pin after the stop action completed',
         uiTimeoutMs
       )
-      await captureScreenshot(control, 'project-automation-board-hover-pinned.png')
-      await control.command('press', 'body', { key: 'Escape' })
+      const moonshotPopupClose = `${moonshotProgressPopup}[data-pinned="true"] [data-testid="cloud-todo-card-progress-popup-${moonshotOverrideIssue.id}-close"]`
+      await control.command('waitFor', moonshotPopupClose, {
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
+      await captureScreenshot(control, 'project-automation-board-hover-stopped-pinned.png')
+      await control.command('click', moonshotPopupClose, { visible: true })
       await control.command('waitFor', moonshotProgressPopup, {
         timeoutMs: uiTimeoutMs,
         visible: false,
       })
+      await captureScreenshot(control, 'project-automation-board-hover-closed.png')
     } finally {
       releaseMoonshotFollowUp()
     }
-    await control.command(
-      'waitFor',
-      `[data-testid="cloud-todo-card-final-response-${moonshotOverrideIssue.id}"]`,
-      {
-        text: MOONSHOT_OVERRIDE_FOLLOW_UP_COMPLETION,
-        timeoutMs: automationRuntimeTimeoutMs,
-        visible: true,
-      }
-    )
 
     await control.command('waitFor', `${activeBoard} [data-testid="cloud-project-board-view"]`, {
       timeoutMs: uiTimeoutMs,
@@ -2818,13 +2838,16 @@ export function createDesktopScenario({
           })
           response.flushHeaders()
           response.write(createSse([responseCreated(responseId)]))
+          resolveMoonshotFollowUpStarted()
           await moonshotFollowUpRelease
-          response.end(
-            createSse([
-              assistantMessage(MOONSHOT_OVERRIDE_FOLLOW_UP_COMPLETION),
-              responseCompleted(responseId),
-            ])
-          )
+          if (!response.destroyed) {
+            response.end(
+              createSse([
+                assistantMessage(MOONSHOT_OVERRIDE_FOLLOW_UP_COMPLETION),
+                responseCompleted(responseId),
+              ])
+            )
+          }
           return true
         }
         if (serialized.includes('请确认当前分派结果')) {

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -554,17 +554,21 @@ describe('ChatInput', () => {
         onSubmit={vi.fn()}
         disabled={false}
         variant="desktop"
+        collapseWhenIdle
         isStreaming
         onPause={onPause}
       />
     )
 
+    const form = screen.getByTestId('project-chat-composer-form')
+    expect(form).toHaveAttribute('data-short-expanded', 'false')
     expect(screen.getByTestId('pause-response-button')).toBeInTheDocument()
     expect(screen.queryByTestId('send-message-button')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('pause-response-button'))
 
     expect(onPause).toHaveBeenCalledTimes(1)
+    expect(form).toHaveAttribute('data-short-expanded', 'true')
   })
 
   test('shows desktop send button for a draft while the assistant is streaming', async () => {

--- a/wework/src/components/ui/hover-card.test.tsx
+++ b/wework/src/components/ui/hover-card.test.tsx
@@ -1,4 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { createPortal } from 'react-dom'
 import { HoverCard } from './hover-card'
@@ -284,7 +286,7 @@ describe('HoverCard', () => {
     expect(screen.queryByTestId('pinned-hover-card')).not.toBeInTheDocument()
   })
 
-  test('pins only interactions inside the configured region', () => {
+  test('pins only interactions inside the configured region', async () => {
     render(
       <HoverCard
         testId="scoped-pinned-hover-card"
@@ -312,7 +314,63 @@ describe('HoverCard', () => {
 
     fireEvent.pointerDown(screen.getByLabelText('Reply'))
     fireEvent.focus(screen.getByLabelText('Reply'))
+    fireEvent.click(screen.getByLabelText('Reply'))
+    await act(async () => Promise.resolve())
     expect(screen.getByTestId('scoped-pinned-hover-card-close')).toBeInTheDocument()
+  })
+
+  test('lets a pointer action finish before controlled pinning changes the card', async () => {
+    const events: string[] = []
+    const ControlledCard = () => {
+      const [pinned, setPinned] = useState(false)
+      const [active, setActive] = useState(true)
+      return (
+        <HoverCard
+          testId="controlled-action-hover-card"
+          interactive
+          openOnFocus
+          pinOnInteraction
+          pinOnInteractionSelector="[data-pin-region]"
+          pinned={pinned}
+          onPinnedChange={nextPinned => {
+            events.push(nextPinned ? 'pin' : 'unpin')
+            setPinned(nextPinned)
+          }}
+          content={
+            <div data-pin-region>
+              {!pinned ? <span>Unpinned controls</span> : null}
+              {active ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    events.push('action')
+                    setActive(false)
+                  }}
+                >
+                  Stop response
+                </button>
+              ) : (
+                <span>Response stopped</span>
+              )}
+            </div>
+          }
+        >
+          <button type="button">Current task</button>
+        </HoverCard>
+      )
+    }
+
+    render(<ControlledCard />)
+    fireEvent.focus(screen.getByText('Current task'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Stop response' }))
+
+    expect(events).toEqual(['action', 'pin'])
+    expect(screen.getByTestId('controlled-action-hover-card')).toHaveAttribute(
+      'data-pinned',
+      'true'
+    )
+    expect(screen.getByTestId('controlled-action-hover-card-close')).toHaveClass('z-10')
   })
 
   test('keeps a controlled pinned card open until its owner clears the pinned state', () => {

--- a/wework/src/components/ui/hover-card.tsx
+++ b/wework/src/components/ui/hover-card.tsx
@@ -114,6 +114,7 @@ export function HoverCard({
   const closeTimerRef = useRef<number | null>(null)
   const focusWithinRef = useRef(false)
   const pinnedRef = useRef(false)
+  const pointerPinPendingRef = useRef(false)
   const openRef = useRef(false)
   const [open, setOpen] = useState(false)
   const [position, setPosition] = useState<HoverCardPosition | null>(null)
@@ -218,7 +219,11 @@ export function HoverCard({
         event.target instanceof Node &&
         !focusIsInsideAnchor
       ) {
-        pin()
+        if (pointerPinPendingRef.current) {
+          keepOpen()
+        } else {
+          pin()
+        }
       }
       if (focusIsInsideAnchor && !openOnFocus) return
       focusWithinRef.current = true
@@ -325,6 +330,7 @@ export function HoverCard({
       onBlurCapture={interactive || openOnFocus ? handleBlurCapture : undefined}
       onPointerMoveCapture={interactive ? keepOpen : undefined}
       onPointerDownCapture={event => {
+        pointerPinPendingRef.current = false
         if (interactive) {
           if (event.target instanceof Node && anchorRef.current?.contains(event.target)) {
             if (shouldPinInteraction(event.target)) {
@@ -339,14 +345,18 @@ export function HoverCard({
             event.target instanceof Node &&
             !anchorRef.current?.contains(event.target)
           ) {
-            pin()
+            pointerPinPendingRef.current = true
           }
           keepOpen()
           return
         }
         close()
       }}
+      onPointerCancelCapture={() => {
+        pointerPinPendingRef.current = false
+      }}
       onContextMenuCapture={event => {
+        pointerPinPendingRef.current = false
         if (interactive) {
           if (event.target instanceof Node && anchorRef.current?.contains(event.target)) {
             close()
@@ -369,6 +379,12 @@ export function HoverCard({
             style={position ?? { left: 0, top: 0, visibility: 'hidden' }}
             onMouseEnter={interactive ? keepOpen : undefined}
             onMouseLeave={interactive ? scheduleClose : undefined}
+            onClickCapture={event => {
+              if (!pointerPinPendingRef.current) return
+              pointerPinPendingRef.current = false
+              if (!shouldPinInteraction(event.target)) return
+              window.queueMicrotask(pin)
+            }}
             className={cn(
               'fixed z-[78] max-h-[calc(100vh-1rem)] overflow-x-hidden overflow-y-auto rounded-xl border border-border bg-background p-3 text-xs text-text-primary shadow-[0_16px_44px_rgba(0,0,0,0.16)]',
               interactive ? 'pointer-events-auto' : 'pointer-events-none',
@@ -386,7 +402,7 @@ export function HoverCard({
                   close()
                 }}
                 aria-label={closeLabel}
-                className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition hover:bg-muted hover:text-text-primary"
+                className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition hover:bg-muted hover:text-text-primary"
               >
                 <X className="h-4 w-4" />
               </button>


### PR DESCRIPTION
## Summary

- defer hover-card pinning until the clicked action completes, preventing controlled rerenders from replacing the click target
- keep the hover-card close control above popup content
- cover the collapsed streaming stop action and the real board hover stop/close flow

## Verification

- `pnpm --filter wework test src/components/ui/hover-card.test.tsx src/features/todo/CloudTodoBoardCard.test.tsx`
- `pnpm --filter wework test src/components/chat/ChatInput.test.tsx -t 'shows desktop pause button while the assistant is streaming'`\n- `pnpm --filter wework exec tsc --noEmit`\n- real Electron `project-automation` desktop scenario (passed)