### PR TITLE
fix(wework): show full goal on hover

### DIFF
--- a/wework/src/components/chat/composer/GoalStatusBar.test.tsx
+++ b/wework/src/components/chat/composer/GoalStatusBar.test.tsx
@@ -1,0 +1,47 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { RuntimeGoal } from '@/types/api'
+import { GoalStatusBar } from './GoalStatusBar'
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+const goal: RuntimeGoal = {
+  threadId: 'thread-1',
+  objective: '完成一段很长、在输入框上方会被截断但悬停时必须完整展示的目标内容',
+  status: 'paused',
+  tokenBudget: null,
+  tokensUsed: 0,
+  timeUsedSeconds: 12,
+  createdAt: 1780000000000,
+  updatedAt: 1780000000000,
+}
+
+describe('GoalStatusBar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.advanceTimersByTime(301)
+    vi.useRealTimers()
+  })
+
+  test('shows the full objective in a tooltip when hovering the truncated text', () => {
+    render(<GoalStatusBar goal={goal} />)
+
+    const objective = screen.getByTestId('goal-objective')
+    expect(objective).toHaveClass('truncate')
+    expect(screen.queryByTestId('goal-objective-tooltip')).not.toBeInTheDocument()
+
+    fireEvent.pointerEnter(objective.parentElement as HTMLElement)
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+
+    expect(screen.getByTestId('goal-objective-tooltip')).toHaveTextContent(goal.objective)
+  })
+})

--- a/wework/src/components/chat/composer/GoalStatusBar.tsx
+++ b/wework/src/components/chat/composer/GoalStatusBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { CircleDot, Pause, Pencil, Play, Target, Trash2 } from 'lucide-react'
+import { Tooltip } from '@/components/ui/tooltip'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { RuntimeGoal, RuntimeGoalStatus } from '@/types/api'
 
@@ -84,7 +85,16 @@ export function GoalStatusBar({
         <span className="shrink-0 font-semibold text-text-primary">
           {t('workbench.goal_chip', '目标')}
         </span>
-        <span className="ml-1 min-w-0 truncate text-text-secondary">· {goal.objective}</span>
+        <Tooltip
+          label={goal.objective}
+          align="start"
+          testId="goal-objective-tooltip"
+          className="ml-1 min-w-0 flex-1 shrink overflow-hidden"
+        >
+          <span data-testid="goal-objective" className="block min-w-0 truncate text-text-secondary">
+            · {goal.objective}
+          </span>
+        </Tooltip>
       </div>
       {!canToggle && (
         <span className="shrink-0 text-text-muted">{t(statusLabel.key, statusLabel.fallback)}</span>


### PR DESCRIPTION
## Summary
- wrap the truncated composer goal objective with the shared tooltip
- keep the goal rail layout constrained while exposing the full objective on hover
- add focused regression coverage for the hover behavior

## Verification
- `pnpm --filter wework test src/components/chat/composer/GoalStatusBar.test.tsx`
- `pnpm --filter wework test src/components/chat/ChatInput.test.tsx -t "renders desktop goal status bar actions"`
- `pnpm --filter wework exec prettier --check src/components/chat/composer/GoalStatusBar.tsx src/components/chat/composer/GoalStatusBar.test.tsx`
- `pnpm --filter wework exec eslint src/components/chat/composer/GoalStatusBar.tsx src/components/chat/composer/GoalStatusBar.test.tsx`
- isolated Electron verification: created a long Goal and confirmed `goal-objective-tooltip` shows the complete objective after hover