### PR TITLE
fix(wework): sync transcripts after worktree cleanup

### DIFF
--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -79,11 +79,13 @@ pub const APP_IPC_PROTOCOL_VERSION: u64 = 1;
 const DEFAULT_TIMEOUT_SECONDS: f64 = 60.0;
 const DEFAULT_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 const APP_IPC_REQUEST_TIMEOUT_SECONDS: u64 = 75;
+const TRANSCRIPT_EXPORT_TIMEOUT_SECONDS: u64 = 10 * 60;
 
 fn app_ipc_request_timeout_seconds(method: Option<&str>) -> u64 {
     match method {
         Some("executor.plugin_auth.migrate") => 280,
         Some("executor.plugin_auth.run") => 200,
+        Some("runtime.tasks.transcript.export") => TRANSCRIPT_EXPORT_TIMEOUT_SECONDS,
         _ => APP_IPC_REQUEST_TIMEOUT_SECONDS,
     }
 }
@@ -3586,9 +3588,21 @@ mod tests {
     use tokio::time::Duration;
 
     use super::{
-        app_ipc_request_metadata, is_bulk_app_ipc_event, local_app_command, AppIpcServer,
-        BlockingSingleFlight,
+        app_ipc_request_metadata, app_ipc_request_timeout_seconds, is_bulk_app_ipc_event,
+        local_app_command, AppIpcServer, BlockingSingleFlight,
     };
+
+    #[test]
+    fn transcript_export_allows_large_snapshot_packaging() {
+        assert_eq!(
+            app_ipc_request_timeout_seconds(Some("runtime.tasks.transcript.export")),
+            10 * 60
+        );
+        assert_eq!(
+            app_ipc_request_timeout_seconds(Some("runtime.tasks.list")),
+            75
+        );
+    }
 
     #[test]
     fn app_ipc_request_metadata_includes_device_command_key() {

--- a/executor/src/runtime_work/handler/transcript_sync.rs
+++ b/executor/src/runtime_work/handler/transcript_sync.rs
@@ -5,7 +5,7 @@
 use super::*;
 use crate::runtime_work::native_transcript::{
     export_segment, remove_restored_transcript, restore_segments, ExportRequest, RestoreSegment,
-    RestoredTranscript,
+    RestoredTranscript, WorkspaceSnapshot,
 };
 
 const CLOUD_TRANSCRIPT_HANDLE_KEY: &str = "cloudTranscript";
@@ -105,11 +105,20 @@ impl RuntimeWorkRpcHandler {
             .ok_or_else(|| {
                 AppIpcError::new("bad_request", "transcript encryptionKey is required")
             })?;
+        let workspace_path = Path::new(&link.workspace_path).to_path_buf();
+        let workspace_snapshot =
+            self.worktrees
+                .snapshot_source_for(&workspace_path)
+                .map(|snapshot| WorkspaceSnapshot {
+                    git_common_dir: snapshot.git_common_dir,
+                    reference: snapshot.reference,
+                });
         let request = ExportRequest {
             transcript_id,
             task_id,
             title: link.title.clone(),
-            workspace_path: Path::new(&link.workspace_path).to_path_buf(),
+            workspace_path,
+            workspace_snapshot,
             thread_id,
             sequence,
             base_sequence,

--- a/executor/src/runtime_work/native_transcript.rs
+++ b/executor/src/runtime_work/native_transcript.rs
@@ -5,8 +5,9 @@
 use std::{
     collections::HashSet,
     env, fs,
-    io::{Read, Write},
+    io::{Cursor, Read, Write},
     path::{Component, Path, PathBuf},
+    process::Command,
 };
 
 use aes_gcm::{
@@ -87,12 +88,19 @@ pub(crate) struct ExportRequest {
     pub task_id: String,
     pub title: String,
     pub workspace_path: PathBuf,
+    pub workspace_snapshot: Option<WorkspaceSnapshot>,
     pub thread_id: String,
     pub sequence: u64,
     pub base_sequence: u64,
     pub rollout_start: u64,
     pub snapshot: bool,
     pub encryption_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WorkspaceSnapshot {
+    pub git_common_dir: PathBuf,
+    pub reference: String,
 }
 
 #[derive(Debug, Clone)]
@@ -194,7 +202,11 @@ pub(crate) fn export_segment(request: ExportRequest) -> Result<ExportedSegment, 
                 .map_err(|error| format!("failed to serialize transcript manifest: {error}"))?,
         )?;
         append_bytes(&mut archive, ROLLOUT_PATH, &rollout[rollout_start..])?;
-        append_workspace(&mut archive, &request.workspace_path)?;
+        append_workspace(
+            &mut archive,
+            &request.workspace_path,
+            request.workspace_snapshot.as_ref(),
+        )?;
         archive
             .into_inner()
             .and_then(GzEncoder::finish)
@@ -615,10 +627,20 @@ fn append_bytes(
 fn append_workspace(
     archive: &mut Builder<GzEncoder<fs::File>>,
     workspace: &Path,
+    snapshot: Option<&WorkspaceSnapshot>,
 ) -> Result<(), String> {
-    if !workspace.is_dir() {
-        return Err(format!("workspace does not exist: {}", workspace.display()));
+    if workspace.is_dir() {
+        return append_workspace_directory(archive, workspace);
     }
+    let snapshot =
+        snapshot.ok_or_else(|| format!("workspace does not exist: {}", workspace.display()))?;
+    append_workspace_snapshot(archive, snapshot)
+}
+
+fn append_workspace_directory(
+    archive: &mut Builder<GzEncoder<fs::File>>,
+    workspace: &Path,
+) -> Result<(), String> {
     let mut total_bytes = 0_u64;
     for entry in WalkBuilder::new(workspace)
         .hidden(false)
@@ -656,22 +678,97 @@ fn append_workspace(
                 .metadata()
                 .map_err(|error| format!("failed to inspect workspace member: {error}"))?
                 .len();
-            if size > MAX_WORKSPACE_FILE_BYTES {
-                return Err(format!(
-                    "workspace member exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte limit: {}",
-                    relative.display()
-                ));
-            }
-            total_bytes = total_bytes
-                .checked_add(size)
-                .ok_or_else(|| "workspace is too large to synchronize".to_owned())?;
-            if total_bytes > MAX_WORKSPACE_BYTES {
-                return Err("workspace is too large to synchronize".to_owned());
-            }
+            validate_workspace_member_size(relative, size, &mut total_bytes)?;
         }
         archive
             .append_path_with_name(path, Path::new(WORKSPACE_PREFIX).join(relative))
             .map_err(|error| format!("failed to append workspace member: {error}"))?;
+    }
+    Ok(())
+}
+
+fn append_workspace_snapshot(
+    archive: &mut Builder<GzEncoder<fs::File>>,
+    snapshot: &WorkspaceSnapshot,
+) -> Result<(), String> {
+    let mut command = Command::new("git");
+    command
+        .arg("--git-dir")
+        .arg(&snapshot.git_common_dir)
+        .args(["archive", "--format=tar", &snapshot.reference, "--", "."]);
+    for name in EXCLUDED_NAMES {
+        command.arg(format!(":(exclude,glob){name}/**"));
+        command.arg(format!(":(exclude,glob)**/{name}/**"));
+    }
+    let output = command
+        .output()
+        .map_err(|error| format!("failed to read workspace snapshot: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to read workspace snapshot {}: {}",
+            snapshot.reference,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let mut source = Archive::new(Cursor::new(output.stdout));
+    let mut total_bytes = 0_u64;
+    for entry in source
+        .entries()
+        .map_err(|error| format!("failed to open workspace snapshot: {error}"))?
+    {
+        let mut entry =
+            entry.map_err(|error| format!("failed to read workspace snapshot member: {error}"))?;
+        let relative = entry
+            .path()
+            .map_err(|error| format!("invalid workspace snapshot path: {error}"))?
+            .to_path_buf();
+        if unsafe_path(&relative)
+            || relative
+                .components()
+                .any(|part| EXCLUDED_NAMES.contains(&part.as_os_str().to_string_lossy().as_ref()))
+        {
+            continue;
+        }
+        let entry_type = entry.header().entry_type();
+        if !entry_type.is_file() && !entry_type.is_dir() {
+            continue;
+        }
+        let size = entry.size();
+        if entry_type.is_file() {
+            validate_workspace_member_size(&relative, size, &mut total_bytes)?;
+        }
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(entry_type);
+        header.set_mode(entry.header().mode().unwrap_or(0o600));
+        header.set_size(size);
+        header.set_cksum();
+        archive
+            .append_data(
+                &mut header,
+                Path::new(WORKSPACE_PREFIX).join(&relative),
+                &mut entry,
+            )
+            .map_err(|error| format!("failed to append workspace snapshot member: {error}"))?;
+    }
+    Ok(())
+}
+
+fn validate_workspace_member_size(
+    relative: &Path,
+    size: u64,
+    total_bytes: &mut u64,
+) -> Result<(), String> {
+    if size > MAX_WORKSPACE_FILE_BYTES {
+        return Err(format!(
+            "workspace member exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte limit: {}",
+            relative.display()
+        ));
+    }
+    *total_bytes = total_bytes
+        .checked_add(size)
+        .ok_or_else(|| "workspace is too large to synchronize".to_owned())?;
+    if *total_bytes > MAX_WORKSPACE_BYTES {
+        return Err("workspace is too large to synchronize".to_owned());
     }
     Ok(())
 }
@@ -1028,6 +1125,122 @@ mod tests {
     }
 
     #[test]
+    fn packages_a_deleted_workspace_from_its_managed_git_snapshot() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let workspace = root.path().join("workspace");
+        fs::create_dir_all(&source).unwrap();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.name", "Wegent Test"],
+            vec!["config", "user.email", "test@wegent.local"],
+        ] {
+            assert!(Command::new("git")
+                .current_dir(&source)
+                .args(args)
+                .status()
+                .unwrap()
+                .success());
+        }
+        fs::write(source.join("tracked.txt"), "base\n").unwrap();
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args(["add", "."])
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args(["commit", "-m", "base"])
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args(["worktree", "add", "--detach"])
+            .arg(&workspace)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(workspace.join("tracked.txt"), "snapshot content\n").unwrap();
+        fs::create_dir_all(workspace.join("node_modules/package")).unwrap();
+        fs::write(
+            workspace.join("node_modules/package/ignored.txt"),
+            "ignored\n",
+        )
+        .unwrap();
+        assert!(Command::new("git")
+            .current_dir(&workspace)
+            .args(["add", "-f", "."])
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .current_dir(&workspace)
+            .args(["commit", "-m", "snapshot"])
+            .status()
+            .unwrap()
+            .success());
+        let reference = String::from_utf8(
+            Command::new("git")
+                .current_dir(&workspace)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_owned();
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args(["worktree", "remove", "--force"])
+            .arg(&workspace)
+            .status()
+            .unwrap()
+            .success());
+
+        let archive_path = root.path().join("workspace.tgz");
+        let output = fs::File::create(&archive_path).unwrap();
+        let encoder = GzEncoder::new(output, Compression::default());
+        let mut archive = Builder::new(encoder);
+        append_workspace(
+            &mut archive,
+            &workspace,
+            Some(&WorkspaceSnapshot {
+                git_common_dir: source.join(".git"),
+                reference,
+            }),
+        )
+        .unwrap();
+        archive.into_inner().unwrap().finish().unwrap();
+
+        let input = fs::File::open(archive_path).unwrap();
+        let mut restored = Archive::new(GzDecoder::new(input));
+        let mut files = restored
+            .entries()
+            .unwrap()
+            .map(|entry| {
+                let mut entry = entry.unwrap();
+                let path = entry.path().unwrap().to_path_buf();
+                let mut content = String::new();
+                if entry.header().entry_type().is_file() {
+                    entry.read_to_string(&mut content).unwrap();
+                }
+                (path, content)
+            })
+            .collect::<Vec<_>>();
+        files.sort_by(|left, right| left.0.cmp(&right.0));
+
+        assert!(files.iter().any(|(path, content)| {
+            path == Path::new("workspace/tracked.txt") && content == "snapshot content\n"
+        }));
+        assert!(!files
+            .iter()
+            .any(|(path, _)| path.starts_with("workspace/node_modules")));
+    }
+
+    #[test]
     fn snapshot_and_delta_restore_native_rollout_workspace_and_state() {
         let _guard = environment_lock();
         let root = tempfile::tempdir().unwrap();
@@ -1098,6 +1311,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             title: "Task".to_owned(),
             workspace_path: workspace.clone(),
+            workspace_snapshot: None,
             thread_id: thread_id.to_owned(),
             sequence: 1,
             base_sequence: 0,
@@ -1111,6 +1325,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             title: "Task".to_owned(),
             workspace_path: workspace.clone(),
+            workspace_snapshot: None,
             thread_id: thread_id.to_owned(),
             sequence: 1,
             base_sequence: 0,
@@ -1142,6 +1357,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             title: "Task".to_owned(),
             workspace_path: workspace.clone(),
+            workspace_snapshot: None,
             thread_id: thread_id.to_owned(),
             sequence: 2,
             base_sequence: 1,
@@ -1222,6 +1438,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             title: "Task".to_owned(),
             workspace_path: restored.workspace_path.clone(),
+            workspace_snapshot: None,
             thread_id: restored.thread_id.clone(),
             sequence: 3,
             base_sequence: 2,

--- a/executor/src/runtime_work/worktrees.rs
+++ b/executor/src/runtime_work/worktrees.rs
@@ -129,6 +129,12 @@ pub(crate) struct WorktreePruneBatch {
     pub errors: Vec<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WorktreeSnapshotSource {
+    pub git_common_dir: PathBuf,
+    pub reference: String,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default, rename_all = "camelCase")]
 pub(crate) struct WorktreeSettings {
@@ -222,6 +228,18 @@ pub(crate) struct WorktreeManager {
 }
 
 impl WorktreeManager {
+    pub fn snapshot_source_for(&self, workspace_path: &Path) -> Option<WorktreeSnapshotSource> {
+        let record = self
+            .load()
+            .records
+            .get(&normalized_path_key(workspace_path))?
+            .clone();
+        Some(WorktreeSnapshotSource {
+            git_common_dir: PathBuf::from(record.git_common_dir?),
+            reference: record.snapshot_ref?,
+        })
+    }
+
     pub fn source_path_for(&self, workspace_path: &str) -> Option<String> {
         let normalized_path = normalized_path_key(Path::new(workspace_path));
         self.load()
@@ -2766,6 +2784,21 @@ mod tests {
         let deleted = manager.delete(&path, true).unwrap();
         assert_eq!(deleted.state, "restorable");
         assert!(!path.exists());
+        assert_eq!(
+            manager.snapshot_source_for(&path),
+            Some(WorktreeSnapshotSource {
+                git_common_dir: PathBuf::from(
+                    deleted
+                        .git_common_dir
+                        .clone()
+                        .expect("snapshot must retain its Git common directory")
+                ),
+                reference: deleted
+                    .snapshot_ref
+                    .clone()
+                    .expect("snapshot must retain its reference"),
+            })
+        );
         assert!(
             !path.parent().unwrap().exists(),
             "deleting a worktree must remove its empty runtime container"

--- a/wework/dsh/executor-runtime/index.js
+++ b/wework/dsh/executor-runtime/index.js
@@ -14,6 +14,7 @@ const BASE_PATH = '/wework/executor/v1'
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024
 const MAX_EVENT_FRAME_BYTES = 16 * 1024 * 1024
 const SLOW_CONSUMER_TIMEOUT_MS = 30_000
+const TRANSCRIPT_EXPORT_TIMEOUT_MS = 10 * 60 * 1000
 
 export async function apply(ctx) {
   const client = ExecutorRuntimeClient.fromEnvironment()
@@ -84,14 +85,18 @@ export async function exportExecutorTranscript(client, turn, options = {}) {
   const summarized = options.summary
     ? { ...turn, payload: options.summary }
     : await readExecutorTurn(client, turn)
-  const exported = await client.request('runtime.tasks.transcript.export', {
-    transcriptId: turn.transcriptId,
-    taskId: turn.taskId,
-    baseSequence: options.baseSequence,
-    sequence: options.sequence,
-    snapshot: options.snapshot === true,
-    encryptionKey: options.encryptionKey,
-  })
+  const exported = await client.request(
+    'runtime.tasks.transcript.export',
+    {
+      transcriptId: turn.transcriptId,
+      taskId: turn.taskId,
+      baseSequence: options.baseSequence,
+      sequence: options.sequence,
+      snapshot: options.snapshot === true,
+      encryptionKey: options.encryptionKey,
+    },
+    TRANSCRIPT_EXPORT_TIMEOUT_MS
+  )
   return { ...turn, ...exported, summary: summarized.payload }
 }
 

--- a/wework/dsh/executor-runtime/index.test.mjs
+++ b/wework/dsh/executor-runtime/index.test.mjs
@@ -7,8 +7,9 @@ const TEST_ENCRYPTION_KEY = Buffer.alloc(32, 7).toString('base64')
 
 test('exports a native segment with a separate structured summary', async () => {
   const client = {
-    async request(method, params) {
+    async request(method, params, timeoutMs) {
       if (method === 'runtime.tasks.transcript') {
+        assert.equal(timeoutMs, undefined)
         assert.deepEqual(params, { taskId: 'task-1', limit: 100 })
         return {
           turns: [
@@ -29,6 +30,7 @@ test('exports a native segment with a separate structured summary', async () => 
         }
       }
       assert.equal(method, 'runtime.tasks.transcript.export')
+      assert.equal(timeoutMs, 10 * 60 * 1000)
       assert.deepEqual(params, {
         transcriptId: 'transcript-1',
         taskId: 'task-1',


### PR DESCRIPTION
## Summary

- export transcript workspaces from the retained Git snapshot when an auto-cleaned worktree no longer exists
- exclude generated dependency/cache directories before reading snapshot contents
- allow transcript export RPCs enough time to package larger snapshots without changing normal IPC timeouts

## Root cause

Transcript export always read `workspace_path` directly. Auto-cleanup removes that worktree after preserving it under a managed Git snapshot ref, so queued transcript turns failed permanently with `workspace does not exist`.

## Verification

- `cargo test runtime_work::native_transcript::tests --lib`
- `cargo test snapshot_delete_and_restore_preserve_uncommitted_files --lib`
- `cargo test transcript_export_allows_large_snapshot_packaging --lib`
- `node --test wework/dsh/executor-runtime/index.test.mjs`
- `cargo fmt --check`
- Prettier and Node syntax checks for changed JavaScript files
- validated the real queued transcript for deleted workspace `runtime-375802658`: snapshot-backed export produced a 48,878,301-byte encrypted segment, and a local multipart receiver returned HTTP 201 after matching the complete payload size and SHA-256

## Desktop E2E evidence

The first focused `transcript-sync` run reached cross-device restore and exposed a device-C task-row wait race. That same wait fix is already present on current `main` (`d55b1f9bf`). A subsequent run stopped before scenario execution because Electron timed out during initial `runtime-configure` while multiple unrelated worktree E2E Electron processes were active on the host; no transcript assertion failed in that run.