### PR TITLE
fix(wework): reuse task conversations for board previews

### DIFF
--- a/docs/en/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/en/wework/developer-guide/wework-chat-state-sources.md
@@ -33,6 +33,16 @@ This document records the state sources for the Wework chat path. The goal is to
 | Attachment/model/skill selection      | `projectChat` context                                                                                                                                                                    | Send payload, composer controls                                                                                    | In-task option locking is derived from `projectChat.isOptionsLocked`                                                                                                                                                                        |
 | Device availability                   | `state.devices` + current task/project device selection                                                                                                                                  | Composer disabled reason, device prompts                                                                           | Use only for send preconditions; never for assistant streaming status                                                                                                                                                                       |
 
+## Board Conversation Split Views
+
+The project-space board Hover task panel is a split view of the original task conversation, not a separate preview conversation. The Task page, Hover panel, and card summary must use the same runtime task address and read the same canonical `RuntimeConversationTurn[]` from `runtimeConversationCache`.
+
+- The Hover panel directly reuses `TemporaryChatPanel`; message loading, live events, continuation, and attachments all target the original task conversation.
+- Card progress text and tool activity may only be projected from canonical turns through pure selectors. Do not persist `finalResponsePreview`, serialize assistant messages, or introduce board/Hover-specific message caches.
+- When the server confirms that a transcript is idle, that response is the task's authoritative snapshot and replaces old terminal turns absent from the server. Only an active transcript is merged with buffered local events.
+- A terminal conversation is evicted after five idle minutes when no full conversation view retains it. Card summaries may observe updates but must not prevent eviction merely because the board remains mounted; an open Task page or Hover split view retains the conversation while subscribed.
+- The board prefetches only a bounded transcript tail for running and review tasks. Increasing that range requires evidence that the UI needs it; a one-line summary must not load or copy complete tool output.
+
 ## Runtime Event Flow
 
 1. A new message submit sets `sendPhase` to `submitting`.

--- a/docs/zh/wework/developer-guide/wework-chat-state-sources.md
+++ b/docs/zh/wework/developer-guide/wework-chat-state-sources.md
@@ -33,6 +33,16 @@ sidebar_position: 18
 | 附件/模型/技能选择            | `projectChat` context                                                                                                           | send payload、composer 控件                                                                            | 当前 LocalTask 内选项锁定由 `projectChat.isOptionsLocked` 派生                                                                                                                  |
 | 设备可用性                    | `state.devices` + 当前任务/项目设备选择                                                                                         | composer disabled reason、设备提示                                                                     | 只用于发送前置条件，不参与 assistant streaming 判断                                                                                                                             |
 
+## 看板会话分屏
+
+项目空间看板上的 Hover 任务面板是原任务会话的分屏视图，不是独立预览会话。任务页、Hover 面板和卡片摘要必须使用同一个 runtime task address，并读取 `runtimeConversationCache` 中同一份 canonical `RuntimeConversationTurn[]`。
+
+- Hover 面板直接复用 `TemporaryChatPanel`，消息加载、实时事件、继续对话和附件都进入原任务会话。
+- 卡片上的进展文字和工具活动只能通过纯 selector 从 canonical turns 即时投影；不能保存 `finalResponsePreview`、序列化 assistant message，或维护 board/Hover 专用消息缓存。
+- 服务端确认 transcript 已 idle 时，响应是该任务的权威快照，应替换缓存中不存在于服务端的旧 terminal turns；运行中的 transcript 才与本地缓冲事件合并。
+- 已结束会话在没有完整会话视图保活时空闲五分钟后回收。卡片摘要可以监听更新，但不能因为看板常驻而阻止回收；打开的任务页或 Hover 分屏在订阅期间保活。
+- 看板只为运行中和待审核任务预取有限的 transcript 尾部。增加预取范围前必须先证明 UI 需要，不能为了生成一行摘要加载或复制完整工具输出。
+
 ## Runtime 事件流
 
 1. 新消息提交时，`sendPhase` 进入 `submitting`。

--- a/wework/src/features/todo/CloudTodoBoardCard.test.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.test.tsx
@@ -538,6 +538,43 @@ describe('CloudTodoBoardCard', () => {
     expect(conversation).toHaveAttribute('data-scroll-origin', 'bottom')
   })
 
