### PR TITLE
fix(wework): wait for update settings readiness

### DIFF
--- a/wework/e2e/desktop/scenarios/app-update-differential.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/app-update-differential.scenario.mjs
@@ -10,6 +10,7 @@ import { hashComponentPath } from '../../../scripts/lib/component-content-hash.m
 
 const TEST_TRAILER = Buffer.from('\nwework-e2e-differential-update\n')
 const UPDATE_CHANNEL = 'stable'
+const SIDEBAR_READY_STABILITY_MS = 750
 const electronPackage = resolve(
   dirname(fileURLToPath(import.meta.url)),
   '..',
@@ -181,7 +182,10 @@ export async function createDesktopScenario({
           timeoutMs: uiTimeoutMs,
         })
       }
-      await control.command('click', '[data-testid="settings-button"]')
+      await control.command('clickWhenEnabled', '[data-testid="settings-button"]', {
+        stableMs: SIDEBAR_READY_STABILITY_MS,
+        timeoutMs: uiTimeoutMs,
+      })
       await control.command('click', '[data-testid="check-app-update-button"]')
       await control.command('waitFor', '[data-testid="app-update-error-details-button"]', {
         timeoutMs: uiTimeoutMs,


### PR DESCRIPTION
## 问题\n\n2026-09-11 的 Wework App 发布运行 34554985910 在 macOS arm64 的 `app-update-differential` checkpoint 失败，报错为无法找到 `settings-button`。诊断产物显示失败后 DOM 中该按钮存在，应用启动也已完成；场景只等待常驻的 `app-shell`，随后使用一次性即时 `click`，会撞上启动阶段侧栏的短暂重挂载。\n\n## 修复\n\n- 在差分更新场景中等待设置按钮连续稳定 750ms 且可用后再点击\n- 保留原有 UI 超时和所有更新错误、重试、差分下载断言\n- 不增加重试，不修改产品行为\n\n## 验证\n\n- `node --check e2e/desktop/scenarios/app-update-differential.scenario.mjs`\n- `pnpm exec prettier --check e2e/desktop/scenarios/app-update-differential.scenario.mjs`\n- `pnpm exec eslint e2e/desktop/scenarios/app-update-differential.scenario.mjs`\n- `pnpm test src/test/bundled-plugin-resources.test.ts`（7 passed）\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for app updates by waiting for the settings control and sidebar to be ready before interaction.
  * Increased reliability when running the differential app-update scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->