### PR TITLE
fix(wework): recover Windows standard-user startup

### DIFF
--- a/.github/scripts/report-wework-desktop-e2e-failures.mjs
+++ b/.github/scripts/report-wework-desktop-e2e-failures.mjs
@@ -1,0 +1,52 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+
+const workspace = resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
+const resultRoot = resolve(
+  process.argv[2] ?? resolve(workspace, "wework/test-results/desktop-e2e"),
+);
+const diagnosticNames = new Set(["app.log", "failure.txt"]);
+
+async function collectDiagnostics(directory) {
+  const entries = await readdir(directory, { withFileTypes: true }).catch(
+    () => [],
+  );
+  const diagnostics = [];
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      diagnostics.push(...(await collectDiagnostics(path)));
+    } else if (entry.isFile() && diagnosticNames.has(entry.name)) {
+      diagnostics.push({
+        modifiedAt: (await stat(path)).mtimeMs,
+        name: entry.name,
+        path,
+      });
+    }
+  }
+  return diagnostics;
+}
+
+function escapeCommandData(value) {
+  return value
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+}
+
+function escapeCommandProperty(value) {
+  return escapeCommandData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+const diagnostics = (await collectDiagnostics(resultRoot))
+  .sort((left, right) => right.modifiedAt - left.modifiedAt)
+  .slice(0, 8);
+
+for (const diagnostic of diagnostics) {
+  const content = (await readFile(diagnostic.path, "utf8")).slice(-12_000);
+  if (!content) continue;
+  const path = relative(workspace, diagnostic.path);
+  console.log(
+    `::error file=${escapeCommandProperty(path)},title=${escapeCommandProperty(`Windows standard-user ${diagnostic.name}`)}::${escapeCommandData(content)}`,
+  );
+}

--- a/.github/scripts/run-windows-standard-user-process.ps1
+++ b/.github/scripts/run-windows-standard-user-process.ps1
@@ -1,0 +1,65 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$FilePath,
+
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$ArgumentList
+)
+
+$ErrorActionPreference = "Stop"
+
+$userName = "wework-e2e-$PID"
+$passwordText = [Convert]::ToBase64String(
+  [Security.Cryptography.RandomNumberGenerator]::GetBytes(24)
+) + "aA1!"
+$password = ConvertTo-SecureString $passwordText -AsPlainText -Force
+$credential = [PSCredential]::new("$env:COMPUTERNAME\$userName", $password)
+$workspace = (Resolve-Path -LiteralPath $env:GITHUB_WORKSPACE).Path
+$profileRoot = Join-Path $workspace "wework/test-results/windows-standard-user"
+
+try {
+  New-LocalUser `
+    -Name $userName `
+    -Password $password `
+    -AccountNeverExpires `
+    -PasswordNeverExpires | Out-Null
+  Add-LocalGroupMember -Group "Users" -Member $userName
+
+  if (
+    Get-LocalGroupMember -Group "Administrators" |
+      Where-Object { $_.Name -eq "$env:COMPUTERNAME\$userName" }
+  ) {
+    throw "The Windows E2E account unexpectedly has administrator membership"
+  }
+
+  New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+  & icacls.exe $workspace /grant "${env:COMPUTERNAME}\${userName}:(OI)(CI)M" /Q
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to grant the Windows E2E account access to the workspace"
+  }
+
+  $env:USERNAME = $userName
+  $env:USERPROFILE = $profileRoot
+  $env:HOME = $profileRoot
+  $env:HOMEDRIVE = (Split-Path -Qualifier $profileRoot).TrimEnd("\")
+  $env:HOMEPATH = $profileRoot.Substring($env:HOMEDRIVE.Length)
+  $env:APPDATA = Join-Path $profileRoot "AppData/Roaming"
+  $env:LOCALAPPDATA = Join-Path $profileRoot "AppData/Local"
+  $env:TEMP = Join-Path $profileRoot "AppData/Local/Temp"
+  $env:TMP = $env:TEMP
+  New-Item -ItemType Directory -Path $env:APPDATA, $env:LOCALAPPDATA, $env:TEMP -Force |
+    Out-Null
+
+  Write-Host "[windows-standard-user] account=$env:COMPUTERNAME\$userName"
+  $process = Start-Process `
+    -FilePath (Resolve-Path -LiteralPath $FilePath).Path `
+    -ArgumentList $ArgumentList `
+    -Credential $credential `
+    -WorkingDirectory $workspace `
+    -NoNewWindow `
+    -Wait `
+    -PassThru
+  exit $process.ExitCode
+} finally {
+  Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
+}

--- a/.github/scripts/run-windows-standard-user-process.ps1
+++ b/.github/scripts/run-windows-standard-user-process.ps1
@@ -15,14 +15,15 @@ $passwordText = [Convert]::ToBase64String(
 $password = ConvertTo-SecureString $passwordText -AsPlainText -Force
 $credential = [PSCredential]::new("$env:COMPUTERNAME\$userName", $password)
 $workspace = (Resolve-Path -LiteralPath $env:GITHUB_WORKSPACE).Path
-$profileRoot = Join-Path $workspace "wework/test-results/windows-standard-user"
+$userSid = $null
 
 try {
-  New-LocalUser `
+  $user = New-LocalUser `
     -Name $userName `
     -Password $password `
     -AccountNeverExpires `
-    -PasswordNeverExpires | Out-Null
+    -PasswordNeverExpires
+  $userSid = $user.SID.Value
   Add-LocalGroupMember -Group "Users" -Member $userName
 
   if (
@@ -32,11 +33,28 @@ try {
     throw "The Windows E2E account unexpectedly has administrator membership"
   }
 
-  New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
   & icacls.exe $workspace /grant "${env:COMPUTERNAME}\${userName}:(OI)(CI)M" /Q
   if ($LASTEXITCODE -ne 0) {
     throw "Failed to grant the Windows E2E account access to the workspace"
   }
+
+  $profileBootstrap = Start-Process `
+    -FilePath $env:ComSpec `
+    -ArgumentList "/d", "/c", "exit", "0" `
+    -Credential $credential `
+    -LoadUserProfile `
+    -NoNewWindow `
+    -Wait `
+    -PassThru
+  if ($profileBootstrap.ExitCode -ne 0) {
+    throw "Failed to initialize the Windows E2E account profile"
+  }
+  $profile = Get-CimInstance -ClassName Win32_UserProfile |
+    Where-Object { $_.SID -eq $userSid }
+  if (-not $profile -or -not $profile.LocalPath) {
+    throw "The Windows E2E account profile was not created"
+  }
+  $profileRoot = $profile.LocalPath
 
   $env:USERNAME = $userName
   $env:USERPROFILE = $profileRoot
@@ -55,11 +73,17 @@ try {
     -FilePath (Resolve-Path -LiteralPath $FilePath).Path `
     -ArgumentList $ArgumentList `
     -Credential $credential `
+    -LoadUserProfile `
     -WorkingDirectory $workspace `
     -NoNewWindow `
     -Wait `
     -PassThru
   exit $process.ExitCode
 } finally {
+  if ($userSid) {
+    Get-CimInstance -ClassName Win32_UserProfile -ErrorAction SilentlyContinue |
+      Where-Object { $_.SID -eq $userSid } |
+      Remove-CimInstance -ErrorAction SilentlyContinue
+  }
   Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
 }

--- a/.github/workflows/wework-e2e.yml
+++ b/.github/workflows/wework-e2e.yml
@@ -636,6 +636,8 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Run Windows Wework desktop Core shard E2E
+        id: windows-core-e2e
+        continue-on-error: true
         shell: pwsh
         env:
           CI: true
@@ -657,7 +659,23 @@ jobs:
               throw "Missing Windows Wework desktop E2E resource: $path"
             }
           }
