### PR TITLE
fix(knowledge): default Milvus hybrid retrieval to RRFRanker

### DIFF
--- a/frontend/src/__tests__/features/knowledge/document/retrieval-settings-section.test.tsx
+++ b/frontend/src/__tests__/features/knowledge/document/retrieval-settings-section.test.tsx
@@ -28,7 +28,9 @@ jest.mock('@/components/ui/radio-group', () => ({
 
 jest.mock('@/components/ui/slider', () => ({
   Slider: () => <div />,
-  DualWeightSlider: () => <div />,
+  DualWeightSlider: ({ disabled }: { disabled?: boolean }) => (
+    <div data-testid="dual-weight-slider" data-disabled={disabled ? 'true' : 'false'} />
+  ),
 }))
 
 jest.mock('@/features/knowledge/document/hooks/useRetrievers', () => ({
@@ -62,7 +64,7 @@ jest.mock('@/features/knowledge/document/hooks/useEmbeddingModels', () => ({
 
 jest.mock('@/features/knowledge/document/hooks/useRetrievalMethods', () => ({
   useRetrievalMethods: () => ({
-    methods: { milvus: ['vector'] },
+    methods: { milvus: ['vector', 'hybrid'] },
     loading: false,
   }),
 }))
@@ -88,5 +90,21 @@ describe('RetrievalSettingsSection', () => {
     const selectors = screen.getAllByRole('combobox')
     expect(selectors[0]).toBeEnabled()
     expect(selectors[1]).toBeDisabled()
+  })
+
+  test('disables hybrid weights with a rank-fusion hint for milvus retrievers', () => {
+    render(
+      <RetrievalSettingsSection
+        config={{
+          retriever_name: 'personal-retriever',
+          retriever_namespace: 'default',
+          retrieval_mode: 'hybrid',
+        }}
+        onChange={jest.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('dual-weight-slider')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByText('document.retrieval.milvusHybridRankFusion')).toBeInTheDocument()
   })
 })

--- a/frontend/src/features/knowledge/document/components/RetrievalSettingsSection.tsx
+++ b/frontend/src/features/knowledge/document/components/RetrievalSettingsSection.tsx
@@ -446,9 +446,17 @@ export function RetrievalSettingsSection({
             onChange={handleWeightChange}
             leftLabel={t('document.retrieval.semanticWeight')}
             rightLabel={t('document.retrieval.keywordWeight')}
-            disabled={isOtherSettingsDisabled || isAllDisabledDueToRag}
+            disabled={
+              isOtherSettingsDisabled ||
+              isAllDisabledDueToRag ||
+              selectedRetriever?.storageType === 'milvus'
+            }
           />
-          <p className="text-xs text-text-muted">{t('document.retrieval.weightSum')}</p>
+          <p className="text-xs text-text-muted">
+            {selectedRetriever?.storageType === 'milvus'
+              ? t('document.retrieval.milvusHybridRankFusion')
+              : t('document.retrieval.weightSum')}
+          </p>
         </div>
       )}
     </div>

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -747,6 +747,7 @@
       "semanticWeight": "Semantic Weight",
       "keywordWeight": "Keyword Weight",
       "weightSum": "Weights must sum to 1.0",
+      "milvusHybridRankFusion": "Milvus hybrid search fuses by rank (RRF); weights have no effect",
       "sourceType": {
         "user": "Personal",
         "public": "Public",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -747,6 +747,7 @@
       "semanticWeight": "语义权重",
       "keywordWeight": "关键词权重",
       "weightSum": "权重之和必须等于 1.0",
+      "milvusHybridRankFusion": "Milvus 混合检索按排名融合（RRF），权重配置不生效",
       "sourceType": {
         "user": "个人",
         "public": "公共",

--- a/knowledge_engine/knowledge_engine/storage/milvus_backend.py
+++ b/knowledge_engine/knowledge_engine/storage/milvus_backend.py
@@ -254,16 +254,19 @@ class MilvusBackend(BaseStorageBackend):
 
     def _resolve_hybrid_ranker(self) -> str:
         """
-        Resolve the hybrid ranker with WeightedRanker as the default.
+        Resolve the hybrid ranker with RRFRanker as the default.
 
-        RRFRanker remains available as an explicit compatibility opt-out.
+        RRF fuses the dense and sparse legs by rank, which is immune to the
+        incompatible score scales of cosine similarity (0-1) and BM25
+        (unbounded). WeightedRanker remains available as an explicit opt-in
+        via ext.hybrid_ranker = "WeightedRanker" for callers who have
+        verified their score scales are comparable; per-query retrieval
+        weights (vector_weight/keyword_weight) only apply to WeightedRanker.
         """
         configured_ranker = self.ext.get("hybrid_ranker")
-        if configured_ranker == "RRFRanker":
+        if configured_ranker in ("RRFRanker", "WeightedRanker"):
             return configured_ranker
-        if configured_ranker == "WeightedRanker":
-            return configured_ranker
-        return "WeightedRanker"
+        return "RRFRanker"
 
     def _resolve_hybrid_ranker_params(
         self,
@@ -275,6 +278,11 @@ class MilvusBackend(BaseStorageBackend):
         configured_params = dict(self.ext.get("hybrid_ranker_params") or {})
 
         if configured_ranker != "WeightedRanker":
+            # "weights" is a WeightedRanker-only parameter; passing it to
+            # RRFRanker would raise a TypeError. Drop stale weights so a
+            # retriever configured for WeightedRanker keeps working when the
+            # ranker resolves to RRFRanker.
+            configured_params.pop("weights", None)
             return configured_params
 
         vector_weight = (

--- a/knowledge_engine/tests/storage/test_milvus_backend.py
+++ b/knowledge_engine/tests/storage/test_milvus_backend.py
@@ -158,13 +158,13 @@ class TestCreateVectorStore:
             upsert_mode=True,
             overwrite=False,
             enable_sparse=True,
-            hybrid_ranker="WeightedRanker",
+            hybrid_ranker="RRFRanker",
             hybrid_ranker_params={},
         )
 
     @patch("knowledge_engine.storage.milvus_backend.LazyAsyncMilvusVectorStore")
-    def test_create_vector_store_defaults_to_weighted_ranker(self, mock_milvus_vs):
-        """Test that WeightedRanker is the default hybrid ranker."""
+    def test_create_vector_store_defaults_to_rrf_ranker(self, mock_milvus_vs):
+        """Test that RRFRanker is the default hybrid ranker."""
         backend = MilvusBackend(
             {
                 "url": "http://localhost:19530/default",
@@ -174,12 +174,31 @@ class TestCreateVectorStore:
 
         backend.create_vector_store("test_collection")
 
-        assert mock_milvus_vs.call_args.kwargs["hybrid_ranker"] == "WeightedRanker"
+        assert mock_milvus_vs.call_args.kwargs["hybrid_ranker"] == "RRFRanker"
         assert mock_milvus_vs.call_args.kwargs["hybrid_ranker_params"] == {}
 
     @patch("knowledge_engine.storage.milvus_backend.LazyAsyncMilvusVectorStore")
-    def test_create_vector_store_can_opt_out_to_rrf_ranker(self, mock_milvus_vs):
-        """Test that an explicit opt-out can request RRFRanker."""
+    def test_create_vector_store_drops_stale_weights_under_rrf(self, mock_milvus_vs):
+        """Stale WeightedRanker weights in ext config must not reach RRFRanker."""
+        backend = MilvusBackend(
+            {
+                "url": "http://localhost:19530/default",
+                "indexStrategy": {"mode": "per_dataset"},
+                "ext": {
+                    "hybrid_ranker": "RRFRanker",
+                    "hybrid_ranker_params": {"weights": [0.6, 0.4], "k": 100},
+                },
+            }
+        )
+
+        backend.create_vector_store("test_collection")
+
+        assert mock_milvus_vs.call_args.kwargs["hybrid_ranker"] == "RRFRanker"
+        assert mock_milvus_vs.call_args.kwargs["hybrid_ranker_params"] == {"k": 100}
+
+    @patch("knowledge_engine.storage.milvus_backend.LazyAsyncMilvusVectorStore")
+    def test_create_vector_store_explicit_rrf_ranker(self, mock_milvus_vs):
+        """Test that an explicit selection of RRFRanker is honored."""
         backend = MilvusBackend(
             {
                 "url": "http://localhost:19530/default",
@@ -189,6 +208,27 @@ class TestCreateVectorStore:
         )
 
         backend.create_vector_store("test_collection")
+
+        assert mock_milvus_vs.call_args.kwargs["hybrid_ranker"] == "RRFRanker"
+        assert mock_milvus_vs.call_args.kwargs["hybrid_ranker_params"] == {}
+
+    @patch("knowledge_engine.storage.milvus_backend.LazyAsyncMilvusVectorStore")
+    def test_create_vector_store_ignores_retrieval_weights_under_rrf(
+        self, mock_milvus_vs
+    ):
+        """Retrieval weights only feed WeightedRanker; RRF fuses by rank."""
+        backend = MilvusBackend(
+            {
+                "url": "http://localhost:19530/default",
+                "indexStrategy": {"mode": "per_dataset"},
+            }
+        )
+
+        backend.create_vector_store(
+            "test_collection",
+            retrieval_mode="hybrid",
+            retrieval_setting={"vector_weight": 0.7, "keyword_weight": 0.3},
+        )
 
         assert mock_milvus_vs.call_args.kwargs["hybrid_ranker"] == "RRFRanker"
         assert mock_milvus_vs.call_args.kwargs["hybrid_ranker_params"] == {}


### PR DESCRIPTION
## 问题

Milvus 知识库检索精确关键词（如人名）时返回无关结果。根因：Milvus hybrid 检索默认使用 `WeightedRanker`，对向量路（cosine，0-1 区间）和 BM25 稀疏路（无界）的原始分数直接加权求和。只在关键词路命中的 chunk 融合分为 0.3×0.76≈0.23，低于向量路命中的 0.7×0.66≈0.46，被 top_k=5 截断。Elasticsearch 因为先对每路分数归一化再加权，不受影响。

## 改动

- knowledge_engine：hybrid 默认 ranker 从 `WeightedRanker` 改为 `RRFRanker`（按排名融合，对分数尺度免疫）；`WeightedRanker` 保留 `ext.hybrid_ranker` 显式 opt-in；per-query 检索权重仍只作用于 `WeightedRanker`；resolved ranker 为 RRFRanker 时剥离 `ext.hybrid_ranker_params` 中残留的 `weights`，避免 TypeError
- frontend：选中的 Retriever 为 Milvus 且模式为 hybrid 时，权重滑块置灰并提示按排名融合、权重不生效（中英文案）
- 测试：更新默认 ranker 断言；新增「RRF 下忽略 per-query 权重」和「剥离残留 weights」两条用例

## 验证

- knowledge_engine 321 个测试全部通过；frontend jest 相关用例与 tsc 通过
- 已在真实 Milvus 集合复现原始失败并验证：RRF 下精确命中的 chunk 在任意权重设置下都回到 top-5；修复前 WeightedRanker(0.7, 0.3) 下被截断

## 行为变化

Milvus hybrid 返回的 score 变为 RRF 分值（约 0.01-0.05 区间）；知识库配置的 vector/keyword 权重对 Milvus 不再生效（前端已置灰提示）。