+  it('does not show an older response while a new task turn is starting', () => {
+    seedAssistantResponse('older completed response')
+    applyRuntimeConversationAction(
+      { deviceId: 'local', taskId: 'task-85' },
+      {
+        type: 'assistant_started',
+        taskId: 'task-85',
+        subtaskId: 'turn-new',
+      }
+    )
+
+    render(
+      <CloudTodoBoardCard
+        item={{ ...item, status: 'in_progress' }}
+        taskBindings={[
+          {
+            id: 85,
+            device_id: 'local',
+            task_id: 'task-85',
+            task_title: 'Fix the board popup',
+            running: false,
+          },
+        ]}
+        onClick={vi.fn()}
+        onArchive={vi.fn()}
+        display={{
+          showAssignee: false,
+          showPriority: false,
+          showTags: false,
+          showDate: false,
+        }}
+      />
+    )
+
+    expect(screen.queryByText('older completed response')).not.toBeInTheDocument()
+  })
+
   it('marks an unread task as read after its conversation preview stays open for 3 seconds', async () => {
     vi.useFakeTimers()
     const onMarkRead = vi.fn()

--- a/wework/src/features/todo/CloudTodoBoardCard.test.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.test.tsx
@@ -5,6 +5,10 @@ import '@/i18n'
 import type { TaskChangeRequestSnapshot } from '@/api/changeRequests'
 import type { CloudLoopItem } from '@/api/deliveries'
 import { WEWORK_DSH_SLOTS } from '@/features/dsh-runtime/dshUiSlots'
+import {
+  applyRuntimeConversationAction,
+  clearRuntimeConversationCacheForTests,
+} from '@/features/workbench/runtimeConversationCache'
 import { installDshUiTestContributions } from '@/test/setup'
 import { CloudTodoBoardCard } from './CloudTodoBoardCard'
 
@@ -93,8 +97,29 @@ const snapshot: TaskChangeRequestSnapshot = {
   error: null,
 }
 
+function seedAssistantResponse(content: string, taskId = 'task-85') {
+  const address = { deviceId: 'local', taskId }
+  const turnId = `turn-${taskId}`
+  applyRuntimeConversationAction(address, {
+    type: 'assistant_started',
+    taskId,
+    subtaskId: turnId,
+  })
+  applyRuntimeConversationAction(address, {
+    type: 'assistant_chunk',
+    subtaskId: turnId,
+    itemId: `assistant-${taskId}`,
+    content,
+  })
+  applyRuntimeConversationAction(address, {
+    type: 'assistant_done',
+    subtaskId: turnId,
+  })
+}
+
 describe('CloudTodoBoardCard', () => {
   afterEach(() => {
+    clearRuntimeConversationCacheForTests()
     vi.useRealTimers()
   })
 
@@ -314,6 +339,7 @@ describe('CloudTodoBoardCard', () => {
 
   it('aligns the pull request status as a trailing action beside compact progress', () => {
     changeRequestMonitorMocks.useTaskChangeRequest.mockReturnValue(snapshot)
+    seedAssistantResponse('已完成布局修复')
 
     render(
       <CloudTodoBoardCard
@@ -326,7 +352,6 @@ describe('CloudTodoBoardCard', () => {
             task_title: 'Fix the board popup',
             running: false,
             changeRequestTarget: snapshot.target,
-            finalResponsePreview: '已完成布局修复',
           },
         ]}
         onClick={vi.fn()}
@@ -365,7 +390,6 @@ describe('CloudTodoBoardCard', () => {
             task_id: 'task-85',
             task_title: 'Fix the board popup',
             running: false,
-            finalResponsePreview: '已完成布局修复',
           },
         ]}
         onClick={vi.fn()}
@@ -472,6 +496,9 @@ describe('CloudTodoBoardCard', () => {
   })
 
   it('mounts the shared task conversation in the hover preview', async () => {
+    seedAssistantResponse(
+      '第一行：完成布局\n第二行：保留工具层级\n第三行：展示完整回复\n第四行：展示验证结果\n第五行：展示提交状态\n第六行：等待确认'
+    )
     render(
       <CloudTodoBoardCard
         item={{ ...item, is_unread: true }}
@@ -482,8 +509,6 @@ describe('CloudTodoBoardCard', () => {
             task_id: 'task-85',
             task_title: 'Fix the board popup',
             running: false,
-            finalResponsePreview:
-              '第一行：完成布局\n第二行：保留工具层级\n第三行：展示完整回复\n第四行：展示验证结果\n第五行：展示提交状态\n第六行：等待确认',
           },
         ]}
         onClick={vi.fn()}
@@ -526,7 +551,6 @@ describe('CloudTodoBoardCard', () => {
             task_id: 'task-85',
             task_title: 'Fix the board popup',
             running: false,
-            finalResponsePreview: '已完成',
           },
         ]}
         onClick={vi.fn()}
@@ -566,7 +590,6 @@ describe('CloudTodoBoardCard', () => {
             task_id: 'task-85',
             task_title: 'Fix the board popup',
             running: false,
-            finalResponsePreview: '已完成',
           },
         ]}
         onClick={vi.fn()}
@@ -662,7 +685,6 @@ describe('CloudTodoBoardCard', () => {
             task_id: 'task-85',
             task_title: 'Fix the board popup model',
             running: false,
-            finalResponsePreview: '已完成',
             modelSelection: {
               modelName: 'gpt-5.6-sol',
               modelType: 'public',
@@ -724,7 +746,6 @@ describe('CloudTodoBoardCard', () => {
             task_id: 'task-85',
             task_title: 'Fix the board popup',
             running: true,
-            finalResponsePreview: '已定位第一个任务的当前回复',
           },
           {
             id: 86,
@@ -732,7 +753,6 @@ describe('CloudTodoBoardCard', () => {
             task_id: 'task-86',
             task_title: 'Verify the hover behavior',
             running: true,
-            finalResponsePreview: '正在校验第二个任务的运行过程',
           },
         ]}
         onClick={vi.fn()}

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -29,19 +29,19 @@ import { getInputField } from '@/components/chat/blocks/toolBlockKinds'
 import { Tooltip } from '@/components/ui/tooltip'
 import { HoverCard } from '@/components/ui/hover-card'
 import {
-  getRuntimeConversationLiveActivitySnapshot,
-  getRuntimeConversationMessages,
+  getRuntimeConversationTurns,
   subscribeRuntimeConversation,
 } from '@/features/workbench/runtimeConversationCache'
 import {
-  runtimeLiveActivityFromSnapshot,
+  EMPTY_RUNTIME_LIVE_ACTIVITY,
+  getLatestRuntimeLiveActivityFromTurns,
   type RuntimeLiveActivity,
   type RuntimeLiveToolActivity,
 } from '@/features/workbench/runtimeThinking'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type { ModelSelectionConfig, RuntimeGoal, RuntimeTaskAddress } from '@/types/api'
-import type { WorkbenchMessage } from '@/types/workbench'
+import type { RuntimeConversationTurn } from '@/types/workbench'
 import type { ChangeRequestMonitor } from '@/features/workbench/changeRequestMonitor'
 import { useTaskChangeRequest } from '@/features/workbench/changeRequestMonitor'
 import {
@@ -50,12 +50,8 @@ import {
 } from '@/features/workbench/changeRequestStatus'
 import { isLoopItemExecutionActive } from './cloudMyWorkModel'
 import { workflowNodeExecutionMode } from '@/api/issueWorkflow'
-import {
-  finalAssistantMessagesText,
-  latestResponseLine,
-  latestAssistantMessage,
-} from './runtimeTaskResponsePreview'
 import { priorityBadgeClasses } from './todoShared'
+import { getRuntimeTaskResponsePreview } from './runtimeTaskResponsePreview'
 import { itemNeedsExecutionConfiguration } from './workflowExecutionConfig'
 import { getCurrentWorkflowNode, workflowNodeStatusLabel } from './workflowStagePresentation'
 
@@ -69,6 +65,7 @@ export interface BoardCardDisplaySettings {
 export type BoardCardProgressDisplay = 'compact' | 'focused'
 
 const MARK_READ_PREVIEW_DELAY_MS = 3000
+const EMPTY_RUNTIME_CONVERSATION_TURNS: RuntimeConversationTurn[] = []
 
 const priorityLabels: Record<CloudLoopItem['priority'], string> = {
   none: '普通',
@@ -300,7 +297,6 @@ export interface CloudTodoBoardTaskBinding {
   workflow_node_id?: string | null
   running: boolean
   changeRequestTarget?: TaskChangeRequestTarget | null
-  finalResponsePreview?: string | null
   modelSelection?: ModelSelectionConfig | null
   runtimeGoal?: RuntimeGoal | null
   runtimeGoalLoaded?: boolean
@@ -660,19 +656,14 @@ function RuntimeTaskProgressSummary({
     }),
     [binding.device_id, binding.modelSelection, binding.task_id]
   )
-  const activityAddress = active ? taskAddress : null
   useEffect(() => {
     if (binding.runtimeGoalLoaded || !onLoadRuntimeGoal) return
     void onLoadRuntimeGoal(taskAddress)
   }, [binding.runtimeGoalLoaded, onLoadRuntimeGoal, taskAddress])
-  const activity = useRuntimeTaskActivity(activityAddress)
-  const liveMessage = useRuntimeTaskLatestAssistantMessage(activity.active ? taskAddress : null)
-  const cachedFinalResponse = useRuntimeTaskFinalResponse(
-    item.status === 'in_review' && !activity.active ? taskAddress : null
+  const { activity, responsePreview } = useRuntimeTaskProjection(
+    compact ? taskAddress : null,
+    active
   )
-  const finalResponseText = binding.finalResponsePreview ?? cachedFinalResponse
-  const responseText = activity.active ? liveMessage?.content?.trim() || null : finalResponseText
-  const responsePreview = responseText ? latestResponseLine(responseText) : null
   const taskTitle = binding.task_title || binding.task_id
   const showCompactChangeRequest = compact && Boolean(changeRequestSnapshot?.changeRequest)
 
@@ -930,55 +921,37 @@ function RuntimeTaskToolActivity({
   )
 }
 
-function useRuntimeTaskActivity(address: RuntimeTaskAddress | null): RuntimeLiveActivity {
+function useRuntimeTaskProjection(
+  address: RuntimeTaskAddress | null,
+  active: boolean
+): {
+  activity: RuntimeLiveActivity
+  responsePreview: string | null
+} {
   const subscribe = useCallback(
     (listener: () => void) =>
-      address ? subscribeRuntimeConversation(address, listener) : () => undefined,
-    [address]
-  )
-  const getSnapshot = useCallback(
-    () => (address ? getRuntimeConversationLiveActivitySnapshot(address) : ''),
-    [address]
-  )
-  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-
-  return useMemo(() => runtimeLiveActivityFromSnapshot(snapshot), [snapshot])
-}
-
-function useRuntimeTaskFinalResponse(address: RuntimeTaskAddress | null): string | null {
-  const subscribe = useCallback(
-    (listener: () => void) =>
-      address ? subscribeRuntimeConversation(address, listener) : () => undefined,
-    [address]
-  )
-  const getSnapshot = useCallback(
-    () => (address ? finalAssistantMessagesText(getRuntimeConversationMessages(address)) : null),
-    [address]
-  )
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-}
-
-function useRuntimeTaskLatestAssistantMessage(
-  address: RuntimeTaskAddress | null
-): WorkbenchMessage | null {
-  const subscribe = useCallback(
-    (listener: () => void) =>
-      address ? subscribeRuntimeConversation(address, listener) : () => undefined,
-    [address]
-  )
-  const getSnapshot = useCallback(
-    () =>
       address
-        ? JSON.stringify(latestAssistantMessage(getRuntimeConversationMessages(address)))
-        : '',
+        ? subscribeRuntimeConversation(address, listener, {
+            retainWhileSubscribed: false,
+          })
+        : () => undefined,
     [address]
   )
-  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-
-  return useMemo(
-    () => (snapshot ? (JSON.parse(snapshot) as WorkbenchMessage | null) : null),
-    [snapshot]
+  const getSnapshot = useCallback(
+    () => (address ? getRuntimeConversationTurns(address) : EMPTY_RUNTIME_CONVERSATION_TURNS),
+    [address]
   )
+  const turns = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  return useMemo(() => {
+    const activity = active
+      ? getLatestRuntimeLiveActivityFromTurns(turns)
+      : EMPTY_RUNTIME_LIVE_ACTIVITY
+    return {
+      activity,
+      responsePreview: getRuntimeTaskResponsePreview(turns, activity.active) || null,
+    }
+  }, [active, turns])
 }
 
 function runtimeToolActivityText(

--- a/wework/src/features/todo/CloudTodoBoardCard.tsx
+++ b/wework/src/features/todo/CloudTodoBoardCard.tsx
@@ -949,7 +949,7 @@ function useRuntimeTaskProjection(
       : EMPTY_RUNTIME_LIVE_ACTIVITY
     return {
       activity,
-      responsePreview: getRuntimeTaskResponsePreview(turns, activity.active) || null,
+      responsePreview: getRuntimeTaskResponsePreview(turns, active) || null,
     }
   }, [active, turns])
 }

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -19,6 +19,8 @@ import { RuntimeTaskLifecycleStore } from '@/features/workbench/runtimeTaskLifec
 import {
   applyRuntimeConversationAction,
   clearRuntimeConversationCacheForTests,
+  getRuntimeConversationTurns,
+  reconcileRuntimeConversationSnapshot,
 } from '@/features/workbench/runtimeConversationCache'
 import type { RuntimeTaskCreateRequest, User } from '@/types/api'
 import { CloudTodoWorkspace } from './CloudTodoWorkspace'
@@ -1535,6 +1537,7 @@ describe('CloudTodoWorkspace', () => {
       workspacePath: '/tmp/wegent',
       runtime: 'codex' as const,
       running: false,
+      fullContent: true,
       messages: [
         {
           id: 'user-output',
@@ -1565,6 +1568,7 @@ describe('CloudTodoWorkspace', () => {
       ],
     }))
     workbenchServices.runtimeWorkApi = {
+      ...workbenchServices.runtimeWorkApi,
       getRuntimeTranscript,
     } as WorkbenchServices['runtimeWorkApi']
 
@@ -1621,6 +1625,109 @@ describe('CloudTodoWorkspace', () => {
     const conversation = await screen.findByTestId('cloud-todo-card-popup-conversation-WEG-1')
     expect(conversation).toHaveAttribute('data-device-id', 'local-device')
     expect(conversation).toHaveAttribute('data-task-id', 'runtime-in-progress')
+  })
+
+  it('preserves older cached turns when the board preload transcript is bounded', async () => {
+    const workbenchServices = services()
+    const address = { deviceId: 'local-device', taskId: 'runtime-bounded' }
+    reconcileRuntimeConversationSnapshot(address, [
+      {
+        id: 'older-turn',
+        status: 'done',
+        items: [
+          {
+            id: 'older-assistant',
+            type: 'assistant_text',
+            content: 'older cached response',
+            createdAt: '2026-08-22T00:02:00Z',
+          },
+        ],
+      },
+    ])
+    workbenchServices.deliveryApi!.listTaskBindings = vi.fn(async () => [
+      {
+        id: 2,
+        loop_item_id: item.id,
+        task_user_id: 1,
+        device_id: 'local-device',
+        task_id: 'runtime-bounded',
+        task_title: '保留完整会话',
+        backend_task_id: null,
+        linked_at: '2026-08-23T00:01:00Z',
+      },
+    ])
+    const getRuntimeTranscript = vi.fn(async request => ({
+      taskId: request.taskId,
+      workspacePath: '/tmp/wegent',
+      runtime: 'codex' as const,
+      running: false,
+      fullContent: false,
+      hasMoreBefore: true,
+      beforeCursor: 'older-cursor',
+      messages: [],
+      turns: [
+        {
+          id: 'newer-turn',
+          status: 'done',
+          items: [
+            {
+              id: 'newer-assistant',
+              type: 'assistant_text' as const,
+              content: 'newer bounded response',
+              createdAt: '2026-08-23T00:02:00Z',
+            },
+          ],
+        },
+      ],
+    }))
+    workbenchServices.runtimeWorkApi = {
+      getRuntimeTranscript,
+      getRuntimeGoal: vi.fn(async () => ({ accepted: false })),
+    } as WorkbenchServices['runtimeWorkApi']
+
+    render(
+      <CloudTodoWorkspace
+        user={{ id: 1, user_name: 'local', email: 'local@example.com' } as User}
+        localProjects={[]}
+        runtimeWork={{
+          projects: [
+            {
+              project: { id: project.id, name: project.name },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'local-device',
+                  available: true,
+                  workspacePath: '/tmp/wegent',
+                  tasks: [
+                    {
+                      taskId: 'runtime-bounded',
+                      workspacePath: '/tmp/wegent',
+                      title: '保留完整会话',
+                      runtime: 'codex',
+                      running: false,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          chats: [],
+          totalTasks: 1,
+        }}
+        services={workbenchServices}
+      />
+    )
+
+    await userEvent.click((await screen.findAllByText('Wegent V4'))[0])
+    await waitFor(() =>
+      expect(screen.getByTestId('cloud-todo-card-final-response-WEG-1')).toHaveTextContent(
+        'newer bounded response'
+      )
+    )
+    expect(getRuntimeConversationTurns(address).map(turn => turn.id)).toEqual([
+      'older-turn',
+      'newer-turn',
+    ])
   })
 
   it('reports the concrete project name for the active document tab', async () => {

--- a/wework/src/features/todo/CloudTodoWorkspace.test.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.test.tsx
@@ -1549,7 +1549,20 @@ describe('CloudTodoWorkspace', () => {
           created_at: '2026-08-23T00:02:00Z',
         },
       ],
-      turns: [],
+      turns: [
+        {
+          id: 'turn-output',
+          status: 'done',
+          items: [
+            {
+              id: 'assistant-output',
+              type: 'assistant_text' as const,
+              content: '已经定位问题\n正在验证修复',
+              createdAt: '2026-08-23T00:02:00Z',
+            },
+          ],
+        },
+      ],
     }))
     workbenchServices.runtimeWorkApi = {
       getRuntimeTranscript,
@@ -1600,7 +1613,7 @@ describe('CloudTodoWorkspace', () => {
       expect.objectContaining({
         deviceId: 'local-device',
         taskId: 'runtime-in-progress',
-        limit: 50,
+        limit: 20,
       })
     )
 
@@ -5180,7 +5193,7 @@ describe('CloudTodoWorkspace', () => {
       expect.objectContaining({
         deviceId: 'local-device',
         taskId: 'stopped-task',
-        limit: 50,
+        limit: 20,
       })
     )
     expect(screen.getByTestId('cloud-todo-column-completed')).toHaveTextContent(

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -3226,7 +3226,10 @@ export function CloudTodoWorkspace({
               workspacePath: task?.workspacePath,
               runtimeHandle: task?.runtimeHandle,
             }
-            if (isRuntimePaneTranscriptConfirmedIdle(projectedTranscript)) {
+            if (
+              projectedTranscript.fullContent === true &&
+              isRuntimePaneTranscriptConfirmedIdle(projectedTranscript)
+            ) {
               replaceRuntimeConversationSnapshot(address, projectedTranscript.turns)
             } else {
               reconcileRuntimeConversationSnapshot(address, projectedTranscript.turns)

--- a/wework/src/features/todo/CloudTodoWorkspace.tsx
+++ b/wework/src/features/todo/CloudTodoWorkspace.tsx
@@ -89,7 +89,11 @@ import { cn } from '@/lib/utils'
 import { track } from '@/telemetry/client'
 import { invokeDesktopHost } from '@/api/dsh/desktopHost'
 import { getDesktopWindowLabel, isElectronRuntime } from '@/lib/runtime-environment'
-import { runtimeConversationKey } from '@/features/workbench/runtimeConversationCache'
+import {
+  reconcileRuntimeConversationSnapshot,
+  replaceRuntimeConversationSnapshot,
+  runtimeConversationKey,
+} from '@/features/workbench/runtimeConversationCache'
 import { WorkbenchContext } from '@/features/workbench/workbenchContexts'
 import {
   getChangeRequestMonitor,
@@ -105,7 +109,9 @@ import {
   completeChangeRequestAutoRepair,
 } from '@/features/workbench/changeRequestStatus'
 import {
+  isRuntimePaneTranscriptConfirmedIdle,
   isRuntimeTaskExecutionRunning,
+  projectRuntimePaneTranscript,
   runtimeTaskTrackingExecutionStatus,
 } from '@/features/workbench/runtimeTaskLifecycle/projection'
 import { createRuntimeUserMessage } from '@/features/workbench/runtimeUserMessage'
@@ -168,8 +174,8 @@ import { GlobalTodoSearch } from './GlobalTodoSearch'
 import { BoardQuickCreate } from './BoardQuickCreate'
 import { BoardQuickStartGuide } from './BoardQuickStartGuide'
 import { parseDingTalkAITableLink, repositoryProviderConfig } from './projectProviderConfig'
+import { isLoopItemExecutionActive } from './cloudMyWorkModel'
 import { isRuntimeMyWorkItem, runtimeMyWorkItems } from './runtimeMyWork'
-import { finalAssistantTranscriptText } from './runtimeTaskResponsePreview'
 import { rememberProjectTaskStore } from '@/features/workbench/projectTaskTracking'
 import { TaskSearchPanel } from './TaskSearchPanel'
 import { TodoEditor } from './TodoEditor'
@@ -1562,20 +1568,12 @@ export function CloudTodoWorkspace({
   const [runtimeBatchArchiveItems, setRuntimeBatchArchiveItems] = useState<
     LocatedLoopItem[] | null
   >(null)
-  const [runtimeConversationPreviews, setRuntimeConversationPreviews] = useState<
-    Record<
-      string,
-      {
-        signature: string
-        text: string | null
-      }
-    >
-  >({})
   const [runtimeGoalsByAddress, setRuntimeGoalsByAddress] = useState<
     Record<string, RuntimeGoal | null>
   >({})
   const runtimeConversationRequestsRef = useRef(new Set<string>())
   const runtimeConversationLatestSignatureRef = useRef(new Map<string, string>())
+  const runtimeConversationLoadedSignatureRef = useRef(new Map<string, string>())
   const runtimeGoalRequestsRef = useRef(new Set<string>())
   useEffect(() => {
     if (projectMenuId === null) return
@@ -1802,7 +1800,6 @@ export function CloudTodoWorkspace({
               taskId: binding.task_id,
             })
             const runtimeTask = runtimeTaskByAddress.get(addressKey)
-            const preview = runtimeConversationPreviews[addressKey]
             const runtimeGoalLoaded = Object.prototype.hasOwnProperty.call(
               runtimeGoalsByAddress,
               addressKey
@@ -1819,20 +1816,13 @@ export function CloudTodoWorkspace({
               changeRequestTarget: runtimeTask
                 ? runtimeTaskChangeRequestTarget(runtimeTask.workspace, runtimeTask.task)
                 : null,
-              finalResponsePreview: preview?.text ?? null,
               runtimeGoal: runtimeGoalsByAddress[addressKey] ?? null,
               runtimeGoalLoaded,
             }
           }),
         ])
       ),
-    [
-      itemTaskBindings,
-      runtimeConversationPreviews,
-      runtimeGoalsByAddress,
-      runtimeTaskByAddress,
-      runtimeTaskRunningByAddress,
-    ]
+    [itemTaskBindings, runtimeGoalsByAddress, runtimeTaskByAddress, runtimeTaskRunningByAddress]
   )
   const loadBoardTaskRuntimeGoal = useCallback(
     async (address: RuntimeTaskAddress): Promise<void> => {
@@ -3195,6 +3185,7 @@ export function CloudTodoWorkspace({
       return
     }
     for (const item of items) {
+      if (item.status !== 'in_review' && !isLoopItemExecutionActive(item)) continue
       for (const binding of itemTaskBindings[item.id] ?? []) {
         const addressKey = runtimeConversationKey({
           deviceId: binding.device_id,
@@ -3207,7 +3198,7 @@ export function CloudTodoWorkspace({
           task?.status ?? '',
           task?.turnStatus ?? '',
         ].join(':')
-        if (runtimeConversationPreviews[addressKey]?.signature === signature) continue
+        if (runtimeConversationLoadedSignatureRef.current.get(addressKey) === signature) continue
         const requestKey = `${addressKey}:${signature}`
         if (runtimeConversationRequestsRef.current.has(requestKey)) continue
         runtimeConversationRequestsRef.current.add(requestKey)
@@ -3220,20 +3211,27 @@ export function CloudTodoWorkspace({
             threadId: task?.threadId,
             workspacePath: task?.workspacePath,
             runtimeHandle: task?.runtimeHandle,
-            limit: 50,
+            limit: 20,
           })
           .then(transcript => {
             if (runtimeConversationLatestSignatureRef.current.get(addressKey) !== signature) {
               return
             }
-            const text = finalAssistantTranscriptText(transcript)
-            setRuntimeConversationPreviews(current => ({
-              ...current,
-              [addressKey]: {
-                signature,
-                text,
-              },
-            }))
+            const projectedTranscript = projectRuntimePaneTranscript(transcript)
+            const address = {
+              deviceId: binding.device_id,
+              taskId: binding.task_id,
+              runtime: task?.runtime,
+              threadId: task?.threadId,
+              workspacePath: task?.workspacePath,
+              runtimeHandle: task?.runtimeHandle,
+            }
+            if (isRuntimePaneTranscriptConfirmedIdle(projectedTranscript)) {
+              replaceRuntimeConversationSnapshot(address, projectedTranscript.turns)
+            } else {
+              reconcileRuntimeConversationSnapshot(address, projectedTranscript.turns)
+            }
+            runtimeConversationLoadedSignatureRef.current.set(addressKey, signature)
           })
           .catch(error => {
             console.warn('[Wework project board] failed to preload task conversation', {
@@ -3246,13 +3244,6 @@ export function CloudTodoWorkspace({
             if (runtimeConversationLatestSignatureRef.current.get(addressKey) !== signature) {
               return
             }
-            setRuntimeConversationPreviews(current => ({
-              ...current,
-              [addressKey]: {
-                signature,
-                text: null,
-              },
-            }))
           })
           .finally(() => {
             runtimeConversationRequestsRef.current.delete(requestKey)
@@ -3263,7 +3254,6 @@ export function CloudTodoWorkspace({
     itemTaskBindings,
     itemTaskBindingsProjectKey,
     items,
-    runtimeConversationPreviews,
     runtimeTasksByKey,
     selectedProjectKey,
     services.runtimeWorkApi,

--- a/wework/src/features/todo/runtimeTaskResponsePreview.test.ts
+++ b/wework/src/features/todo/runtimeTaskResponsePreview.test.ts
@@ -1,129 +1,99 @@
-import { describe, expect, it } from 'vitest'
-import {
-  finalAssistantMessagesText,
-  finalAssistantMessagesPreview,
-  finalAssistantTranscriptText,
-  finalAssistantTranscriptPreview,
-} from './runtimeTaskResponsePreview'
+import { describe, expect, test } from 'vitest'
+import type { RuntimeConversationTurn } from '@/types/workbench'
+import { getRuntimeTaskResponsePreview } from './runtimeTaskResponsePreview'
 
 describe('runtimeTaskResponsePreview', () => {
-  it('uses the latest non-empty assistant response when a trailing placeholder is empty', () => {
-    expect(
-      finalAssistantMessagesPreview([
-        {
-          role: 'assistant',
-          content: '第一行\n第二行\n第三行\n第四行',
-        },
-        {
-          role: 'assistant',
-          content: '',
-        },
-      ])
-    ).toBe('第四行')
-  })
-
-  test('keeps the full final assistant response for expanded progress details', () => {
-    const messages = [
+  test('reads only the latest response line from canonical turns', () => {
+    const turns: RuntimeConversationTurn[] = [
       {
-        role: 'assistant',
-        content: '第一行\n第二行\n第三行\n第四行',
+        id: 'turn-1',
+        status: 'streaming',
+        items: [
+          {
+            id: 'tool-1',
+            type: 'block',
+            block: {
+              id: 'tool-1',
+              subtaskId: 'turn-1',
+              type: 'tool',
+              toolName: 'functions.apply_patch',
+              toolInput: { patch: 'x'.repeat(100_000) },
+              status: 'done',
+              createdAt: 1,
+            },
+          },
+          {
+            id: 'assistant-1',
+            type: 'assistant_text',
+            content: 'older response line\nlatest response line',
+            createdAt: '2026-09-11T00:00:00Z',
+          },
+        ],
       },
     ]
 
-    expect(finalAssistantMessagesText(messages)).toBe('第一行\n第二行\n第三行\n第四行')
-    expect(
-      finalAssistantTranscriptText({
-        messages: [],
-        turns: [
-          {
-            items: [
-              {
-                type: 'assistant_text',
-                content: '第一行\n第二行\n第三行\n第四行',
-              },
-            ],
-          },
-        ],
-      })
-    ).toBe('第一行\n第二行\n第三行\n第四行')
+    expect(getRuntimeTaskResponsePreview(turns, true)).toBe('latest response line')
   })
 
-  it('falls back to canonical assistant turn items', () => {
-    expect(
-      finalAssistantTranscriptPreview({
-        messages: [],
-        turns: [
+  test('does not fall back to an older turn while the latest turn is active', () => {
+    const turns: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        status: 'completed',
+        items: [
           {
-            items: [
-              {
-                type: 'assistant_text',
-                content: '完成修复\n测试通过',
-              },
-            ],
+            id: 'assistant-1',
+            type: 'assistant_text',
+            content: 'older response',
+            createdAt: '2026-09-11T00:00:00Z',
           },
         ],
-      })
-    ).toBe('测试通过')
+      },
+      {
+        id: 'turn-2',
+        status: 'streaming',
+        items: [
+          {
+            id: 'tool-2',
+            type: 'block',
+            block: {
+              id: 'tool-2',
+              subtaskId: 'turn-2',
+              type: 'tool',
+              toolName: 'functions.exec_command',
+              status: 'streaming',
+              createdAt: 2,
+            },
+          },
+        ],
+      },
+    ]
+
+    expect(getRuntimeTaskResponsePreview(turns, true)).toBe('')
   })
 
-  it('uses the final response from the latest turn instead of an older message', () => {
-    expect(
-      finalAssistantTranscriptText({
-        messages: [
+  test('uses the latest completed text block when there is no assistant text item', () => {
+    const turns: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        status: 'completed',
+        items: [
           {
-            role: 'assistant',
-            content: '几轮之前的 final content',
+            id: 'text-1',
+            type: 'block',
+            block: {
+              id: 'text-1',
+              subtaskId: 'turn-1',
+              type: 'text',
+              content: 'completed response',
+              status: 'done',
+              createdAt: 1,
+            },
           },
         ],
-        turns: [
-          {
-            items: [
-              {
-                type: 'assistant_text',
-                content: '旧一轮回复',
-              },
-            ],
-          },
-          {
-            items: [
-              {
-                type: 'assistant_text',
-                content: '最后一轮回复',
-              },
-            ],
-          },
-        ],
-      })
-    ).toBe('最后一轮回复')
-  })
+      },
+    ]
 
-  it('does not fall back to an older response when the latest turn has no final content', () => {
-    expect(
-      finalAssistantTranscriptText({
-        messages: [
-          {
-            role: 'assistant',
-            content: '几轮之前的 final content',
-          },
-        ],
-        turns: [
-          {
-            items: [
-              {
-                type: 'assistant_text',
-                content: '旧一轮回复',
-              },
-            ],
-          },
-          {
-            items: [
-              {
-                type: 'block',
-              },
-            ],
-          },
-        ],
-      })
-    ).toBeNull()
+    expect(getRuntimeTaskResponsePreview(turns, false)).toBe('completed response')
   })
 })

--- a/wework/src/features/todo/runtimeTaskResponsePreview.test.ts
+++ b/wework/src/features/todo/runtimeTaskResponsePreview.test.ts
@@ -72,6 +72,30 @@ describe('runtimeTaskResponsePreview', () => {
     expect(getRuntimeTaskResponsePreview(turns, true)).toBe('')
   })
 
+  test('does not fall back while the newest active turn has no visible activity', () => {
+    const turns: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        status: 'completed',
+        items: [
+          {
+            id: 'assistant-1',
+            type: 'assistant_text',
+            content: 'older response',
+            createdAt: '2026-09-11T00:00:00Z',
+          },
+        ],
+      },
+      {
+        id: 'turn-2',
+        status: 'pending',
+        items: [],
+      },
+    ]
+
+    expect(getRuntimeTaskResponsePreview(turns, true)).toBe('')
+  })
+
   test('uses the latest completed text block when there is no assistant text item', () => {
     const turns: RuntimeConversationTurn[] = [
       {
@@ -95,5 +119,30 @@ describe('runtimeTaskResponsePreview', () => {
     ]
 
     expect(getRuntimeTaskResponsePreview(turns, false)).toBe('completed response')
+  })
+
+  test('ignores unfinished text blocks when selecting a completed response', () => {
+    const turns: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        status: 'completed',
+        items: [
+          {
+            id: 'text-1',
+            type: 'block',
+            block: {
+              id: 'text-1',
+              subtaskId: 'turn-1',
+              type: 'text',
+              content: 'partial response',
+              status: 'streaming',
+              createdAt: 1,
+            },
+          },
+        ],
+      },
+    ]
+
+    expect(getRuntimeTaskResponsePreview(turns, false)).toBe('')
   })
 })

--- a/wework/src/features/todo/runtimeTaskResponsePreview.ts
+++ b/wework/src/features/todo/runtimeTaskResponsePreview.ts
@@ -1,93 +1,78 @@
-interface RuntimeResponseBlock {
-  type?: string | null
-  content?: unknown
-}
+import type { RuntimeConversationTurn } from '@/types/workbench'
 
-interface RuntimeResponseMessage {
-  role?: string | null
-  content?: string | null
-  blocks?: readonly RuntimeResponseBlock[] | null
-}
-
-interface RuntimeResponseTurn {
-  items: readonly {
-    type: string
-    content?: unknown
-  }[]
-}
-
-export function latestResponseLine(value: string): string | null {
-  const lines = value
-    .split(/\r?\n/)
-    .map(line => line.trim())
-    .filter(Boolean)
-  return lines.at(-1) ?? null
-}
-
-export function finalAssistantMessagesPreview(
-  messages: readonly RuntimeResponseMessage[]
-): string | null {
-  const response = finalAssistantMessagesText(messages)
-  return response ? latestResponseLine(response) : null
-}
-
-export function finalAssistantMessagesText(
-  messages: readonly RuntimeResponseMessage[]
-): string | null {
-  for (const message of [...messages].reverse()) {
-    if (!message.role?.toLowerCase().startsWith('assistant')) continue
-    const content = messageText(message)
-    if (content) return content
+export function getRuntimeTaskResponsePreview(
+  turns: RuntimeConversationTurn[],
+  active: boolean
+): string {
+  for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex -= 1) {
+    const turn = turns[turnIndex]
+    if (!turn) continue
+    let segmentEnd = turn.items.length
+    while (segmentEnd > 0) {
+      const previousUserIndex = turn.items.findLastIndex(
+        (item, itemIndex) => itemIndex < segmentEnd && item.type === 'user_message'
+      )
+      const segmentStart = previousUserIndex + 1
+      const assistantLine = latestAssistantTextLine(turn.items, segmentStart, segmentEnd)
+      const hasBlocks = segmentHasBlocks(turn.items, segmentStart, segmentEnd)
+      if (active && (assistantLine || hasBlocks)) return assistantLine
+      if (!active) {
+        const blockLine = latestTextBlockLine(turn.items, segmentStart, segmentEnd)
+        if (assistantLine || blockLine) return assistantLine || blockLine
+      }
+      segmentEnd = previousUserIndex
+    }
   }
-  return null
+  return ''
 }
 
-export function latestAssistantMessage<T extends RuntimeResponseMessage>(
-  messages: readonly T[]
-): T | null {
-  for (const message of [...messages].reverse()) {
-    if (!message.role?.toLowerCase().startsWith('assistant')) continue
-    if (messageText(message) || message.blocks?.length) return message
+function latestAssistantTextLine(
+  items: RuntimeConversationTurn['items'],
+  start: number,
+  end: number
+): string {
+  for (let index = end - 1; index >= start; index -= 1) {
+    const item = items[index]
+    if (item?.type !== 'assistant_text') continue
+    const line = latestNonEmptyLine(item.content)
+    if (line) return line
   }
-  return null
+  return ''
 }
 
-export function finalAssistantTranscriptMessage<T extends RuntimeResponseMessage>(transcript: {
-  messages: readonly T[]
-}): T | null {
-  return latestAssistantMessage(transcript.messages)
+function latestTextBlockLine(
+  items: RuntimeConversationTurn['items'],
+  start: number,
+  end: number
+): string {
+  for (let index = end - 1; index >= start; index -= 1) {
+    const item = items[index]
+    if (item?.type !== 'block' || item.block.type !== 'text') continue
+    const line = latestNonEmptyLine(item.block.content)
+    if (line) return line
+  }
+  return ''
 }
 
-export function finalAssistantTranscriptPreview(transcript: {
-  messages: readonly RuntimeResponseMessage[]
-  turns: readonly RuntimeResponseTurn[]
-}): string | null {
-  const response = finalAssistantTranscriptText(transcript)
-  return response ? latestResponseLine(response) : null
+function segmentHasBlocks(
+  items: RuntimeConversationTurn['items'],
+  start: number,
+  end: number
+): boolean {
+  for (let index = end - 1; index >= start; index -= 1) {
+    if (items[index]?.type === 'block') return true
+  }
+  return false
 }
 
-export function finalAssistantTranscriptText(transcript: {
-  messages: readonly RuntimeResponseMessage[]
-  turns: readonly RuntimeResponseTurn[]
-}): string | null {
-  const latestTurn = transcript.turns.at(-1)
-  if (!latestTurn) return finalAssistantMessagesText(transcript.messages)
-
-  const content = latestTurn.items
-    .flatMap(item =>
-      item.type === 'assistant_text' && typeof item.content === 'string' ? [item.content] : []
-    )
-    .join('\n')
-    .trim()
-  return content || null
-}
-
-function messageText(message: RuntimeResponseMessage): string {
-  if (message.content?.trim()) return message.content.trim()
-  return (message.blocks ?? [])
-    .flatMap(block =>
-      block.type === 'text' && typeof block.content === 'string' ? [block.content] : []
-    )
-    .join('\n')
-    .trim()
+function latestNonEmptyLine(value: string): string {
+  let end = value.length
+  while (end > 0) {
+    const start = value.lastIndexOf('\n', end - 1) + 1
+    const line = value.slice(start, end).trim()
+    if (line) return line
+    if (start === 0) break
+    end = start - 1
+  }
+  return ''
 }

--- a/wework/src/features/todo/runtimeTaskResponsePreview.ts
+++ b/wework/src/features/todo/runtimeTaskResponsePreview.ts
@@ -7,6 +7,8 @@ export function getRuntimeTaskResponsePreview(
   for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex -= 1) {
     const turn = turns[turnIndex]
     if (!turn) continue
+    const activeTurn = active && (turn.status === 'pending' || turn.status === 'streaming')
+    if (activeTurn && turn.items.length === 0) return ''
     let segmentEnd = turn.items.length
     while (segmentEnd > 0) {
       const previousUserIndex = turn.items.findLastIndex(
@@ -14,12 +16,9 @@ export function getRuntimeTaskResponsePreview(
       )
       const segmentStart = previousUserIndex + 1
       const assistantLine = latestAssistantTextLine(turn.items, segmentStart, segmentEnd)
-      const hasBlocks = segmentHasBlocks(turn.items, segmentStart, segmentEnd)
-      if (active && (assistantLine || hasBlocks)) return assistantLine
-      if (!active) {
-        const blockLine = latestTextBlockLine(turn.items, segmentStart, segmentEnd)
-        if (assistantLine || blockLine) return assistantLine || blockLine
-      }
+      if (activeTurn) return assistantLine
+      const blockLine = active ? '' : latestTextBlockLine(turn.items, segmentStart, segmentEnd)
+      if (assistantLine || blockLine) return assistantLine || blockLine
       segmentEnd = previousUserIndex
     }
   }
@@ -47,22 +46,13 @@ function latestTextBlockLine(
 ): string {
   for (let index = end - 1; index >= start; index -= 1) {
     const item = items[index]
-    if (item?.type !== 'block' || item.block.type !== 'text') continue
+    if (item?.type !== 'block' || item.block.type !== 'text' || item.block.status !== 'done') {
+      continue
+    }
     const line = latestNonEmptyLine(item.block.content)
     if (line) return line
   }
   return ''
-}
-
-function segmentHasBlocks(
-  items: RuntimeConversationTurn['items'],
-  start: number,
-  end: number
-): boolean {
-  for (let index = end - 1; index >= start; index -= 1) {
-    if (items[index]?.type === 'block') return true
-  }
-  return false
 }
 
 function latestNonEmptyLine(value: string): string {

--- a/wework/src/features/workbench/runtimeConversationCache.test.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.test.ts
@@ -16,16 +16,17 @@ import {
   getConversationScrollSnapshot,
   getConversationVirtualMeasurements,
   getRuntimeConversationCacheStats,
-  getRuntimeConversationLiveActivitySnapshot,
   getRuntimeConversationMetadata,
   getRuntimeConversationMessages,
   getRuntimeConversationMessagesForLogicalAddress,
   getRuntimeConversationQueuedMessages,
   getRuntimeConversationQueuePaused,
+  getRuntimeConversationTurns,
   markRuntimeConversationGuidanceInterrupted,
   optimisticallyInterruptRuntimeConversation,
   removeOptimisticRuntimeConversationGuidance,
   reconcileRuntimeConversationQueueAfterTransportReplacement,
+  replaceRuntimeConversationSnapshot,
   markRuntimeConversationAssistantStarted,
   runtimeConversationSnapshotSettlesLatestTurn,
   subscribeRuntimeConversation,
@@ -38,6 +39,7 @@ import {
   takeInterruptedRuntimeConversationGuidance,
   restoreOptimisticallyInterruptedRuntimeConversation,
 } from './runtimeConversationCache'
+import { getLatestRuntimeLiveActivityFromTurns } from './runtimeThinking'
 
 const address = {
   deviceId: 'device-1',
@@ -118,7 +120,120 @@ describe('runtimeConversationCache', () => {
       subtaskId: 'turn-1',
     })
 
-    expect(getRuntimeConversationLiveActivitySnapshot(address)).toBe('')
+    expect(getLatestRuntimeLiveActivityFromTurns(getRuntimeConversationTurns(address))).toEqual({
+      active: false,
+      thinking: '',
+      processText: '',
+      tools: [],
+    })
+  })
+
+  test('replaces stale terminal turns with an authoritative idle snapshot', () => {
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_started',
+      taskId: address.taskId,
+      subtaskId: 'stale-turn',
+    })
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_chunk',
+      subtaskId: 'stale-turn',
+      itemId: 'stale-assistant',
+      content: 'stale output',
+    })
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_done',
+      subtaskId: 'stale-turn',
+    })
+
+    replaceRuntimeConversationSnapshot(address, [
+      {
+        id: 'server-turn',
+        status: 'done',
+        items: [
+          {
+            id: 'server-assistant',
+            type: 'assistant_text',
+            content: 'authoritative output',
+            createdAt: '2026-09-11T00:00:00Z',
+          },
+        ],
+      },
+    ])
+
+    expect(getRuntimeConversationTurns(address)).toEqual([
+      expect.objectContaining({
+        id: 'server-turn',
+        items: [expect.objectContaining({ content: 'authoritative output' })],
+      }),
+    ])
+  })
+
+  test('evicts an unobserved terminal conversation after the idle ttl', () => {
+    vi.useFakeTimers()
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_started',
+      taskId: address.taskId,
+      subtaskId: 'turn-1',
+    })
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_done',
+      subtaskId: 'turn-1',
+    })
+
+    vi.advanceTimersByTime(5 * 60 * 1000 - 1)
+    expect(getRuntimeConversationCacheStats().messageEntries).toBe(1)
+
+    vi.advanceTimersByTime(1)
+    expect(getRuntimeConversationCacheStats().messageEntries).toBe(0)
+    vi.useRealTimers()
+  })
+
+  test('keeps a terminal conversation while a view is subscribed', () => {
+    vi.useFakeTimers()
+    const unsubscribe = subscribeRuntimeConversation(address, () => undefined)
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_started',
+      taskId: address.taskId,
+      subtaskId: 'turn-1',
+    })
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_done',
+      subtaskId: 'turn-1',
+    })
+
+    vi.advanceTimersByTime(5 * 60 * 1000)
+    expect(getRuntimeConversationCacheStats().messageEntries).toBe(1)
+
+    unsubscribe()
+    vi.advanceTimersByTime(5 * 60 * 1000)
+    expect(getRuntimeConversationCacheStats().messageEntries).toBe(0)
+    vi.useRealTimers()
+  })
+
+  test('expires a terminal conversation observed only by a board summary', () => {
+    vi.useFakeTimers()
+    const listener = vi.fn()
+    const unsubscribe = subscribeRuntimeConversation(address, listener, {
+      retainWhileSubscribed: false,
+    })
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_started',
+      taskId: address.taskId,
+      subtaskId: 'turn-1',
+    })
+    applyRuntimeConversationAction(address, {
+      type: 'assistant_done',
+      subtaskId: 'turn-1',
+    })
+    listener.mockClear()
+
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(getRuntimeConversationCacheStats().messageEntries).toBe(0)
+    expect(getRuntimeConversationTurns(address)).toEqual([])
+    expect(listener).toHaveBeenCalledTimes(1)
+    unsubscribe()
+    vi.useRealTimers()
   })
 
   test('keeps a replacement hydration active when the older request resolves later', () => {
@@ -141,9 +256,9 @@ describe('runtimeConversationCache', () => {
     abortRuntimeConversationHydration(address, olderToken)
     completeRuntimeConversationHydration(address, replacementToken, [])
 
-    expect(getRuntimeConversationLiveActivitySnapshot(address)).toContain(
-      'replacement request activity'
-    )
+    expect(
+      getLatestRuntimeLiveActivityFromTurns(getRuntimeConversationTurns(address)).thinking
+    ).toBe('replacement request activity')
   })
 
   test('reconciles buffered completion with the canonical hydration snapshot', () => {

--- a/wework/src/features/workbench/runtimeConversationCache.ts
+++ b/wework/src/features/workbench/runtimeConversationCache.ts
@@ -9,11 +9,11 @@ import type {
   RuntimeTaskAddress,
 } from '@/types/api'
 import type {
+  ProcessingBlock,
   RuntimeConversationTurn,
   RuntimePaneQueuedMessage,
   RuntimeSubagentStatus,
   WorkbenchMessage,
-  ProcessingBlock,
 } from '@/types/workbench'
 import type { VirtualItem } from '@tanstack/react-virtual'
 import {
@@ -28,12 +28,16 @@ import {
   createOptimisticRuntimeGuidanceMessage,
 } from './runtimeGuidanceMessages'
 import { updateRuntimeGoalContinuation } from '@/lib/runtime-goal'
-import { getLatestRuntimeLiveActivity, runtimeLiveActivitySnapshot } from './runtimeThinking'
-
 const MAX_CONVERSATION_CACHE_ENTRIES = 50
+const TERMINAL_CONVERSATION_IDLE_TTL_MS = 5 * 60 * 1000
+const EMPTY_RUNTIME_CONVERSATION_TURNS: RuntimeConversationTurn[] = []
 const turnsByConversation = new Map<string, RuntimeConversationTurn[]>()
 const metadataByConversation = new Map<string, RuntimeConversationMetadata>()
 const listenersByConversation = new Map<string, Set<(action?: RuntimePaneMessageAction) => void>>()
+const retainingListenersByConversation = new Map<
+  string,
+  Set<(action?: RuntimePaneMessageAction) => void>
+>()
 const runtimeTransportReplacedListeners = new Set<
   (payload: RuntimeTransportReplacedPayload) => void
 >()
@@ -50,6 +54,10 @@ const interruptedGuidanceIdsByConversation = new Map<string, Set<string>>()
 const scrollSnapshotsByConversation = new Map<string, ConversationScrollSnapshot>()
 const virtualMeasurementsByConversation = new Map<string, VirtualItem[]>()
 const pendingStreamingNotifications = new Map<string, () => void>()
+const terminalConversationEvictionTimers = new Map<
+  string,
+  ReturnType<typeof globalThis.setTimeout>
+>()
 
 export interface ConversationScrollSnapshot {
   distanceFromBottomPx: number
@@ -161,6 +169,13 @@ export function getRuntimeConversationMessages(address: RuntimeTaskAddress): Wor
   return projectRuntimeConversationTurns(touchEntry(turnsByConversation, key) ?? [])
 }
 
+export function getRuntimeConversationTurns(
+  address: RuntimeTaskAddress
+): RuntimeConversationTurn[] {
+  const key = runtimeConversationKey(address)
+  return turnsByConversation.get(key) ?? EMPTY_RUNTIME_CONVERSATION_TURNS
+}
+
 export function getRuntimeConversationMessagesForLogicalAddress(
   address: RuntimeTaskAddress
 ): WorkbenchMessage[] {
@@ -195,23 +210,30 @@ export function runtimeConversationMessageHasStartedTurn(
   )
 }
 
-export function getRuntimeConversationLiveActivitySnapshot(address: RuntimeTaskAddress): string {
-  return runtimeLiveActivitySnapshot(
-    getLatestRuntimeLiveActivity(getRuntimeConversationMessages(address))
-  )
-}
-
 export function subscribeRuntimeConversation(
   address: RuntimeTaskAddress,
-  listener: (action?: RuntimePaneMessageAction) => void
+  listener: (action?: RuntimePaneMessageAction) => void,
+  options?: {
+    retainWhileSubscribed?: boolean
+  }
 ): () => void {
   const key = runtimeConversationKey(address)
   const listeners = listenersByConversation.get(key) ?? new Set()
   listeners.add(listener)
   listenersByConversation.set(key, listeners)
+  if (options?.retainWhileSubscribed !== false) {
+    cancelTerminalConversationEviction(key)
+    const retainingListeners = retainingListenersByConversation.get(key) ?? new Set()
+    retainingListeners.add(listener)
+    retainingListenersByConversation.set(key, retainingListeners)
+  }
   return () => {
     listeners.delete(listener)
     if (listeners.size === 0) listenersByConversation.delete(key)
+    const retainingListeners = retainingListenersByConversation.get(key)
+    retainingListeners?.delete(listener)
+    if (retainingListeners?.size === 0) retainingListenersByConversation.delete(key)
+    scheduleTerminalConversationEviction(key)
   }
 }
 
@@ -230,6 +252,7 @@ export function beginRuntimeConversationHydration(address: RuntimeTaskAddress): 
   const key = runtimeConversationKey(address)
   const existing = hydrationByConversation.get(key)
   if (existing) return existing.token
+  cancelTerminalConversationEviction(key)
   const token = Symbol(key)
   hydrationByConversation.set(key, { token, bufferedActions: [] })
   return token
@@ -283,6 +306,16 @@ export function reconcileRuntimeConversationSnapshot(
   cacheRuntimeConversationTurns(key, turns)
   notifyRuntimeConversation(key)
   return projectRuntimeConversationTurns(turns)
+}
+
+export function replaceRuntimeConversationSnapshot(
+  address: RuntimeTaskAddress,
+  snapshotTurns: RuntimeConversationTurn[]
+): WorkbenchMessage[] {
+  const key = runtimeConversationKey(address)
+  cacheRuntimeConversationTurns(key, snapshotTurns)
+  notifyRuntimeConversation(key)
+  return projectRuntimeConversationTurns(snapshotTurns)
 }
 
 export function runtimeConversationSnapshotSettlesLatestTurn(
@@ -424,8 +457,10 @@ export function cacheRuntimeConversationQueuedMessagesByKey(
 ) {
   if (messages.length === 0) {
     queuedMessagesByConversation.delete(key)
+    scheduleTerminalConversationEviction(key)
     return
   }
+  cancelTerminalConversationEviction(key)
   cacheBoundedEntry(queuedMessagesByConversation, key, messages)
 }
 
@@ -839,8 +874,12 @@ function shortRuntimeAgentId(agentId: string): string {
 }
 
 export function evictRuntimeConversation(address: RuntimeTaskAddress) {
-  const key = runtimeConversationKey(address)
+  evictRuntimeConversationKey(runtimeConversationKey(address))
+}
+
+function evictRuntimeConversationKey(key: string) {
   cancelPendingStreamingNotification(key)
+  cancelTerminalConversationEviction(key)
   turnsByConversation.delete(key)
   metadataByConversation.delete(key)
   hydrationByConversation.delete(key)
@@ -862,9 +901,12 @@ export function getRuntimeConversationCacheStats() {
 export function clearRuntimeConversationCacheForTests() {
   pendingStreamingNotifications.forEach(cancel => cancel())
   pendingStreamingNotifications.clear()
+  terminalConversationEvictionTimers.forEach(timer => globalThis.clearTimeout(timer))
+  terminalConversationEvictionTimers.clear()
   turnsByConversation.clear()
   metadataByConversation.clear()
   listenersByConversation.clear()
+  retainingListenersByConversation.clear()
   runtimeTransportReplacedListeners.clear()
   hydrationByConversation.clear()
   queuedMessagesByConversation.clear()
@@ -935,7 +977,42 @@ function touchEntry<T>(entries: Map<string, T>, key: string): T | undefined {
 }
 
 function cacheRuntimeConversationTurns(key: string, turns: RuntimeConversationTurn[]) {
-  cacheBoundedEntry(turnsByConversation, key, turns, cancelPendingStreamingNotification)
+  cacheBoundedEntry(turnsByConversation, key, turns, evictedKey => {
+    cancelPendingStreamingNotification(evictedKey)
+    cancelTerminalConversationEviction(evictedKey)
+  })
+  scheduleTerminalConversationEviction(key)
+}
+
+function scheduleTerminalConversationEviction(key: string): void {
+  cancelTerminalConversationEviction(key)
+  if (!canEvictTerminalConversation(key)) return
+
+  const timer = globalThis.setTimeout(() => {
+    terminalConversationEvictionTimers.delete(key)
+    if (!canEvictTerminalConversation(key)) return
+    evictRuntimeConversationKey(key)
+    notifyRuntimeConversation(key)
+  }, TERMINAL_CONVERSATION_IDLE_TTL_MS)
+  terminalConversationEvictionTimers.set(key, timer)
+}
+
+function canEvictTerminalConversation(key: string): boolean {
+  const turns = turnsByConversation.get(key)
+  return Boolean(
+    turns &&
+    !retainingListenersByConversation.has(key) &&
+    !hydrationByConversation.has(key) &&
+    (queuedMessagesByConversation.get(key)?.length ?? 0) === 0 &&
+    !turns.some(turn => turn.status === 'pending' || turn.status === 'streaming')
+  )
+}
+
+function cancelTerminalConversationEviction(key: string): void {
+  const timer = terminalConversationEvictionTimers.get(key)
+  if (timer === undefined) return
+  globalThis.clearTimeout(timer)
+  terminalConversationEvictionTimers.delete(key)
 }
 
 function cacheBoundedEntry<T>(

--- a/wework/src/features/workbench/runtimeThinking.test.ts
+++ b/wework/src/features/workbench/runtimeThinking.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { WorkbenchMessage } from '@/types/workbench'
-import {
-  EMPTY_RUNTIME_LIVE_ACTIVITY,
-  getLatestRuntimeLiveActivity,
-  runtimeLiveActivityFromSnapshot,
-  runtimeLiveActivitySnapshot,
-} from './runtimeThinking'
+import { getLatestRuntimeLiveActivity } from './runtimeThinking'
 
 describe('runtimeThinking', () => {
   test('projects the latest process text separately from private thinking', () => {
@@ -39,38 +34,36 @@ describe('runtimeThinking', () => {
 
     const activity = getLatestRuntimeLiveActivity([message])
 
-    expect(activity.processText).toBe('先定位卡片的数据来源。')
     expect(activity.thinking).toBe('Private chain of thought')
+    expect(activity.processText).toBe('先定位卡片的数据来源。')
   })
 
-  test('round trips process text in the compact live-activity snapshot', () => {
-    const activity = {
-      active: true,
-      processText: '正在运行聚焦测试。',
-      thinking: '',
-      tools: [],
+  test('bounds tool history and large tool inputs in live activity', () => {
+    const message: WorkbenchMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      status: 'streaming',
+      createdAt: '2026-09-11T00:00:00Z',
+      blocks: Array.from({ length: 5 }, (_, index) => ({
+        id: `tool-${index}`,
+        subtaskId: 'turn-1',
+        type: 'tool' as const,
+        toolName: 'functions.apply_patch',
+        toolInput: {
+          patch: `${index}:${'x'.repeat(10_000)}`,
+          unrelatedPayload: 'y'.repeat(10_000),
+        },
+        status: 'done' as const,
+        createdAt: index,
+      })),
     }
 
-    expect(runtimeLiveActivityFromSnapshot(runtimeLiveActivitySnapshot(activity))).toEqual(activity)
-  })
+    const activity = getLatestRuntimeLiveActivity([message])
 
-  test('falls back safely for malformed live-activity snapshots', () => {
-    expect(runtimeLiveActivityFromSnapshot('{invalid')).toEqual(EMPTY_RUNTIME_LIVE_ACTIVITY)
-    expect(runtimeLiveActivityFromSnapshot('null')).toEqual(EMPTY_RUNTIME_LIVE_ACTIVITY)
-    expect(
-      runtimeLiveActivityFromSnapshot(
-        JSON.stringify({
-          active: true,
-          processText: 42,
-          thinking: null,
-          tools: { id: 'not-an-array' },
-        })
-      )
-    ).toEqual({
-      active: true,
-      processText: '',
-      thinking: '',
-      tools: [],
-    })
+    expect(activity.tools.map(tool => tool.id)).toEqual(['tool-2', 'tool-3', 'tool-4'])
+    expect(activity.tools[0]?.toolInput?.patch).toHaveLength(2_048)
+    expect(activity.tools[0]?.toolInput).not.toHaveProperty('unrelatedPayload')
+    expect(JSON.stringify(activity).length).toBeLessThan(7_000)
   })
 })

--- a/wework/src/features/workbench/runtimeThinking.ts
+++ b/wework/src/features/workbench/runtimeThinking.ts
@@ -1,4 +1,42 @@
-import type { ProcessingBlock, ToolBlock, WorkbenchMessage } from '@/types/workbench'
+import type {
+  ProcessingBlock,
+  RuntimeConversationTurn,
+  ToolBlock,
+  WorkbenchMessage,
+} from '@/types/workbench'
+
+const MAX_LIVE_ACTIVITY_TOOLS = 3
+const MAX_LIVE_ACTIVITY_INPUT_LENGTH = 2_048
+const MAX_LIVE_ACTIVITY_INPUT_DEPTH = 2
+const MAX_LIVE_ACTIVITY_PROCESS_TEXT_LENGTH = 8_192
+const LIVE_ACTIVITY_INPUT_KEYS = new Set([
+  'command',
+  'cmd',
+  'commandLine',
+  'file_path',
+  'filePath',
+  'filepath',
+  'path',
+  'file',
+  'filename',
+  'target_file',
+  'targetFile',
+  'notebook_path',
+  'notebookPath',
+  'query',
+  'pattern',
+  'search',
+  'directory',
+  'dir',
+  'root',
+  'cwd',
+  'workdir',
+  'workingDirectory',
+  'patch',
+  'content',
+  'input',
+  'arguments',
+])
 
 export type RuntimeLiveToolActivity = Pick<
   ToolBlock,
@@ -7,15 +45,15 @@ export type RuntimeLiveToolActivity = Pick<
 
 export interface RuntimeLiveActivity {
   active: boolean
-  processText: string
   thinking: string
+  processText: string
   tools: RuntimeLiveToolActivity[]
 }
 
 export const EMPTY_RUNTIME_LIVE_ACTIVITY: RuntimeLiveActivity = {
   active: false,
-  processText: '',
   thinking: '',
+  processText: '',
   tools: [],
 }
 
@@ -30,72 +68,102 @@ export function getLatestRuntimeLiveActivity(messages: WorkbenchMessage[]): Runt
     const message = messages[index]
     if (message?.role !== 'assistant' || message.status !== 'streaming') continue
 
-    return {
+    return populatedRuntimeLiveActivityOrEmpty({
       active: true,
-      processText: getRuntimeMessageProcessText(message),
-      thinking: getRuntimeMessageActiveThinking(message),
-      tools:
-        message.blocks
-          ?.filter(block => block.type === 'tool')
-          .map(block => ({
-            id: block.id,
-            status: block.status,
-            toolName: block.toolName,
-            toolInput: block.toolInput,
-            createdAt: block.createdAt,
-            completedAt: block.completedAt,
-            durationMs: block.durationMs,
-          })) ?? [],
-    }
+      thinking: compactLiveActivityText(getRuntimeMessageActiveThinking(message)),
+      processText: compactLiveActivityText(getLatestProcessTextBlock(message.blocks)),
+      tools: getLatestToolActivities(message.blocks),
+    })
   }
   return EMPTY_RUNTIME_LIVE_ACTIVITY
 }
 
-export function runtimeLiveActivitySnapshot(activity: RuntimeLiveActivity): string {
-  if (
-    !activity.active ||
-    (!activity.processText && !activity.thinking && activity.tools.length === 0)
-  ) {
-    return ''
+export function getLatestRuntimeLiveActivityFromTurns(
+  turns: RuntimeConversationTurn[]
+): RuntimeLiveActivity {
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index]
+    if (!turn || (turn.status !== 'pending' && turn.status !== 'streaming')) continue
+
+    const lastUserIndex = turn.items.findLastIndex(item => item.type === 'user_message')
+    return populatedRuntimeLiveActivityOrEmpty(runtimeLiveActivityFromTurn(turn, lastUserIndex + 1))
   }
-  return JSON.stringify(activity)
+  return EMPTY_RUNTIME_LIVE_ACTIVITY
 }
 
-export function runtimeLiveActivityFromSnapshot(snapshot: string): RuntimeLiveActivity {
-  if (!snapshot) return EMPTY_RUNTIME_LIVE_ACTIVITY
+function runtimeLiveActivityFromTurn(
+  turn: RuntimeConversationTurn,
+  start: number
+): RuntimeLiveActivity {
+  let thinking = turn.streamingThinkingContent?.trim() ?? ''
+  let processText = ''
+  const tools: RuntimeLiveToolActivity[] = []
 
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(snapshot)
-  } catch {
-    return EMPTY_RUNTIME_LIVE_ACTIVITY
-  }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return EMPTY_RUNTIME_LIVE_ACTIVITY
+  for (let index = turn.items.length - 1; index >= start; index -= 1) {
+    const item = turn.items[index]
+    if (item?.type !== 'block') continue
+    const block = item.block
+    if (!processText && block.type === 'text' && block.content.trim()) {
+      processText = block.content.trim()
+    } else if (
+      !thinking &&
+      block.type === 'thinking' &&
+      block.status !== 'done' &&
+      block.status !== 'error' &&
+      block.content.trim()
+    ) {
+      thinking = block.content
+    }
+    if (block.type === 'tool' && tools.length < MAX_LIVE_ACTIVITY_TOOLS) {
+      tools.push(toLiveToolActivity(block))
+    }
   }
 
-  const activity = parsed as Record<string, unknown>
   return {
-    active: activity.active === true,
-    processText: typeof activity.processText === 'string' ? activity.processText : '',
-    thinking: typeof activity.thinking === 'string' ? activity.thinking : '',
-    tools: Array.isArray(activity.tools)
-      ? (activity.tools as RuntimeLiveToolActivity[])
-      : EMPTY_RUNTIME_LIVE_ACTIVITY.tools,
+    active: true,
+    thinking: compactLiveActivityText(thinking),
+    processText: compactLiveActivityText(processText),
+    tools: tools.reverse(),
   }
 }
 
-function getRuntimeMessageProcessText(message: WorkbenchMessage): string {
-  if (message.role !== 'assistant' || message.status !== 'streaming' || !message.blocks?.length) {
-    return ''
-  }
+function populatedRuntimeLiveActivityOrEmpty(activity: RuntimeLiveActivity): RuntimeLiveActivity {
+  return activity.thinking || activity.processText || activity.tools.length > 0
+    ? activity
+    : EMPTY_RUNTIME_LIVE_ACTIVITY
+}
 
-  for (let index = message.blocks.length - 1; index >= 0; index -= 1) {
-    const block = message.blocks[index]
+function getLatestProcessTextBlock(blocks: ProcessingBlock[] | undefined): string {
+  if (!blocks?.length) return ''
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index]
     if (block?.type === 'text' && block.content.trim()) return block.content.trim()
   }
-
   return ''
+}
+
+function getLatestToolActivities(blocks: ProcessingBlock[] | undefined): RuntimeLiveToolActivity[] {
+  if (!blocks?.length) return []
+  const tools: RuntimeLiveToolActivity[] = []
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index]
+    if (block?.type !== 'tool') continue
+    tools.push(toLiveToolActivity(block))
+    if (tools.length === MAX_LIVE_ACTIVITY_TOOLS) break
+  }
+  return tools.reverse()
+}
+
+function toLiveToolActivity(block: ToolBlock): RuntimeLiveToolActivity {
+  return {
+    id: block.id,
+    status: block.status,
+    toolName: block.toolName,
+    toolInput: compactLiveActivityToolInput(block.toolInput),
+    createdAt: block.createdAt,
+    completedAt: block.completedAt,
+    durationMs: block.durationMs,
+  }
 }
 
 function getLatestActiveThinkingBlock(blocks: ProcessingBlock[] | undefined): string {
@@ -114,4 +182,36 @@ function getLatestActiveThinkingBlock(blocks: ProcessingBlock[] | undefined): st
   }
 
   return ''
+}
+
+function compactLiveActivityToolInput(
+  input: Record<string, unknown> | undefined,
+  depth = 0
+): Record<string, unknown> | undefined {
+  if (!input || depth >= MAX_LIVE_ACTIVITY_INPUT_DEPTH) return undefined
+
+  const compact: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (!LIVE_ACTIVITY_INPUT_KEYS.has(key)) continue
+    if (typeof value === 'string') {
+      compact[key] = value.slice(0, MAX_LIVE_ACTIVITY_INPUT_LENGTH)
+      continue
+    }
+    if (
+      (key === 'input' || key === 'arguments') &&
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      const nested = compactLiveActivityToolInput(value as Record<string, unknown>, depth + 1)
+      if (nested) compact[key] = nested
+    }
+  }
+  return Object.keys(compact).length > 0 ? compact : undefined
+}
+
+function compactLiveActivityText(value: string): string {
+  return value.length > MAX_LIVE_ACTIVITY_PROCESS_TEXT_LENGTH
+    ? value.slice(-MAX_LIVE_ACTIVITY_PROCESS_TEXT_LENGTH)
+    : value
 }


### PR DESCRIPTION
## Summary

- treat the project-board hover panel as a split view of the original runtime task conversation
- remove board-owned response previews and full assistant-message JSON serialization
- derive bounded card activity and response text directly from canonical conversation turns
- expire unretained terminal conversations after five idle minutes while full conversation views retain them
- replace stale terminal turns when an authoritative idle transcript is loaded
- document the conversation source-of-truth and retention rules in Chinese and English

## Root cause

The board card maintained a second response-preview path beside `runtimeConversationCache`. During streaming updates it projected full workbench messages and serialized/deserialized the latest assistant message. The captured trace attributed 1.645 seconds and 55.6% of renderer active CPU to that path, while the heap retained about 38.9 MB of duplicate strings for one large response.

## Verification

- focused Vitest: 5 files, 160 tests passed
- Wework TypeScript build passed
- ESLint passed for all changed Wework sources
- pre-push Wework static checks and unit tests passed
- real Electron production bundle built, launched, and returned an application snapshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Board task Hover panels now stay synchronized with their corresponding conversations, including response previews, progress updates, and tool activity.
  - Live activity displays are more concise and focused on recent tool activity.
  - Conversation previews now provide more consistent results across active, review, and completed states.

- **Bug Fixes**
  - Corrected stale conversation content after server updates.
  - Improved cleanup of inactive conversations while preserving conversations currently being viewed.

- **Documentation**
  - Added guidance on board conversation split views and transcript handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->