### PR TITLE
fix(frontend): include collaboration deps in image build

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY patches ./patches
 COPY packages/chat-core/package.json ./packages/chat-core/package.json
+COPY packages/collaboration/package.json ./packages/collaboration/package.json
 COPY frontend/package.json ./frontend/package.json
 COPY frontend/scripts ./frontend/scripts
 
@@ -41,6 +42,7 @@ ENV NEXT_PUBLIC_APP_VERSION=${APP_VERSION}
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/frontend/node_modules ./frontend/node_modules
 COPY --from=deps /app/packages/chat-core/node_modules ./packages/chat-core/node_modules
+COPY --from=deps /app/packages/collaboration/node_modules ./packages/collaboration/node_modules
 
 # Copy source code
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
## Summary

- include the shared collaboration workspace manifest in the frontend image dependency stage
- copy the collaboration package node_modules into the builder stage
- restore React and type resolution for the shared collaboration source during Next.js builds

## Verification

- reproduced the original Docker build failure: `packages/collaboration/src/CollaborationApp.tsx` could not resolve `react`
- built the complete frontend image with `docker/frontend/Dockerfile`
- started the resulting image and verified `/` and `/collaboration` both return HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend container build to include collaboration package dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->