### PR TITLE
fix(executor): rebuild missing plugin MCP snapshots

### DIFF
--- a/executor/src/local/capabilities/support.rs
+++ b/executor/src/local/capabilities/support.rs
@@ -21,6 +21,9 @@ const CODEX_PLUGIN_MANIFEST_PATH: &str = ".codex-plugin/plugin.json";
 const PLUGIN_MANIFEST_PATHS: [&str; 2] = [CODEX_PLUGIN_MANIFEST_PATH, CLAUDE_PLUGIN_MANIFEST_PATH];
 const MAX_PACKAGE_ENTRY_COUNT: usize = 10_000;
 const MAX_EXPANDED_PACKAGE_SIZE_BYTES: u64 = 200 * 1024 * 1024;
+pub const CODEX_TASK_MCP_SNAPSHOT: &str = ".wegent-task-mcp-source-codex.json";
+pub const CLAUDE_TASK_MCP_SNAPSHOT: &str = ".wegent-task-mcp-source-claude.json";
+pub const DEFAULT_MCP_SNAPSHOT: &str = ".wegent-default-mcp-source.json";
 const UNIX_FILE_TYPE_MASK: u32 = 0o170_000;
 const UNIX_MODE_SYMLINK: u32 = 0o120_000;
 const CODEX_MANIFEST_FIELDS: [&str; 11] = [
@@ -838,7 +841,14 @@ pub(super) fn copy_dir_recursive(source: &Path, target: &Path) -> Result<(), Cap
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         let source_path = entry.path();
-        let target_path = target.join(entry.file_name());
+        let file_name = entry.file_name();
+        if file_name == *CODEX_TASK_MCP_SNAPSHOT
+            || file_name == *CLAUDE_TASK_MCP_SNAPSHOT
+            || file_name == *DEFAULT_MCP_SNAPSHOT
+        {
+            continue;
+        }
+        let target_path = target.join(&file_name);
         if source_path.is_dir() {
             copy_dir_recursive(&source_path, &target_path)?;
         } else {

--- a/executor/src/plugin_task_token/package.rs
+++ b/executor/src/plugin_task_token/package.rs
@@ -88,8 +88,14 @@ fn declarations(root: &Path, claude: bool) -> Result<Map<String, Value>, String>
     let source_path = root.join(format!(".wegent-task-mcp-source-{runtime}.json"));
     let native = format!("./.wegent-native-mcp-{runtime}.json");
     let manifest = read(&path)?;
-    let source = if manifest["mcpServers"].as_str() == Some(&native) {
-        read(&source_path)?
+    let migrated = manifest["mcpServers"].as_str() == Some(&native);
+    let source = if migrated {
+        // An upgraded Executor may find a runtime cache that was materialized
+        // by an older release. The runtime cache is not authoritative; fall
+        // back to the unmodified default source while rebuilding the snapshot.
+        read(&source_path).or_else(|_| {
+            default_source(root, runtime).map(|servers| json!({"mcpServers": servers}))
+        })?
     } else {
         manifest.get("mcpServers").cloned().unwrap_or_else(|| {
             if root.join(".mcp.json").is_file() {
@@ -100,12 +106,39 @@ fn declarations(root: &Path, claude: bool) -> Result<Map<String, Value>, String>
         })
     };
     let mut all = if claude && root.join(".mcp.json").is_file() {
-        servers(root, &json!("./.mcp.json"))?
+        default_source(root, runtime)?
     } else {
         Map::new()
     };
     all.extend(servers(root, &source)?);
     Ok(all)
+}
+
+fn default_source(root: &Path, runtime: &str) -> Result<Map<String, Value>, String> {
+    let default_path = root.join(".mcp.json");
+    if default_path.is_file() {
+        servers(root, &json!("./.mcp.json"))
+    } else {
+        let native_path = root.join(format!(".wegent-native-mcp-{runtime}.json"));
+        let path = if root.join(DEFAULT_SOURCE).is_file() {
+            root.join(DEFAULT_SOURCE)
+        } else {
+            native_path
+        };
+        read(&path)
+            .and_then(|value| {
+                value
+                    .get("mcpServers")
+                    .cloned()
+                    .ok_or_else(|| "Invalid plugin MCP server map".into())
+            })
+            .and_then(|value| {
+                value
+                    .as_object()
+                    .cloned()
+                    .ok_or_else(|| "Invalid plugin MCP server map".into())
+            })
+    }
 }
 
 pub(crate) fn requires_native_proxy(root: &Path, claude: bool) -> Result<bool, String> {

--- a/executor/src/plugin_task_token/tests.rs
+++ b/executor/src/plugin_task_token/tests.rs
@@ -275,6 +275,66 @@ fn materialization_preserves_source_and_excludes_only_declared_remote_mcps() {
 }
 
 #[test]
+fn missing_runtime_snapshot_is_rebuilt_from_the_default_mcp_source() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir(root.path().join(".codex-plugin")).unwrap();
+    std::fs::write(
+        root.path().join(".codex-plugin/plugin.json"),
+        json!({"name": "fixture", "mcpServers": "./.wegent-native-mcp-codex.json"}).to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".mcp.json"),
+        json!({"private": {"url": "https://business.invalid/mcp", "headers": {"Authorization": "Bearer ${{task_token}}"}}}).to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".wegent-native-mcp-codex.json"),
+        json!({"mcpServers": {}}).to_string(),
+    )
+    .unwrap();
+
+    let prepared = package::materialize(root.path(), false).unwrap();
+
+    assert_eq!(prepared.len(), 1);
+    let source: Value = serde_json::from_slice(
+        &std::fs::read(root.path().join(".wegent-task-mcp-source-codex.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(source["mcpServers"]["private"].is_object());
+}
+
+#[test]
+fn runtime_snapshots_are_not_treated_as_plugin_source_files() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir(root.path().join(".codex-plugin")).unwrap();
+    std::fs::write(
+        root.path().join(".codex-plugin/plugin.json"),
+        json!({"name": "fixture", "mcpServers": {}}).to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".mcp.json"),
+        json!({"mcpServers": {}}).to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".wegent-task-mcp-source-codex.json"),
+        json!({"mcpServers": {"private": {"url": "https://stale.invalid/mcp"}}}).to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join(".wegent-default-mcp-source.json"),
+        json!({"mcpServers": {"private": {"url": "https://stale.invalid/mcp"}}}).to_string(),
+    )
+    .unwrap();
+
+    let prepared = package::materialize(root.path(), false).unwrap();
+
+    assert!(prepared.is_empty());
+}
+
+#[test]
 fn runtime_specific_plugin_declarations_stay_independent() {
     let root = tempfile::tempdir().unwrap();
     for runtime in ["codex", "claude"] {


### PR DESCRIPTION
## Summary
- Rebuild missing TaskToken plugin MCP source snapshots from the original/default MCP declarations instead of failing chat startup with "Plugin MCP configuration is unavailable".
- Skip runtime-generated TaskToken snapshots when copying plugin caches so they do not leak between the Codex runtime cache, Claude runtime cache, and authoritative central store.
- Add regression tests for snapshot recovery and runtime snapshot isolation.

## Root cause
The 0.4.5 TaskToken plugin MCP materialization rewrote a plugin manifest to point at a filtered native MCP file and stored the original declarations in a sidecar snapshot. An upgrade or cache reconciliation could leave the rewritten manifest present while the sidecar snapshot was missing, causing every chat startup to fail before model execution.

## Tests
- cargo test -p wegent-executor --lib plugin_task_token -- --nocapture
- cargo clippy -p wegent-executor --lib --tests -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP configuration recovery when runtime snapshot files are missing or empty.
  * Prevented stale runtime snapshot files from being mistakenly treated as plugin configuration sources.
  * MCP snapshot files are no longer propagated when directories are copied, reducing unintended configuration carryover.
  * Added fallback handling to rebuild task MCP configuration from the default source when cached data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->