### PR TITLE
fix(admin): sync model grouping inputs with JSON config

### DIFF
--- a/frontend/src/__tests__/features/admin/PublicModelList.grouping.test.tsx
+++ b/frontend/src/__tests__/features/admin/PublicModelList.grouping.test.tsx
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { adminApis, type AdminPublicModel } from '@/apis/admin'
+import PublicModelList from '@/features/admin/components/PublicModelList'
+
+jest.mock('@/hooks/useTranslation', () => {
+  const t = (key: string) => key
+  return { useTranslation: () => ({ t }) }
+})
+
+jest.mock('@/hooks/use-toast', () => {
+  const toast = jest.fn()
+  return { useToast: () => ({ toast }) }
+})
+
+jest.mock('@/apis/admin', () => ({
+  adminApis: {
+    getPublicModels: jest.fn(),
+    createPublicModel: jest.fn(),
+    updatePublicModel: jest.fn(),
+  },
+}))
+
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+const model: AdminPublicModel = {
+  id: 1,
+  name: 'kimi',
+  namespace: 'default',
+  display_name: 'Kimi',
+  json: {
+    kind: 'Model',
+    spec: {
+      modelGroup: 'Domestic',
+      modelSubGroup: 'Kimi',
+      modelConfig: { model_id: 'kimi', context_window: 1048576 },
+      isVisible: true,
+    },
+  },
+  is_active: true,
+  is_visible: true,
+  is_advanced: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const mockedAdminApis = jest.mocked(adminApis)
+
+describe.each(['create', 'edit'] as const)('PublicModelList %s grouping synchronization', mode => {
+  const openDialog = async () => {
+    render(<PublicModelList />)
+    if (mode === 'create') {
+      fireEvent.click(
+        await screen.findByRole('button', { name: 'admin:public_models.create_model' })
+      )
+      fireEvent.change(screen.getByLabelText('admin:public_models.form.name *'), {
+        target: { value: 'new-model' },
+      })
+    } else {
+      fireEvent.click(await screen.findByTitle('admin:public_models.edit_model'))
+    }
+    return {
+      group: screen.getByLabelText('admin:public_models.form.model_group'),
+      subGroup: screen.getByLabelText('admin:public_models.form.model_sub_group'),
+      config: screen.getByLabelText(/^admin:public_models.form.config/) as HTMLTextAreaElement,
+    }
+  }
+
+  const saveModel = async () => {
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: mode === 'create' ? 'admin:common.create' : 'admin:common.save',
+      })
+    )
+    if (mode === 'create') {
+      await waitFor(() => expect(mockedAdminApis.createPublicModel).toHaveBeenCalledTimes(1))
+      return mockedAdminApis.createPublicModel.mock.calls[0][0].json
+    }
+    await waitFor(() => expect(mockedAdminApis.updatePublicModel).toHaveBeenCalledTimes(1))
+    return mockedAdminApis.updatePublicModel.mock.calls[0][1].json
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedAdminApis.getPublicModels.mockResolvedValue({ items: [model], total: 1 })
+    mockedAdminApis.createPublicModel.mockResolvedValue(model)
+    mockedAdminApis.updatePublicModel.mockResolvedValue(model)
+  })
+
+  it('writes group inputs into JSON immediately and removes cleared groups before saving', async () => {
+    const { group, subGroup, config } = await openDialog()
+    const originalConfig = JSON.parse(config.value)
+
+    fireEvent.change(group, { target: { value: ' International ' } })
+    fireEvent.change(subGroup, { target: { value: 'Claude' } })
+
+    expect(JSON.parse(config.value)).toEqual({
+      ...originalConfig,
+      spec: { ...originalConfig.spec, modelGroup: 'International', modelSubGroup: 'Claude' },
+    })
+
+    fireEvent.change(group, { target: { value: '' } })
+    expect(JSON.parse(config.value).spec).not.toHaveProperty('modelGroup')
+    expect(JSON.parse(config.value).spec.modelSubGroup).toBe('Claude')
+
+    fireEvent.change(subGroup, { target: { value: '   ' } })
+    expect(JSON.parse(config.value).spec).not.toHaveProperty('modelSubGroup')
+
+    expect(await saveModel()).toEqual({
+      ...JSON.parse(config.value),
+      spec: { ...JSON.parse(config.value).spec, isVisible: true },
+    })
+  })
+
+  it('reads JSON group edits and deletions without overwriting them on save', async () => {
+    const { group, subGroup, config } = await openDialog()
+    const changedConfig = {
+      ...model.json,
+      spec: { modelGroup: 'International', modelSubGroup: 'Claude', isVisible: false },
+    }
+    const jsonText = JSON.stringify(changedConfig)
+
+    fireEvent.change(config, { target: { value: jsonText } })
+
+    expect(group).toHaveValue('International')
+    expect(subGroup).toHaveValue('Claude')
+    expect(config).toHaveValue(jsonText)
+    expect(screen.getByTestId(`public-model-${mode}-visible-switch`)).toHaveAttribute(
+      'data-state',
+      'unchecked'
+    )
+
+    fireEvent.change(config, {
+      target: { value: JSON.stringify({ ...changedConfig, spec: { modelSubGroup: 'Gemini' } }) },
+    })
+    expect(group).toHaveValue('')
+    expect(subGroup).toHaveValue('Gemini')
+
+    expect(await saveModel()).toEqual({
+      ...changedConfig,
+      spec: { modelSubGroup: 'Gemini', isVisible: false },
+    })
+  })
+
+  it('preserves invalid JSON and the last valid groups until the configuration is repaired', async () => {
+    const { group, subGroup, config } = await openDialog()
+    fireEvent.change(config, { target: { value: JSON.stringify(model.json) } })
+
+    for (const invalidConfig of ['{"spec":', '{"spec":null}']) {
+      fireEvent.change(config, { target: { value: invalidConfig } })
+      fireEvent.change(group, { target: { value: 'Lost edit' } })
+      fireEvent.change(subGroup, { target: { value: 'Lost edit' } })
+
+      expect(config).toHaveValue(invalidConfig)
+      expect(group).toHaveValue('Domestic')
+      expect(subGroup).toHaveValue('Kimi')
+      expect(screen.getByText('admin:public_models.errors.config_invalid_json')).toBeInTheDocument()
+    }
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: mode === 'create' ? 'admin:common.create' : 'admin:common.save',
+      })
+    )
+    expect(mockedAdminApis.createPublicModel).not.toHaveBeenCalled()
+    expect(mockedAdminApis.updatePublicModel).not.toHaveBeenCalled()
+
+    fireEvent.change(config, { target: { value: '{"kind":"Model"}' } })
+    expect(group).toHaveValue('')
+    expect(subGroup).toHaveValue('')
+    expect(
+      screen.queryByText('admin:public_models.errors.config_invalid_json')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/admin/components/PublicModelList.tsx
+++ b/frontend/src/features/admin/components/PublicModelList.tsx
@@ -204,13 +204,38 @@ const PublicModelList: React.FC = () => {
   }
 
   const handleConfigChange = (value: string) => {
+    const config = validateConfig(value)
     const configVisibility = getPublicModelVisibilityFromConfig(value)
     setFormData(current => ({
       ...current,
       config: value,
+      ...(config
+        ? {
+            modelGroup: getSpecValue(config, 'modelGroup'),
+            modelSubGroup: getSpecValue(config, 'modelSubGroup'),
+          }
+        : {}),
       ...(configVisibility === undefined ? {} : { is_visible: configVisibility }),
     }))
-    validateConfig(value)
+  }
+
+  const handleGroupChange = (key: 'modelGroup' | 'modelSubGroup', value: string) => {
+    const config = validateConfig(formData.config)
+    if (!config) return
+
+    const spec = isJsonObject(config.spec) ? { ...config.spec } : {}
+    const trimmedValue = value.trim()
+    if (trimmedValue) {
+      spec[key] = trimmedValue
+    } else {
+      delete spec[key]
+    }
+
+    setFormData(current => ({
+      ...current,
+      [key]: value,
+      config: JSON.stringify({ ...config, spec }, null, 2),
+    }))
   }
 
   const handleVisibilityChange = (isVisible: boolean) => {
@@ -547,7 +572,7 @@ const PublicModelList: React.FC = () => {
                   id="model-group"
                   data-testid="public-model-group-input"
                   value={formData.modelGroup}
-                  onChange={e => setFormData({ ...formData, modelGroup: e.target.value })}
+                  onChange={e => handleGroupChange('modelGroup', e.target.value)}
                   placeholder={t('admin:public_models.form.model_group_placeholder')}
                 />
               </div>
@@ -559,7 +584,7 @@ const PublicModelList: React.FC = () => {
                   id="model-sub-group"
                   data-testid="public-model-sub-group-input"
                   value={formData.modelSubGroup}
-                  onChange={e => setFormData({ ...formData, modelSubGroup: e.target.value })}
+                  onChange={e => handleGroupChange('modelSubGroup', e.target.value)}
                   placeholder={t('admin:public_models.form.model_sub_group_placeholder')}
                 />
               </div>
@@ -658,7 +683,7 @@ const PublicModelList: React.FC = () => {
                   id="edit-model-group"
                   data-testid="edit-public-model-group-input"
                   value={formData.modelGroup}
-                  onChange={e => setFormData({ ...formData, modelGroup: e.target.value })}
+                  onChange={e => handleGroupChange('modelGroup', e.target.value)}
                   placeholder={t('admin:public_models.form.model_group_placeholder')}
                 />
               </div>
@@ -670,7 +695,7 @@ const PublicModelList: React.FC = () => {
                   id="edit-model-sub-group"
                   data-testid="edit-public-model-sub-group-input"
                   value={formData.modelSubGroup}
-                  onChange={e => setFormData({ ...formData, modelSubGroup: e.target.value })}
+                  onChange={e => handleGroupChange('modelSubGroup', e.target.value)}
                   placeholder={t('admin:public_models.form.model_sub_group_placeholder')}
                 />
               </div>


### PR DESCRIPTION
Primary and secondary group inputs in the public model dialogs could diverge from the JSON editor, causing JSON group edits to be overwritten on save. Synchronize `spec.modelGroup` and `spec.modelSubGroup` in both directions for both create and edit dialogs, remove cleared grouping fields, and preserve incomplete JSON until it is repaired.

Adds regression coverage for both dialogs, saved values, field deletion, unrelated configuration preservation, and invalid JSON recovery.

Validation: 13 focused tests; full frontend and chat-core unit suites; TypeScript, ESLint, Prettier, and translation checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved public model configuration editing so group and subgroup selections stay synchronized with the JSON configuration.
  - Clearing group fields now correctly removes those values before saving.
  - Valid JSON edits update the corresponding form fields without being overwritten.
  - Invalid JSON is preserved while the last valid grouping values and an error message remain visible until the configuration is corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->