-          node wework/e2e/desktop/run-checkpoints.mjs --parallel-segments $env:WEWORK_E2E_SEGMENTS
+          $arguments = @(
+            "wework/e2e/desktop/run-checkpoints.mjs",
+            "--parallel-segments",
+            $env:WEWORK_E2E_SEGMENTS
+          )
+          $nodePath = (Get-Command node).Source
+          & ./.github/scripts/run-windows-standard-user-process.ps1 `
+            -FilePath $nodePath `
+            @arguments
+
+      - name: Report Windows standard-user startup failures
+        if: always() && steps.windows-core-e2e.outcome == 'failure'
+        run: node .github/scripts/report-wework-desktop-e2e-failures.mjs
+
+      - name: Fail Windows Wework desktop Core shard E2E
+        if: always() && steps.windows-core-e2e.outcome == 'failure'
+        run: exit 1
 
       - name: Prune transient Wework desktop E2E caches
         if: always()

--- a/wework/electron/src/host/downloads-directory.test.ts
+++ b/wework/electron/src/host/downloads-directory.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path'
 import { describe, expect, test, vi } from 'vitest'
 
 import { resolveDownloadsDirectory } from './downloads-directory.js'
@@ -20,8 +21,9 @@ describe('resolveDownloadsDirectory', () => {
       return '/Users/test'
     })
     const onKnownFolderFailure = vi.fn()
