### PR TITLE
fix(wework): save single-node automations inside the assignment contract

### DIFF
--- a/backend/tests/schemas/test_project_automation_schema.py
+++ b/backend/tests/schemas/test_project_automation_schema.py
@@ -90,6 +90,50 @@ def test_manual_assignment_rejects_manager_configuration() -> None:
         )
 
 
+@pytest.mark.parametrize("role_source", ["agent", "generic"])
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("model", "codex-runtime"),
+        ("executionEnvironment", "local"),
+        ("executionDeviceId", "device-1"),
+    ],
+)
+def test_manual_assignment_rejects_a_top_level_execution_target(
+    role_source: str, field: str, value: str
+) -> None:
+    """An execution target never travels on a manual assignment.
+
+    Wework stores the operator's model/device choice on the workflow node, so the
+    assignment contract must stay empty and reject the field outright.
+    """
+
+    with pytest.raises(ValidationError, match="requires AI management"):
+        ProjectAutomationCreate.model_validate(
+            {
+                **_base_create(),
+                "assignmentMode": "manual",
+                "roleSource": role_source,
+                "agentId": "agent-1" if role_source == "agent" else None,
+                field: value,
+            }
+        )
+
+
+def test_ai_managed_custom_rejects_a_top_level_execution_target() -> None:
+    with pytest.raises(ValidationError, match="custom managers use a Runtime profile"):
+        ProjectAutomationCreate.model_validate(
+            {
+                **_base_create(),
+                "assignmentMode": "ai_managed",
+                "managerType": "custom",
+                "runtimeSource": "fixed_profile",
+                "runtimeProfileId": "runtime-1",
+                "model": "codex-runtime",
+            }
+        )
+
+
 def test_partial_update_does_not_require_assignment_configuration() -> None:
     update = ProjectAutomationUpdate.model_validate({"version": 2, "enabled": False})
 

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -437,6 +437,7 @@ export function createDesktopScenario({
     ...createHistoricalRuns(),
   ]
   const createdPayloads = []
+  const updatedPayloads = []
   let archivedAgentPayload = null
   let createdAgentPayload = null
   let agents = [AGENT]
@@ -3434,6 +3435,32 @@ export function createDesktopScenario({
         json(response, 201, created)
         return true
       }
+      const automationMatch = url.pathname.match(
+        new RegExp(`^/api/v1/cloud-projects/${PROJECT_ID}/automations/([^/]+)$`)
+      )
+      if (request.method === 'PATCH' && automationMatch) {
+        const existingIndex = rules.findIndex(rule => rule.id === automationMatch[1])
+        // Automations owned by the real backend keep flowing there; the stub only
+        // answers for the rules it created itself.
+        if (existingIndex >= 0) {
+          const updatedPayload = await readJson(request)
+          const assignmentViolation = automationAssignmentViolation(updatedPayload)
+          if (assignmentViolation) {
+            json(response, 422, { detail: assignmentViolation })
+            return true
+          }
+          updatedPayloads.push({ id: automationMatch[1], ...updatedPayload })
+          const updated = {
+            ...rules[existingIndex],
+            ...updatedPayload,
+            id: automationMatch[1],
+            version: (rules[existingIndex].version ?? 1) + 1,
+          }
+          rules[existingIndex] = updated
+          json(response, 200, updated)
+          return true
+        }
+      }
       const runsMatch = url.pathname.match(
         new RegExp(`^/api/v1/cloud-projects/${PROJECT_ID}/automations/([^/]+)/runs$`)
       )
@@ -4839,6 +4866,25 @@ export function createDesktopScenario({
         ),
         'The single node was not persisted into the runtime workflow definition'
       )
+      // Editing an existing single-node rule must save as well: the update path shares
+      // the assignment contract with the create path.
+      await control.command('fill', '[data-testid="automation-rule-description"]', {
+        value: '编辑已有的单节点自动执行规则。',
+      })
+      await waitForValue(
+        () => Promise.resolve(updatedPayloads.length),
+        count => count >= 1,
+        'Editing the single-node automation did not reach the cloud API',
+        uiTimeoutMs
+      )
+      const updatedSingleNodeAutomation = updatedPayloads[updatedPayloads.length - 1]
+      assert.equal(updatedSingleNodeAutomation.model, null)
+      assert.equal(updatedSingleNodeAutomation.executionEnvironment, null)
+      assert.equal(updatedSingleNodeAutomation.executionDeviceId, null)
+      await control.command('waitFor', '[data-testid="automation-editor-global-actions"]', {
+        text: '已保存',
+        timeoutMs: uiTimeoutMs,
+      })
       await captureScreenshot(control, 'project-automation-single-node.png')
       await control.command('click', '[data-testid="automation-editor-back"]', {
         visible: true,

--- a/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
+++ b/wework/e2e/desktop/scenarios/project-automation.scenario.mjs
@@ -290,6 +290,19 @@ async function readJson(request) {
   return JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')
 }
 
+// Mirror of the backend assignment contract: the operator's model/device choice lives on
+// the workflow node, so a top-level execution target makes the real API answer 422.
+function automationAssignmentViolation(payload) {
+  const executionTarget = [
+    payload.model ?? null,
+    payload.executionEnvironment ?? null,
+    payload.executionDeviceId ?? null,
+  ]
+  return executionTarget.some(value => value !== null)
+    ? 'The automation assignment carried a top-level execution target'
+    : null
+}
+
 async function requestJson(baseUrl, authToken, pathname, options = {}) {
   const { useApiKey = false, ...fetchOptions } = options
   const response = await fetch(`${baseUrl}${pathname}`, {
@@ -3397,6 +3410,11 @@ export function createDesktopScenario({
         url.pathname === `/api/v1/cloud-projects/${PROJECT_ID}/automations`
       ) {
         const createdPayload = await readJson(request)
+        const assignmentViolation = automationAssignmentViolation(createdPayload)
+        if (assignmentViolation) {
+          json(response, 422, { detail: assignmentViolation })
+          return true
+        }
         createdPayloads.push(createdPayload)
         const created = {
           ...RULE,
@@ -4773,6 +4791,63 @@ export function createDesktopScenario({
         timeoutMs: uiTimeoutMs,
         visible: true,
       })
+
+      // A single automatic node must save: the node owns the execution target, and the
+      // assignment payload has to stay inside the backend contract.
+      await control.command('click', '[data-testid="automation-create-rule"]', {
+        visible: true,
+      })
+      await control.command('waitFor', '[data-testid="automation-rule-editor"]', {
+        timeoutMs: uiTimeoutMs,
+      })
+      await control.command('click', '[data-testid="automation-editor-name"]')
+      await control.command('fill', '[data-testid="automation-editor-name-input"]', {
+        value: '单节点自动执行',
+      })
+      await control.command('press', '[data-testid="automation-editor-name-input"]', {
+        key: 'Enter',
+      })
+      await control.command('fill', '[data-testid="automation-rule-description"]', {
+        value: '验证只有一个自动执行节点的规则可以保存。',
+      })
+      await control.command('click', '[data-testid="automation-node-insert-after-trigger"]')
+      await control.command('click', '[data-testid="automation-node-insert-after-task-trigger"]')
+      await control.command('fill', '[data-testid^="execution-node-name-"]', {
+        value: '单节点执行',
+      })
+      await control.command('fill', '[data-testid^="execution-node-prompt-"]', {
+        value: '执行单节点任务。',
+      })
+      await control.command('waitFor', '[data-testid="automation-editor-global-actions"]', {
+        text: '已保存',
+        timeoutMs: uiTimeoutMs,
+      })
+      const singleNodeAutomation = createdPayloads.find(
+        payload => payload.name === '单节点自动执行'
+      )
+      assert.ok(singleNodeAutomation, 'The single-node automation was not saved')
+      assert.equal(singleNodeAutomation.assignmentMode, 'manual')
+      assert.equal(singleNodeAutomation.roleSource, 'generic')
+      assert.equal(singleNodeAutomation.model, null)
+      assert.equal(singleNodeAutomation.executionEnvironment, null)
+      assert.equal(singleNodeAutomation.executionDeviceId, null)
+      const singleNodeGraph = singleNodeAutomation.eventConfig.wework_flow.graph.nodes
+      assert.equal(singleNodeGraph.length, 1)
+      assert.ok(
+        singleNodeAutomation.eventConfig.runtime_workflow_definition.nodes.some(
+          node => node.id === singleNodeGraph[0].id
+        ),
+        'The single node was not persisted into the runtime workflow definition'
+      )
+      await captureScreenshot(control, 'project-automation-single-node.png')
+      await control.command('click', '[data-testid="automation-editor-back"]', {
+        visible: true,
+      })
+      await control.command('waitFor', '[data-testid="automation-create-rule"]', {
+        timeoutMs: uiTimeoutMs,
+        visible: true,
+      })
+
       await control.command('click', '[data-testid="automation-create-rule"]', {
         visible: true,
       })

--- a/wework/src/features/todo/automationRuleBackend.test.ts
+++ b/wework/src/features/todo/automationRuleBackend.test.ts
@@ -384,6 +384,67 @@ describe('automationRuleBackend', () => {
     })
   })
 
+  test('keeps a single automatic node inside the automation assignment contract', () => {
+    const rule = uiRule()
+
+    const input = automationInputFromUi(rule, 7)
+    const workflow = input.eventConfig.runtime_workflow_definition as {
+      nodes: Array<{ execution_config: WorkflowExecutionConfig | null }>
+    }
+    const flow = input.eventConfig.wework_flow as {
+      graph: { nodes: Array<{ model: string; executionDeviceId: string | null }> }
+    }
+
+    // A manual rule resolves its Runtime from the profile or the bound robot, so the
+    // assignment must never carry an execution target; the node keeps the choice.
+    expect(input).toMatchObject({
+      assignmentMode: 'manual',
+      roleSource: 'generic',
+      agentId: null,
+      model: null,
+      executionEnvironment: null,
+      executionDeviceId: null,
+    })
+    expect(flow.graph.nodes).toHaveLength(1)
+    expect(flow.graph.nodes[0]).toMatchObject({
+      model: 'codex-runtime',
+      executionDeviceId: 'device-1',
+    })
+    expect(workflow.nodes[1]?.execution_config).toMatchObject({
+      model: 'codex-runtime',
+      execution_device_id: 'device-1',
+    })
+  })
+
+  test('binds a single automatic node to its robot instead of an execution target', () => {
+    const rule = uiRule()
+    rule.steps[0] = {
+      ...rule.steps[0],
+      executionConfig: {
+        agent_id: 'agent-1',
+        runtime_profile_id: null,
+        execution_device_id: 'device-1',
+        model: 'codex-runtime',
+        model_type: 'runtime',
+        model_options: { reasoning: 'high' },
+        workspace_binding: { type: 'standalone' },
+      },
+    }
+
+    const input = automationInputFromUi(rule, 7)
+
+    expect(input).toMatchObject({
+      assignmentMode: 'manual',
+      roleSource: 'agent',
+      agentId: 'agent-1',
+      runtimeSource: 'agent_default',
+      runtimeProfileId: null,
+      model: null,
+      executionEnvironment: null,
+      executionDeviceId: null,
+    })
+  })
+
   test('uses a standalone conversation when scheduled automation has no project workspace', () => {
     const rule = uiRule()
     rule.trigger = {

--- a/wework/src/features/todo/automationRuleBackend.ts
+++ b/wework/src/features/todo/automationRuleBackend.ts
@@ -1267,9 +1267,12 @@ export function automationInputFromUi(
     managerType: isAiDynamicWorkflow ? 'custom' : null,
     agentId: directAgentId,
     wegentTeamId: null,
-    model: directAgentId ? null : (directConfig?.model ?? null),
-    executionEnvironment: directAgentId ? null : (directStep?.executionEnvironment ?? null),
-    executionDeviceId: directAgentId ? null : (directConfig?.execution_device_id ?? null),
+    // The execution target never travels on the assignment: a bound robot owns it,
+    // otherwise the workflow node in `eventConfig` owns it. The backend rejects a
+    // top-level model/environment/device for manual and AI-managed assignments alike.
+    model: null,
+    executionEnvironment: null,
+    executionDeviceId: null,
     roleSource: directAgentId ? 'agent' : 'generic',
     runtimeSource: directAgentId
       ? 'agent_default'


### PR DESCRIPTION
### 问题

编辑「只有一个自动执行节点」的自动化规则时保存一直失败，编辑器停在「保存失败，点击重试」，点重试无效。

### 根因

`automationInputFromUi` 在规则只含单个自动执行节点时，会把该节点的 `model / executionEnvironment / executionDeviceId` 提升到 assignment 顶层，而 `roleSource` 仍是 `generic`（未绑定机器人）。后端 `ProjectAutomationAssignmentSchema` 只允许 AI 托管场景携带执行目标，manual 场景一律拒绝，返回 422：

```
Value error, custom manager configuration requires AI management
```

所以该形态的规则 100% 存不下来；多节点、循环/分支容器、AI 托管和绑定机器人的规则都不受影响，这也是模板与既有 E2E 一直没暴露它的原因。

### 修复

执行目标本来就不该放在 assignment 上：绑定了机器人由机器人决定，否则由存储的 workflow 节点决定（`eventConfig.wework_flow` 与 `runtime_workflow_definition` 的 `execution_config`），运行时读的也是后者。assignment 现在保持为空，与既有写入路径 `buildAutomationInput` 的契约一致；`agentId / roleSource / runtimeSource / runtimeProfileId / runtimeUserId` 的传递保持不变。

### 测试

- 前端单测：单节点自动执行的 assignment 必须为空、且节点配置仍保留在 workflow 中；单节点绑定机器人时走 `roleSource: agent`。修复前该用例确实失败。
- 后端契约测试：manual（generic 与 agent）以及 ai_managed+custom 携带任一执行目标都必须 422。
- E2E `project-automation` checkpoint：新增「只插一个自动执行节点 → 保存 → 再编辑保存」，覆盖 POST 与 PATCH；该 checkpoint 的云端 stub 现在会像真实后端一样对违规 assignment 返回 422。
- 本地验证：`pnpm --filter wework exec vitest run src/features/todo`（49 files / 551 tests）通过，`backend` 的 `tests/schemas/test_project_automation_schema.py` 与 `tests/services/test_project_automations.py` 通过；prettier / eslint / typography 干净；typecheck 无新增错误（与基线同为 19 个既有错误）。
- 桌面 E2E checkpoint 未在本地完整运行，已交由 CI 覆盖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automation assignments now leave top-level model, execution environment, and device fields unset.
  * Execution targets are preserved through the associated robot or workflow node configuration.
  * Invalid top-level execution-target fields are rejected during automation creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->