+    const fallbackPath = join('/Users/test', 'Downloads')
 
-    expect(resolveDownloadsDirectory(getPath, onKnownFolderFailure)).toBe('/Users/test/Downloads')
-    expect(onKnownFolderFailure).toHaveBeenCalledWith(knownFolderError, '/Users/test/Downloads')
+    expect(resolveDownloadsDirectory(getPath, onKnownFolderFailure)).toBe(fallbackPath)
+    expect(onKnownFolderFailure).toHaveBeenCalledWith(knownFolderError, fallbackPath)
   })
 })

--- a/wework/electron/src/host/downloads-directory.test.ts
+++ b/wework/electron/src/host/downloads-directory.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { resolveDownloadsDirectory } from './downloads-directory.js'
+
+describe('resolveDownloadsDirectory', () => {
+  test('uses the system Downloads known folder when Electron resolves it', () => {
+    const getPath = vi.fn((name: 'downloads' | 'home') => {
+      if (name === 'downloads') return '/Users/test/System Downloads'
+      return '/Users/test'
+    })
+
+    expect(resolveDownloadsDirectory(getPath)).toBe('/Users/test/System Downloads')
+    expect(getPath).toHaveBeenCalledOnce()
+  })
+
+  test('uses Downloads under home when the Windows known folder is unavailable', () => {
+    const knownFolderError = new Error("Failed to get 'downloads' path")
+    const getPath = vi.fn((name: 'downloads' | 'home') => {
+      if (name === 'downloads') throw knownFolderError
+      return '/Users/test'
+    })
+    const onKnownFolderFailure = vi.fn()
+
+    expect(resolveDownloadsDirectory(getPath, onKnownFolderFailure)).toBe('/Users/test/Downloads')
+    expect(onKnownFolderFailure).toHaveBeenCalledWith(knownFolderError, '/Users/test/Downloads')
+  })
+})

--- a/wework/electron/src/host/downloads-directory.ts
+++ b/wework/electron/src/host/downloads-directory.ts
@@ -1,0 +1,16 @@
+import { join } from 'node:path'
+
+type ElectronPathName = 'downloads' | 'home'
+
+export function resolveDownloadsDirectory(
+  getPath: (name: ElectronPathName) => string,
+  onKnownFolderFailure?: (error: unknown, fallbackPath: string) => void
+): string {
+  try {
+    return getPath('downloads')
+  } catch (error) {
+    const fallbackPath = join(getPath('home'), 'Downloads')
+    onKnownFolderFailure?.(error, fallbackPath)
+    return fallbackPath
+  }
+}

--- a/wework/electron/src/host/feedback-bundle-manager.test.ts
+++ b/wework/electron/src/host/feedback-bundle-manager.test.ts
@@ -2,7 +2,7 @@ import extract from 'extract-zip'
 import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { FeedbackBundleManager } from './feedback-bundle-manager.js'
 
 const temporaryRoots: string[] = []
@@ -23,7 +23,9 @@ describe('FeedbackBundleManager', () => {
       join(logs, 'executor.log'),
       'Authorization: Bearer top-secret\npassword=hunter2\nstatus=401\n'
     )
-    const manager = createManager(root, logs)
+    const downloadsDirectory = vi.fn(() => join(root, 'downloads'))
+    const manager = createManager(root, logs, downloadsDirectory)
+    expect(downloadsDirectory).not.toHaveBeenCalled()
 
     const preview = await manager.preview({
       includeRuntimeLogs: true,
@@ -42,6 +44,7 @@ describe('FeedbackBundleManager', () => {
         },
       ],
     })
+    expect(downloadsDirectory).not.toHaveBeenCalled()
 
     expect(preview.reportId).toMatch(/^WF-[A-F0-9]+$/)
     expect(preview.entries.map(entry => entry.archivePath)).toEqual(
@@ -55,6 +58,7 @@ describe('FeedbackBundleManager', () => {
     )
     expect(JSON.stringify(preview.entries)).not.toContain('task-secret')
     const exported = await manager.confirm(preview.stagingId)
+    expect(downloadsDirectory).toHaveBeenCalledOnce()
     await expect(stat(exported.path)).resolves.toMatchObject({ size: expect.any(Number) })
 
     const extracted = join(root, 'extracted')
@@ -95,11 +99,15 @@ describe('FeedbackBundleManager', () => {
   })
 })
 
-function createManager(root: string, logs: string): FeedbackBundleManager {
+function createManager(
+  root: string,
+  logs: string,
+  downloadsDirectory: () => string = () => join(root, 'downloads')
+): FeedbackBundleManager {
   return new FeedbackBundleManager({
     appVersion: () => '1.2.3',
     cacheDirectory: join(root, 'cache'),
-    downloadsDirectory: join(root, 'downloads'),
+    downloadsDirectory,
     logDirectories: [logs],
   })
 }

--- a/wework/electron/src/host/feedback-bundle-manager.ts
+++ b/wework/electron/src/host/feedback-bundle-manager.ts
@@ -75,7 +75,7 @@ export class FeedbackBundleManager {
     private readonly options: {
       appVersion: () => string
       cacheDirectory: string
-      downloadsDirectory: string
+      downloadsDirectory: () => string
       logDirectories: string[]
     }
   ) {}
@@ -100,11 +100,9 @@ export class FeedbackBundleManager {
 
   async confirm(stagingIdInput: string): Promise<{ reportId: string; path: string }> {
     const { stagingId, staged } = await this.resolveStaged(stagingIdInput)
-    await mkdir(this.options.downloadsDirectory, { recursive: true })
-    const destination = join(
-      this.options.downloadsDirectory,
-      `wework-feedback-${staged.reportId}.zip`
-    )
+    const downloadsDirectory = this.options.downloadsDirectory()
+    await mkdir(downloadsDirectory, { recursive: true })
+    const destination = join(downloadsDirectory, `wework-feedback-${staged.reportId}.zip`)
     try {
       await rename(staged.path, destination)
     } catch (moveError) {

--- a/wework/electron/src/host/smart-app-manager.test.ts
+++ b/wework/electron/src/host/smart-app-manager.test.ts
@@ -459,7 +459,7 @@ function createManager(
 ): SmartAppManager {
   return new SmartAppManager({
     dataDirectory: join(root, 'data'),
-    downloadsDirectory: join(root, 'downloads'),
+    downloadsDirectory: () => join(root, 'downloads'),
     logDirectory: join(root, 'logs'),
     runtimeRoot: join(root, 'runtime'),
     environment: {},

--- a/wework/electron/src/host/smart-app-manager.ts
+++ b/wework/electron/src/host/smart-app-manager.ts
@@ -72,7 +72,7 @@ export interface SmartAppRuntimeHost {
 
 export interface SmartAppManagerOptions {
   dataDirectory: string
-  downloadsDirectory: string
+  downloadsDirectory: () => string
   logDirectory: string
   runtimeRoot: string
   environment: NodeJS.ProcessEnv
@@ -522,9 +522,10 @@ export class SmartAppManager {
 
   async exportToDownloads(installationId: string): Promise<SmartAppSavedExport> {
     const exported = await this.export(installationId)
-    await mkdir(this.options.downloadsDirectory, { recursive: true })
+    const downloadsDirectory = this.options.downloadsDirectory()
+    await mkdir(downloadsDirectory, { recursive: true })
     const filename = `${safeName(exported.manifest.name)}-${exported.manifest.version}.zip`
-    const destinationPath = await uniquePath(this.options.downloadsDirectory, filename)
+    const destinationPath = await uniquePath(downloadsDirectory, filename)
     await copyFile(exported.archivePath, destinationPath)
     return { ...exported, destinationPath }
   }

--- a/wework/electron/src/main.ts
+++ b/wework/electron/src/main.ts
@@ -40,6 +40,7 @@ import { DesktopHostEventBroker } from './host/desktop-host-events.js'
 import { requiresMacosQuitWorkaround } from './host/macos-quit-workaround.js'
 import { RendererHealthService } from './host/renderer-health.js'
 import { SmartAppManager, type SmartAppRuntimeHost } from './host/smart-app-manager.js'
+import { resolveDownloadsDirectory } from './host/downloads-directory.js'
 import { SystemSleepController } from './host/system-sleep-controller.js'
 import { PreferencesStore } from './host/preferences-store.js'
 import {
@@ -1299,6 +1300,18 @@ function smartAppRuntimeHost(): SmartAppRuntimeHost | null {
   }
 }
 
+function downloadsDirectory(): string {
+  return resolveDownloadsDirectory(
+    name => app.getPath(name),
+    (error, fallbackPath) => {
+      console.warn(
+        `[downloads] system Downloads folder is unavailable; using ${fallbackPath}`,
+        error
+      )
+    }
+  )
+}
+
 async function configureDesktopRuntime(): Promise<void> {
   if (desktopRuntime) return
   logStartupStep('runtime-configure', 'started')
@@ -1331,7 +1344,7 @@ async function configureDesktopRuntime(): Promise<void> {
   const feedback = new FeedbackBundleManager({
     appVersion: () => app.getVersion(),
     cacheDirectory: join(app.getPath('userData'), 'cache'),
-    downloadsDirectory: app.getPath('downloads'),
+    downloadsDirectory,
     logDirectories: [app.getPath('logs')],
   })
   const secureStorage = new SecureValueStore(app.getPath('userData'))
@@ -1373,7 +1386,7 @@ async function configureDesktopRuntime(): Promise<void> {
   if (runtimeRoot) {
     smartApps = new SmartAppManager({
       dataDirectory: app.getPath('userData'),
-      downloadsDirectory: app.getPath('downloads'),
+      downloadsDirectory,
       logDirectory: app.getPath('logs'),
       runtimeRoot,
       environment,


### PR DESCRIPTION
## 问题

Windows 普通用户的 Known Folder / profile 无法解析时，Electron `app.getPath('downloads')` 会抛错。Wework 在启动配置阶段为反馈包和 Smart app 管理器提前读取 Downloads，导致桌面 runtime 启动失败并一直停留在启动页；管理员账号使用另一套完整 profile 时可以进入。

## 修改

- 所有 Windows Desktop Core E2E shard 默认创建并使用真实本地非管理员账号，加载该账号的 Windows profile 后执行完整 runner。
- Downloads 仅在实际确认反馈导出或 Smart app 导出时解析，不再阻塞启动。
- 系统 Known Folder 无法解析时，统一使用当前用户 home 下的 `Downloads`，由现有导出逻辑创建目录并写入文件。
- Windows E2E 失败时将应用日志和场景错误写入 check annotations，保留可检索证据。

## 验证

- `pnpm --filter wework test electron/src/host/downloads-directory.test.ts electron/src/host/feedback-bundle-manager.test.ts electron/src/host/smart-app-manager.test.ts`：3 files / 17 tests passed。
- ESLint、Electron TypeScript、Wework unit tests、actionlint、脚本语法和 pre-push 全部通过。
- Windows 普通用户全量验证 run 34575987299：17 个 shard 全部在加载真实 profile 的非管理员账号下运行；所有有应用日志的 shard 均完成 `desktop-runtime-start`、显示主窗口并关闭启动页，未再出现 `Failed to get 'downloads' path` 或等待 Electron 连接超时。8 个 shard 通过；其余失败均发生在启动后的既有业务断言，且与 2026-09-09 的 main 定时基线失败高度重合，未修改原 E2E 来规避。

Task: WEWORKC2FA61-545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when exporting feedback bundles and Smart App data to the Downloads folder.
  - If the system Downloads location cannot be found, exports now use a fallback Downloads folder in the user’s home directory.
  - The Downloads location is resolved when an export is confirmed, helping ensure files are saved to the current valid destination.

- **Tests**
  - Added coverage for standard and fallback Downloads-folder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->