### PR TITLE
feat(backend): add terminal relay diagnostics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install Redis test server
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes redis-server
+          redis-server --version
+
       - name: Install dependencies
         working-directory: ./backend
         run: uv sync --dev

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -54,6 +54,12 @@ REDIS_URL=redis://127.0.0.1:6379/0
 # This affects new attaches; existing v2 sessions cannot silently downgrade.
 TERMINAL_PROTOCOL_V2_ENABLED=true
 
+# Backend-only terminal relay diagnostics. Use exact device IDs only; empty disables it.
+TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS=
+TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE=0.01
+TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS=50
+TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS=1
+
 # Celery configuration
 # Celery broker and result backend (uses Redis by default)
 # CELERY_BROKER_URL=redis://127.0.0.1:6379/0

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -66,6 +66,7 @@ from app.core.auth_utils import is_api_key, verify_api_key
 from app.core.constants import get_wework_task_room, get_wework_user_room
 from app.core.events import TaskCompletedEvent, get_event_bus
 from app.core.socketio import get_sio
+from app.core.terminal_socketio_manager import target_location
 from app.db.session import SessionLocal
 from app.models.subtask import SubtaskStatus
 from app.models.user import User
@@ -89,6 +90,15 @@ from app.services.chat.webpage_ws_chat_emitter import get_extended_emitter
 from app.services.device.capability_sync_service import device_capability_sync_service
 from app.services.device.identity import record_route_id
 from app.services.device.record_operations import app_identity_lock
+from app.services.device.terminal_diagnostics import (
+    TerminalTrace,
+    bind_terminal_trace,
+    create_terminal_trace,
+    is_target_device,
+    record_terminal_trace,
+    terminal_diagnostics_enabled,
+    with_terminal_trace_bytes,
+)
 from app.services.device.terminal_metrics import record_terminal_event
 from app.services.device.terminal_protocol import (
     get_browser_socket_id,
@@ -205,6 +215,59 @@ def _terminal_event_error(
     if terminal_end_dispatched:
         error["terminal_end_dispatched"] = True
     return error
+
+
+def _trace_for_device_event(
+    session: dict, data: dict, event: str
+) -> Optional[TerminalTrace]:
+    """Create a trace from the authenticated executor session identity."""
+    device_id = session.get("device_id")
+    session_id = normalize_terminal_session_id(
+        data.get("session_id") if isinstance(data, dict) else None
+    )
+    if not session_id or not is_target_device(device_id):
+        return None
+    consumer_id = get_consumer_id(data)
+    trace = create_terminal_trace(
+        device_id=device_id,
+        session_id=session_id,
+        event=event,
+        direction="device_to_browser",
+        protocol_version=get_protocol_version(data, default=2 if consumer_id else 1),
+        sequence=(
+            data.get("sequence")
+            if isinstance(data, dict) and type(data.get("sequence")) is int
+            else None
+        ),
+    )
+    text = data.get("data") if event == "terminal:output" else None
+    return with_terminal_trace_bytes(trace, text)
+
+
+def _elapsed_ms(started_ns: int) -> float:
+    return (time.perf_counter_ns() - started_ns) / 1_000_000
+
+
+async def _trace_device_event_before_parse(
+    namespace: socketio.AsyncNamespace,
+    sid: str,
+    data: dict,
+    event: str,
+) -> tuple[Optional[dict], Optional[TerminalTrace], Optional[Exception]]:
+    """Read trusted socket identity early without changing parse error semantics."""
+    if not terminal_diagnostics_enabled():
+        return None, None, None
+    try:
+        session = await namespace.get_session(sid)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return None, None, exc
+    try:
+        trace = _trace_for_device_event(session, data, event)
+    except Exception:
+        trace = None
+    return session, trace, None
 
 
 @dataclass(frozen=True)
@@ -2687,37 +2750,137 @@ class DeviceNamespace(socketio.AsyncNamespace):
 
     async def on_terminal_output(self, sid: str, data: dict) -> dict:
         """Forward executor PTY output to the browser terminal namespace."""
+        total_started = time.perf_counter_ns()
+        session, trace, session_error = await _trace_device_event_before_parse(
+            self, sid, data, "terminal:output"
+        )
+        parse_started = time.perf_counter_ns()
         try:
             payload = parse_terminal_event(data, output=True)
         except ValueError as exc:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="parse_failed",
+                parse_ms=_elapsed_ms(parse_started),
+                total_ms=_elapsed_ms(total_started),
+                target_namespace="/terminal",
+                target_location="unknown",
+                reason_code="invalid_terminal_output",
+            )
             return {"error": str(exc)}
+        parse_ms = _elapsed_ms(parse_started)
 
-        record, error = await self._authorize_terminal_event(sid, data)
+        if session_error is not None:
+            raise session_error
+        if session is None:
+            session = await self.get_session(sid)
+            trace = _trace_for_device_event(session, data, "terminal:output")
+        authorization_started = time.perf_counter_ns()
+        record, error = await self._authorize_terminal_event(sid, data, session=session)
+        authorization_ms = _elapsed_ms(authorization_started)
         if error:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="rejected",
+                parse_ms=parse_ms,
+                authorization_ms=authorization_ms,
+                total_ms=_elapsed_ms(total_started),
+                target_namespace="/terminal",
+                target_location="unknown",
+                reason_code=error.get("code", "terminal_event_rejected"),
+            )
             return await self._finish_terminal_event_rejection(
                 data,
                 error,
                 output_complete=False,
+                trace=trace,
             )
 
         payload["session_id"] = record.session_id
-        await get_sio().emit(
-            "terminal:output",
-            payload,
-            room=f"terminal:{record.session_id}",
-            namespace="/terminal",
-        )
+        sio = get_sio()
+        room = f"terminal:{record.session_id}"
+        relay_started = time.perf_counter_ns()
+        try:
+            with bind_terminal_trace(trace):
+                await sio.emit(
+                    "terminal:output",
+                    payload,
+                    room=room,
+                    namespace="/terminal",
+                )
+            relay_ms = _elapsed_ms(relay_started)
+        except Exception:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="relay_failed",
+                parse_ms=parse_ms,
+                authorization_ms=authorization_ms,
+                relay_ms=_elapsed_ms(relay_started),
+                total_ms=_elapsed_ms(total_started),
+                target_namespace="/terminal",
+                target_location=target_location(sio, room, "/terminal"),
+                reason_code="browser_output_relay_failed",
+            )
+            raise
         record_terminal_event(source="device", event="output")
+        record_terminal_trace(
+            trace,
+            stage="namespace.relay",
+            result="handler_accepted",
+            parse_ms=parse_ms,
+            authorization_ms=authorization_ms,
+            relay_ms=relay_ms,
+            total_ms=_elapsed_ms(total_started),
+            target_namespace="/terminal",
+            target_location=target_location(sio, room, "/terminal"),
+        )
         return {"success": True}
 
     async def on_terminal_exit(self, sid: str, data: dict) -> dict:
         """Forward executor PTY exit and remove the terminal session record."""
+        total_started = time.perf_counter_ns()
+        session, trace, session_error = await _trace_device_event_before_parse(
+            self, sid, data, "terminal:exit"
+        )
+        parse_started = time.perf_counter_ns()
         try:
             payload = parse_terminal_event(data, output=False)
         except ValueError as exc:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="parse_failed",
+                parse_ms=_elapsed_ms(parse_started),
+                total_ms=_elapsed_ms(total_started),
+                target_namespace="/terminal",
+                target_location="unknown",
+                reason_code="invalid_terminal_exit",
+            )
             return {"error": str(exc)}
-        record, error = await self._authorize_terminal_event(sid, data)
+        parse_ms = _elapsed_ms(parse_started)
+        if session_error is not None:
+            raise session_error
+        if session is None:
+            session = await self.get_session(sid)
+            trace = _trace_for_device_event(session, data, "terminal:exit")
+        authorization_started = time.perf_counter_ns()
+        record, error = await self._authorize_terminal_event(sid, data, session=session)
+        authorization_ms = _elapsed_ms(authorization_started)
         if error:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="rejected",
+                parse_ms=parse_ms,
+                authorization_ms=authorization_ms,
+                total_ms=_elapsed_ms(total_started),
+                target_namespace="/terminal",
+                target_location="unknown",
+                reason_code=error.get("code", "terminal_event_rejected"),
+            )
             session_id = normalize_terminal_session_id(
                 data.get("session_id") if isinstance(data, dict) else None
             )
@@ -2742,6 +2905,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
                         data,
                         error,
                         output_complete=True,
+                        trace=trace,
                     )
                     if dispatched.get("terminal_end_dispatched") is True:
                         return {"success": True}
@@ -2750,26 +2914,80 @@ class DeviceNamespace(socketio.AsyncNamespace):
                 data,
                 error,
                 output_complete=True,
+                trace=trace,
             )
 
         payload["session_id"] = record.session_id
-        await get_sio().emit(
-            "terminal:exit",
-            payload,
-            room=f"terminal:{record.session_id}",
-            namespace="/terminal",
-        )
-        await terminal_session_service.delete(record.session_id)
+        sio = get_sio()
+        room = f"terminal:{record.session_id}"
+        relay_started = time.perf_counter_ns()
+        try:
+            with bind_terminal_trace(trace):
+                await sio.emit(
+                    "terminal:exit",
+                    payload,
+                    room=room,
+                    namespace="/terminal",
+                )
+            relay_ms = _elapsed_ms(relay_started)
+        except Exception:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="relay_failed",
+                parse_ms=parse_ms,
+                authorization_ms=authorization_ms,
+                relay_ms=_elapsed_ms(relay_started),
+                total_ms=_elapsed_ms(total_started),
+                target_namespace="/terminal",
+                target_location=target_location(sio, room, "/terminal"),
+                reason_code="browser_exit_relay_failed",
+            )
+            raise
+        session_store_started = time.perf_counter_ns()
+        try:
+            await terminal_session_service.delete(record.session_id)
+        except Exception:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="session_store_failed",
+                parse_ms=parse_ms,
+                authorization_ms=authorization_ms,
+                relay_ms=relay_ms,
+                session_store_ms=_elapsed_ms(session_store_started),
+                total_ms=_elapsed_ms(total_started),
+                target_namespace="/terminal",
+                target_location=target_location(sio, room, "/terminal"),
+                reason_code="terminal_session_delete_failed",
+            )
+            raise
+        session_store_ms = _elapsed_ms(session_store_started)
         record_terminal_event(source="device", event="exit")
+        record_terminal_trace(
+            trace,
+            stage="namespace.relay",
+            result="handler_accepted",
+            parse_ms=parse_ms,
+            authorization_ms=authorization_ms,
+            relay_ms=relay_ms,
+            session_store_ms=session_store_ms,
+            total_ms=_elapsed_ms(total_started),
+            target_namespace="/terminal",
+            target_location=target_location(sio, room, "/terminal"),
+        )
         return {"success": True}
 
     async def _authorize_terminal_event(
         self,
         sid: str,
         data: dict,
+        *,
+        session: Optional[dict] = None,
     ) -> tuple[Optional[TerminalSessionRecord], Optional[dict]]:
         """Verify that a terminal event came from the registered executor socket."""
-        session = await self.get_session(sid)
+        if session is None:
+            session = await self.get_session(sid)
         user_id = session.get("user_id")
         device_id = session.get("device_id")
         if not user_id or not device_id:
@@ -2843,6 +3061,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
         error: dict,
         *,
         output_complete: bool,
+        trace: Optional[TerminalTrace] = None,
     ) -> dict:
         """Dispatch a session-scoped terminal end before permanent retirement."""
         if error.get("retryable") is not False:
@@ -2899,20 +3118,34 @@ class DeviceNamespace(socketio.AsyncNamespace):
             call_options = (
                 {"ignore_queue": True} if local_target_connected is True else {}
             )
-            acknowledged = await sio.call(
-                "terminal:exit",
-                payload,
-                to=browser_socket_id,
-                namespace="/terminal",
-                timeout=TERMINAL_END_DISPATCH_TIMEOUT_SECONDS,
-                **call_options,
-            )
+            call_started = time.perf_counter_ns()
+            with bind_terminal_trace(trace):
+                acknowledged = await sio.call(
+                    "terminal:exit",
+                    payload,
+                    to=browser_socket_id,
+                    namespace="/terminal",
+                    timeout=TERMINAL_END_DISPATCH_TIMEOUT_SECONDS,
+                    **call_options,
+                )
             if (
                 not isinstance(acknowledged, dict)
                 or acknowledged.get("success") is not True
             ):
                 raise RuntimeError("Terminal end was not acknowledged")
         except Exception:
+            record_terminal_trace(
+                trace,
+                stage="namespace.forced_exit",
+                result="call_failed",
+                call_total_ms=_elapsed_ms(call_started),
+                target_namespace="/terminal",
+                target_location=(
+                    "local" if local_target_connected is True else "remote_or_absent"
+                ),
+                queue_bypassed=local_target_connected is True,
+                reason_code="terminal_end_dispatch_failed",
+            )
             logger.exception(
                 "[Device WS] Failed to confirm terminal end session=%s code=%s "
                 "target_sid=%s",
@@ -2927,6 +3160,19 @@ class DeviceNamespace(socketio.AsyncNamespace):
             )
 
         record_terminal_event(source="device", event="forced_exit")
+        record_terminal_trace(
+            trace,
+            stage="namespace.forced_exit",
+            result="success",
+            force=True,
+            call_total_ms=_elapsed_ms(call_started),
+            target_namespace="/terminal",
+            target_location=(
+                "local" if local_target_connected is True else "remote_or_absent"
+            ),
+            queue_bypassed=local_target_connected is True,
+            reason_code=code,
+        )
         return _terminal_event_error(
             str(code),
             str(error.get("error") or "Terminal session ended"),

--- a/backend/app/api/ws/terminal_namespace.py
+++ b/backend/app/api/ws/terminal_namespace.py
@@ -5,6 +5,7 @@
 """Browser terminal Socket.IO namespace."""
 
 import logging
+import time
 import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -16,7 +17,16 @@ from app.api.ws.connection_utils import enter_connect_room, save_connect_session
 from app.api.ws.decorators import trace_websocket_event
 from app.core.config import settings
 from app.core.socketio import get_sio
+from app.core.terminal_socketio_manager import target_location
 from app.services.chat.access import get_token_expiry, verify_jwt_token
+from app.services.device.terminal_diagnostics import (
+    TerminalTrace,
+    bind_terminal_trace,
+    create_terminal_trace,
+    is_target_device,
+    record_terminal_trace,
+    with_terminal_trace_bytes,
+)
 from app.services.device.terminal_metrics import record_terminal_event
 from app.services.device.terminal_protocol import (
     TerminalAttachRequest,
@@ -130,6 +140,7 @@ class TerminalNamespace(socketio.AsyncNamespace):
     @trace_async(span_name="terminal.attach", tracer_name=__name__)
     async def on_terminal_attach(self, sid: str, data: dict) -> dict:
         """Attach a browser socket to an existing backend-created terminal session."""
+        total_started = time.perf_counter_ns()
         session = await self.get_session(sid)
         if await self._check_token_expiry(session):
             return await self._handle_token_expired(sid)
@@ -157,6 +168,7 @@ class TerminalNamespace(socketio.AsyncNamespace):
         except ValueError as exc:
             return {"error": str(exc)}
 
+        authorization_started = time.perf_counter_ns()
         try:
             record = await terminal_session_service.authorize(
                 session_id,
@@ -169,23 +181,48 @@ class TerminalNamespace(socketio.AsyncNamespace):
             }
         if not record:
             return {"error": "Terminal session not found or access denied"}
+        authorization_ms = _elapsed_ms(authorization_started)
+        trace = create_terminal_trace(
+            device_id=record.device_id,
+            session_id=record.session_id,
+            event="terminal:attach",
+            direction="browser_to_device",
+            protocol_version=offered,
+        )
 
+        target_lookup_started = time.perf_counter_ns()
         executor_socket_id = await _active_executor_socket(record)
+        target_lookup_ms = _elapsed_ms(target_lookup_started)
         if not executor_socket_id:
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="target_unavailable",
+                authorization_ms=authorization_ms,
+                target_lookup_ms=target_lookup_ms,
+                total_ms=_elapsed_ms(total_started),
+                target_namespace=DEVICE_NAMESPACE,
+                target_location="remote_or_absent",
+                reason_code="terminal_executor_offline",
+            )
             return {"error": "Terminal executor is offline"}
         await self.enter_room(sid, _terminal_room(session_id))
+        call_started = time.perf_counter_ns()
         try:
-            attach_result = await get_sio().call(
-                "terminal:attach",
-                request.payload(
-                    record.session_id,
-                    offered,
-                    browser_socket_id=sid,
-                ),
-                to=executor_socket_id,
-                namespace=DEVICE_NAMESPACE,
-                timeout=TERMINAL_ATTACH_TIMEOUT_SECONDS,
-            )
+            sio = get_sio()
+            with bind_terminal_trace(trace):
+                attach_result = await sio.call(
+                    "terminal:attach",
+                    request.payload(
+                        record.session_id,
+                        offered,
+                        browser_socket_id=sid,
+                    ),
+                    to=executor_socket_id,
+                    namespace=DEVICE_NAMESPACE,
+                    timeout=TERMINAL_ATTACH_TIMEOUT_SECONDS,
+                )
+            call_total_ms = _elapsed_ms(call_started)
         except Exception as exc:
             if previous_session_id != session_id:
                 await self.leave_room(sid, _terminal_room(session_id))
@@ -194,6 +231,18 @@ class TerminalNamespace(socketio.AsyncNamespace):
                 record.session_id,
                 record.device_id,
                 exc,
+            )
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="call_failed",
+                authorization_ms=authorization_ms,
+                target_lookup_ms=target_lookup_ms,
+                call_total_ms=_elapsed_ms(call_started),
+                total_ms=_elapsed_ms(total_started),
+                target_namespace=DEVICE_NAMESPACE,
+                target_location=_executor_target_location(executor_socket_id),
+                reason_code="executor_attach_call_failed",
             )
             return {"error": "Failed to attach terminal executor"}
 
@@ -208,6 +257,18 @@ class TerminalNamespace(socketio.AsyncNamespace):
                 if isinstance(attach_result, dict)
                 else "Invalid executor response"
             )
+            record_terminal_trace(
+                trace,
+                stage="namespace.relay",
+                result="rejected",
+                authorization_ms=authorization_ms,
+                target_lookup_ms=target_lookup_ms,
+                call_total_ms=call_total_ms,
+                total_ms=_elapsed_ms(total_started),
+                target_namespace=DEVICE_NAMESPACE,
+                target_location=_executor_target_location(executor_socket_id),
+                reason_code="executor_attach_rejected",
+            )
             return {"error": str(error or "Failed to attach terminal executor")}
 
         try:
@@ -215,9 +276,21 @@ class TerminalNamespace(socketio.AsyncNamespace):
         except ValueError as exc:
             if previous_session_id != session_id:
                 await self.leave_room(sid, _terminal_room(session_id))
+            _record_attach_relay(
+                trace,
+                result="rejected",
+                total_started=total_started,
+                authorization_ms=authorization_ms,
+                target_lookup_ms=target_lookup_ms,
+                call_total_ms=call_total_ms,
+                executor_socket_id=executor_socket_id,
+                reason_code="protocol_negotiation_failed",
+            )
             return {"error": str(exc)}
 
+        session_store_ms = 0.0
         if executor_socket_id != record.socket_id:
+            session_store_started = time.perf_counter_ns()
             try:
                 rebound = await terminal_session_service.rebind_socket(
                     record,
@@ -226,6 +299,17 @@ class TerminalNamespace(socketio.AsyncNamespace):
             except TerminalSessionAuthorizationUnavailable:
                 if previous_session_id != session_id:
                     await self.leave_room(sid, _terminal_room(session_id))
+                _record_attach_relay(
+                    trace,
+                    result="session_store_failed",
+                    total_started=total_started,
+                    authorization_ms=authorization_ms,
+                    target_lookup_ms=target_lookup_ms,
+                    call_total_ms=call_total_ms,
+                    executor_socket_id=executor_socket_id,
+                    session_store_ms=_elapsed_ms(session_store_started),
+                    reason_code="terminal_session_authorization_unavailable",
+                )
                 return {
                     "error": (
                         "Terminal session authorization is temporarily unavailable"
@@ -234,8 +318,20 @@ class TerminalNamespace(socketio.AsyncNamespace):
             if not rebound:
                 if previous_session_id != session_id:
                     await self.leave_room(sid, _terminal_room(session_id))
+                _record_attach_relay(
+                    trace,
+                    result="session_store_failed",
+                    total_started=total_started,
+                    authorization_ms=authorization_ms,
+                    target_lookup_ms=target_lookup_ms,
+                    call_total_ms=call_total_ms,
+                    executor_socket_id=executor_socket_id,
+                    session_store_ms=_elapsed_ms(session_store_started),
+                    reason_code="terminal_session_rebind_failed",
+                )
                 return {"error": "Terminal session could not be rebound"}
             record = rebound
+            session_store_ms = _elapsed_ms(session_store_started)
 
         if (
             isinstance(previous_session_id, str)
@@ -248,8 +344,37 @@ class TerminalNamespace(socketio.AsyncNamespace):
         session["terminal_protocol_version"] = selected
         session["terminal_consumer_id"] = request.consumer_id if selected == 2 else None
         session["terminal_authorization"] = record
-        await self.save_session(sid, session)
+        session_store_started = time.perf_counter_ns()
+        try:
+            await self.save_session(sid, session)
+        except Exception:
+            session_store_ms += _elapsed_ms(session_store_started)
+            _record_attach_relay(
+                trace,
+                result="session_store_failed",
+                total_started=total_started,
+                authorization_ms=authorization_ms,
+                target_lookup_ms=target_lookup_ms,
+                call_total_ms=call_total_ms,
+                executor_socket_id=executor_socket_id,
+                session_store_ms=session_store_ms,
+                reason_code="browser_session_save_failed",
+            )
+            raise
+        session_store_ms += _elapsed_ms(session_store_started)
         record_terminal_event(source="browser", event="attach")
+        record_terminal_trace(
+            trace,
+            stage="namespace.relay",
+            result="handler_accepted",
+            authorization_ms=authorization_ms,
+            target_lookup_ms=target_lookup_ms,
+            call_total_ms=call_total_ms,
+            session_store_ms=session_store_ms,
+            total_ms=_elapsed_ms(total_started),
+            target_namespace=DEVICE_NAMESPACE,
+            target_location=_executor_target_location(executor_socket_id),
+        )
 
         return {
             "success": True,
@@ -262,33 +387,66 @@ class TerminalNamespace(socketio.AsyncNamespace):
 
     async def on_terminal_ack(self, sid: str, data: dict) -> dict:
         """Relay a browser output acknowledgement to the owning executor."""
-        record, consumer_id, error = await self._authorize_attached_session(sid, data)
+        total_started = time.perf_counter_ns()
+        session = await self.get_session(sid)
+        trace = _trace_for_attached_event(session, data, "terminal:ack")
+        authorization_started = time.perf_counter_ns()
+        record, consumer_id, error = await self._authorize_attached_session(
+            sid, data, session=session
+        )
+        authorization_ms = _elapsed_ms(authorization_started)
         if error:
+            _record_browser_relay_error(trace, error, authorization_ms, total_started)
             return error
 
         if not consumer_id:
+            _record_browser_relay_error(
+                trace,
+                {"error": "Terminal ACK requires protocol v2"},
+                authorization_ms,
+                total_started,
+            )
             return {"error": "Terminal ACK requires protocol v2"}
         sequence = get_sequence(data, "sequence")
         if sequence is None:
-            return {"error": "Invalid terminal sequence"}
-        try:
-            ack_result = await get_sio().call(
-                "terminal:ack",
-                {
-                    "session_id": record.session_id,
-                    "consumer_id": consumer_id,
-                    "sequence": sequence,
-                },
-                to=record.socket_id,
-                namespace=DEVICE_NAMESPACE,
-                timeout=TERMINAL_ATTACH_TIMEOUT_SECONDS,
+            _record_browser_relay_error(
+                trace,
+                {"error": "Invalid terminal sequence"},
+                authorization_ms,
+                total_started,
             )
+            return {"error": "Invalid terminal sequence"}
+        call_started = time.perf_counter_ns()
+        try:
+            sio = get_sio()
+            with bind_terminal_trace(trace):
+                ack_result = await sio.call(
+                    "terminal:ack",
+                    {
+                        "session_id": record.session_id,
+                        "consumer_id": consumer_id,
+                        "sequence": sequence,
+                    },
+                    to=record.socket_id,
+                    namespace=DEVICE_NAMESPACE,
+                    timeout=TERMINAL_ATTACH_TIMEOUT_SECONDS,
+                )
+            call_total_ms = _elapsed_ms(call_started)
         except Exception as exc:
             logger.warning(
                 "[Terminal WS] Executor ACK failed session=%s device=%s: %s",
                 record.session_id,
                 record.device_id,
                 exc,
+            )
+            _record_browser_relay(
+                trace,
+                result="call_failed",
+                record=record,
+                authorization_ms=authorization_ms,
+                total_started=total_started,
+                call_total_ms=_elapsed_ms(call_started),
+                reason_code="executor_ack_call_failed",
             )
             return {"error": "Failed to acknowledge terminal output"}
         if not isinstance(ack_result, dict) or not ack_result.get("success"):
@@ -297,74 +455,188 @@ class TerminalNamespace(socketio.AsyncNamespace):
                 if isinstance(ack_result, dict)
                 else "Invalid executor response"
             )
+            _record_browser_relay(
+                trace,
+                result="rejected",
+                record=record,
+                authorization_ms=authorization_ms,
+                total_started=total_started,
+                call_total_ms=call_total_ms,
+                reason_code="executor_ack_rejected",
+            )
             return {"error": str(error or "Failed to acknowledge terminal output")}
         record_terminal_event(source="browser", event="ack")
+        _record_browser_relay(
+            trace,
+            result="handler_accepted",
+            record=record,
+            authorization_ms=authorization_ms,
+            total_started=total_started,
+            call_total_ms=call_total_ms,
+        )
         return {"success": True}
 
     async def on_terminal_input(self, sid: str, data: dict) -> dict:
         """Relay browser terminal input to the owning executor socket."""
-        record, consumer_id, error = await self._authorize_attached_session(sid, data)
+        total_started = time.perf_counter_ns()
+        session = await self.get_session(sid)
+        trace = _trace_for_attached_event(session, data, "terminal:input")
+        authorization_started = time.perf_counter_ns()
+        record, consumer_id, error = await self._authorize_attached_session(
+            sid, data, session=session
+        )
+        authorization_ms = _elapsed_ms(authorization_started)
         if error:
+            _record_browser_relay_error(trace, error, authorization_ms, total_started)
             return error
 
         text = data.get("data")
         if not isinstance(text, str):
+            _record_browser_relay_error(
+                trace,
+                {"error": "Invalid terminal input"},
+                authorization_ms,
+                total_started,
+            )
             return {"error": "Invalid terminal input"}
-        await get_sio().emit(
-            "terminal:input",
-            {
-                **_control_payload(record.session_id, consumer_id),
-                "data": text,
-            },
-            to=record.socket_id,
-            namespace=DEVICE_NAMESPACE,
-        )
+        relay_started = time.perf_counter_ns()
+        sio = get_sio()
+        try:
+            with bind_terminal_trace(trace):
+                await sio.emit(
+                    "terminal:input",
+                    {
+                        **_control_payload(record.session_id, consumer_id),
+                        "data": text,
+                    },
+                    to=record.socket_id,
+                    namespace=DEVICE_NAMESPACE,
+                )
+            relay_ms = _elapsed_ms(relay_started)
+        except Exception:
+            _record_browser_relay(
+                trace,
+                result="relay_failed",
+                record=record,
+                authorization_ms=authorization_ms,
+                total_started=total_started,
+                relay_ms=_elapsed_ms(relay_started),
+                reason_code="executor_input_relay_failed",
+            )
+            raise
         record_terminal_event(source="browser", event="input")
+        _record_browser_relay(
+            trace,
+            result="handler_accepted",
+            record=record,
+            authorization_ms=authorization_ms,
+            total_started=total_started,
+            relay_ms=relay_ms,
+        )
         return {"success": True}
 
     async def on_terminal_resize(self, sid: str, data: dict) -> dict:
         """Relay terminal resize events to the owning executor socket."""
-        record, consumer_id, error = await self._authorize_attached_session(sid, data)
+        total_started = time.perf_counter_ns()
+        session = await self.get_session(sid)
+        trace = _trace_for_attached_event(session, data, "terminal:resize")
+        authorization_started = time.perf_counter_ns()
+        record, consumer_id, error = await self._authorize_attached_session(
+            sid, data, session=session
+        )
+        authorization_ms = _elapsed_ms(authorization_started)
         if error:
+            _record_browser_relay_error(trace, error, authorization_ms, total_started)
             return error
 
         rows = _get_positive_int(data, "rows")
         cols = _get_positive_int(data, "cols")
         if rows is None or cols is None:
+            _record_browser_relay_error(
+                trace,
+                {"error": "Invalid terminal dimensions"},
+                authorization_ms,
+                total_started,
+            )
             return {"error": "Invalid terminal dimensions"}
-        await get_sio().emit(
-            "terminal:resize",
-            {
-                **_control_payload(record.session_id, consumer_id),
-                "rows": rows,
-                "cols": cols,
-            },
-            to=record.socket_id,
-            namespace=DEVICE_NAMESPACE,
-        )
+        relay_started = time.perf_counter_ns()
+        sio = get_sio()
+        try:
+            with bind_terminal_trace(trace):
+                await sio.emit(
+                    "terminal:resize",
+                    {
+                        **_control_payload(record.session_id, consumer_id),
+                        "rows": rows,
+                        "cols": cols,
+                    },
+                    to=record.socket_id,
+                    namespace=DEVICE_NAMESPACE,
+                )
+            relay_ms = _elapsed_ms(relay_started)
+        except Exception:
+            _record_browser_relay(
+                trace,
+                result="relay_failed",
+                record=record,
+                authorization_ms=authorization_ms,
+                total_started=total_started,
+                relay_ms=_elapsed_ms(relay_started),
+                reason_code="executor_resize_relay_failed",
+            )
+            raise
         record_terminal_event(source="browser", event="resize")
+        _record_browser_relay(
+            trace,
+            result="handler_accepted",
+            record=record,
+            authorization_ms=authorization_ms,
+            total_started=total_started,
+            relay_ms=relay_ms,
+        )
         return {"success": True}
 
     async def on_terminal_close(self, sid: str, data: dict) -> dict:
         """Close the executor PTY and remove the backend session record."""
-        record, consumer_id, error = await self._authorize_attached_session(sid, data)
+        total_started = time.perf_counter_ns()
+        session = await self.get_session(sid)
+        trace = _trace_for_attached_event(session, data, "terminal:close")
+        authorization_started = time.perf_counter_ns()
+        record, consumer_id, error = await self._authorize_attached_session(
+            sid, data, session=session
+        )
+        authorization_ms = _elapsed_ms(authorization_started)
         if error:
+            _record_browser_relay_error(trace, error, authorization_ms, total_started)
             return error
 
+        call_started = time.perf_counter_ns()
         try:
-            close_result = await get_sio().call(
-                "terminal:close",
-                _control_payload(record.session_id, consumer_id),
-                to=record.socket_id,
-                namespace=DEVICE_NAMESPACE,
-                timeout=TERMINAL_ATTACH_TIMEOUT_SECONDS,
-            )
+            sio = get_sio()
+            with bind_terminal_trace(trace):
+                close_result = await sio.call(
+                    "terminal:close",
+                    _control_payload(record.session_id, consumer_id),
+                    to=record.socket_id,
+                    namespace=DEVICE_NAMESPACE,
+                    timeout=TERMINAL_ATTACH_TIMEOUT_SECONDS,
+                )
+            call_total_ms = _elapsed_ms(call_started)
         except Exception as exc:
             logger.warning(
                 "[Terminal WS] Executor close failed session=%s device=%s: %s",
                 record.session_id,
                 record.device_id,
                 exc,
+            )
+            _record_browser_relay(
+                trace,
+                result="call_failed",
+                record=record,
+                authorization_ms=authorization_ms,
+                total_started=total_started,
+                call_total_ms=_elapsed_ms(call_started),
+                reason_code="executor_close_call_failed",
             )
             return {"error": "Failed to close terminal executor"}
         if not isinstance(close_result, dict) or not close_result.get("success"):
@@ -373,7 +645,17 @@ class TerminalNamespace(socketio.AsyncNamespace):
                 if isinstance(close_result, dict)
                 else "Invalid executor response"
             )
+            _record_browser_relay(
+                trace,
+                result="rejected",
+                record=record,
+                authorization_ms=authorization_ms,
+                total_started=total_started,
+                call_total_ms=call_total_ms,
+                reason_code="executor_close_rejected",
+            )
             return {"error": str(error or "Failed to close terminal executor")}
+        session_store_started = time.perf_counter_ns()
         try:
             await terminal_session_service.delete(record.session_id)
         except Exception as exc:
@@ -381,6 +663,16 @@ class TerminalNamespace(socketio.AsyncNamespace):
                 "[Terminal WS] Failed to revoke terminal session=%s: %s",
                 record.session_id,
                 exc,
+            )
+            _record_browser_relay(
+                trace,
+                result="session_store_failed",
+                record=record,
+                authorization_ms=authorization_ms,
+                total_started=total_started,
+                call_total_ms=call_total_ms,
+                session_store_ms=_elapsed_ms(session_store_started),
+                reason_code="terminal_session_delete_failed",
             )
             return {"error": "Failed to close terminal session"}
         await self.leave_room(sid, _terminal_room(record.session_id))
@@ -392,14 +684,26 @@ class TerminalNamespace(socketio.AsyncNamespace):
             session["terminal_authorization"] = None
             await self.save_session(sid, session)
         record_terminal_event(source="browser", event="close")
+        _record_browser_relay(
+            trace,
+            result="handler_accepted",
+            record=record,
+            authorization_ms=authorization_ms,
+            total_started=total_started,
+            call_total_ms=call_total_ms,
+            session_store_ms=_elapsed_ms(session_store_started),
+        )
         return {"success": True}
 
     async def _authorize_attached_session(
         self,
         sid: str,
         data: dict,
+        *,
+        session: Optional[dict[str, Any]] = None,
     ) -> tuple[Optional[TerminalSessionRecord], str, Optional[dict]]:
-        session = await self.get_session(sid)
+        if session is None:
+            session = await self.get_session(sid)
         if await self._check_token_expiry(session):
             return None, "", await self._handle_token_expired(sid)
 
@@ -516,6 +820,136 @@ def _control_payload(session_id: str, consumer_id: str) -> dict:
 
 def _terminal_room(session_id: str) -> str:
     return f"terminal:{session_id}"
+
+
+def _trace_for_attached_event(
+    session: dict, data: dict, event: str
+) -> Optional[TerminalTrace]:
+    """Create a trace only from the trusted, already-attached session record."""
+    session_id = _get_session_id(data)
+    record = session.get("terminal_authorization")
+    if (
+        not session_id
+        or session.get("terminal_session_id") != session_id
+        or not isinstance(record, TerminalSessionRecord)
+        or record.session_id != session_id
+        or record.user_id != session.get("user_id")
+        or not is_target_device(record.device_id)
+    ):
+        return None
+    trace = create_terminal_trace(
+        device_id=record.device_id,
+        session_id=session_id,
+        event=event,
+        direction="browser_to_device",
+        protocol_version=session.get("terminal_protocol_version"),
+        sequence=get_sequence(data, "sequence"),
+    )
+    text = data.get("data") if event == "terminal:input" else None
+    return with_terminal_trace_bytes(trace, text)
+
+
+def _record_browser_relay_error(
+    trace: Optional[TerminalTrace],
+    error: dict,
+    authorization_ms: float,
+    total_started: int,
+) -> None:
+    record_terminal_trace(
+        trace,
+        stage="namespace.relay",
+        result="rejected",
+        authorization_ms=authorization_ms,
+        total_ms=_elapsed_ms(total_started),
+        target_namespace=DEVICE_NAMESPACE,
+        target_location="unknown",
+        reason_code=_terminal_error_reason(error),
+    )
+
+
+def _record_attach_relay(
+    trace: Optional[TerminalTrace],
+    *,
+    result: str,
+    total_started: int,
+    authorization_ms: float,
+    target_lookup_ms: float,
+    call_total_ms: float,
+    executor_socket_id: str,
+    **fields: object,
+) -> None:
+    record_terminal_trace(
+        trace,
+        stage="namespace.relay",
+        result=result,
+        authorization_ms=authorization_ms,
+        target_lookup_ms=target_lookup_ms,
+        call_total_ms=call_total_ms,
+        total_ms=_elapsed_ms(total_started),
+        target_namespace=DEVICE_NAMESPACE,
+        target_location=_executor_target_location(executor_socket_id),
+        **fields,
+    )
+
+
+def _record_browser_relay(
+    trace: Optional[TerminalTrace],
+    *,
+    result: str,
+    record: TerminalSessionRecord,
+    authorization_ms: float,
+    total_started: int,
+    **fields: object,
+) -> None:
+    try:
+        location = target_location(get_sio(), record.socket_id, DEVICE_NAMESPACE)
+    except Exception:
+        location = "unknown"
+    record_terminal_trace(
+        trace,
+        stage="namespace.relay",
+        result=result,
+        authorization_ms=authorization_ms,
+        total_ms=_elapsed_ms(total_started),
+        target_namespace=DEVICE_NAMESPACE,
+        target_location=location,
+        **fields,
+    )
+
+
+def _terminal_error_reason(error: dict) -> str:
+    message = error.get("error")
+    reasons = {
+        "Token expired": "token_expired",
+        "Not authenticated": "not_authenticated",
+        "Missing session_id": "terminal_session_id_missing",
+        "Terminal session is not attached": "terminal_session_not_attached",
+        "Terminal session must be reattached": "terminal_session_reattach_required",
+        "Terminal protocol does not match attachment": "protocol_mismatch",
+        "Terminal ACK requires protocol v2": "ack_requires_v2",
+        "Terminal consumer is no longer active": "consumer_inactive",
+        "Terminal consumer does not match attachment": "consumer_mismatch",
+        "Terminal session not found or access denied": "authorization_denied",
+        "Terminal session expired": "terminal_session_expired",
+        "Terminal session authorization is temporarily unavailable": (
+            "terminal_session_authorization_unavailable"
+        ),
+        "Invalid terminal sequence": "invalid_sequence",
+        "Invalid terminal input": "invalid_input",
+        "Invalid terminal dimensions": "invalid_dimensions",
+    }
+    return reasons.get(message, "terminal_request_rejected")
+
+
+def _elapsed_ms(started_ns: int) -> float:
+    return (time.perf_counter_ns() - started_ns) / 1_000_000
+
+
+def _executor_target_location(socket_id: str) -> str:
+    try:
+        return target_location(get_sio(), socket_id, DEVICE_NAMESPACE)
+    except Exception:
+        return "unknown"
 
 
 async def _active_executor_socket(record: TerminalSessionRecord) -> str:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -303,6 +303,13 @@ class Settings(BaseSettings):
     TERMINAL_SESSION_CACHE_TTL_SECONDS: float = 5.0
     # Keep false during mixed-version Backend rollout; enable after all replicas upgrade.
     TERMINAL_PROTOCOL_V2_ENABLED: bool = True
+    # Exact cloud device IDs whose terminal relay should emit diagnostic logs.
+    TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS: str = ""
+    TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE: float = Field(default=0.01, ge=0, le=1)
+    TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS: float = Field(default=50, ge=0)
+    TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS: float = Field(
+        default=1.0, ge=0.1
+    )
     TASK_RUN_METRICS_RETENTION_DAYS: int = 32
 
     # Public base URL of this backend, reachable from executor devices. The

--- a/backend/app/core/socketio.py
+++ b/backend/app/core/socketio.py
@@ -10,10 +10,12 @@ for multi-worker deployments.
 """
 
 import logging
+from urllib.parse import urlsplit
 
 import socketio
 
 from app.core.config import settings
+from app.core.terminal_socketio_manager import TerminalDiagnosticAsyncRedisManager
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +40,15 @@ def create_socketio_server() -> socketio.AsyncServer:
     redis_url = settings.REDIS_URL
 
     try:
-        mgr = socketio.AsyncRedisManager(redis_url)
-        logger.info(f"Socket.IO Redis manager initialized with {redis_url}")
+        mgr = TerminalDiagnosticAsyncRedisManager(redis_url)
+        logger.info(
+            "Socket.IO Redis manager initialized endpoint=%s",
+            _safe_redis_endpoint(redis_url),
+        )
     except Exception as e:
         logger.warning(
-            f"Failed to create Redis manager: {e}, falling back to in-memory"
+            "Failed to create Redis manager error_type=%s, falling back to in-memory",
+            type(e).__name__,
         )
         mgr = None
 
@@ -92,3 +98,17 @@ def get_sio() -> socketio.AsyncServer:
     if _sio_instance is None:
         _sio_instance = create_socketio_server()
     return _sio_instance
+
+
+def _safe_redis_endpoint(redis_url: str) -> str:
+    """Describe a Redis endpoint without credentials or query parameters."""
+    try:
+        parsed = urlsplit(redis_url)
+        database = parsed.path.lstrip("/") or "0"
+        if not database.isdigit():
+            database = "unknown"
+        host = parsed.hostname or "unknown"
+        port = parsed.port or (6380 if parsed.scheme == "rediss" else 6379)
+        return f"{parsed.scheme or 'redis'}://{host}:{port}/{database}"
+    except (TypeError, ValueError):
+        return "unparseable"

--- a/backend/app/core/terminal_socketio_manager.py
+++ b/backend/app/core/terminal_socketio_manager.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Socket.IO Redis manager instrumentation for terminal relay diagnostics."""
+
+import asyncio
+import os
+import time
+from typing import Any, Optional
+
+import socketio
+
+from app.services.device.terminal_diagnostics import (
+    TERMINAL_TRACE_METADATA_KEY,
+    TerminalTrace,
+    current_terminal_trace,
+    record_terminal_trace,
+)
+
+
+class TerminalDiagnosticAsyncRedisManager(socketio.AsyncRedisManager):
+    """Preserve manager behavior while timing terminal Redis relay stages."""
+
+    async def _publish(self, data: dict[str, Any]) -> Any:
+        trace = current_terminal_trace()
+        message = data
+        if trace is not None and data.get("method") == "emit":
+            try:
+                publish_wall_ns = time.time_ns()
+                message = dict(data)
+                message[TERMINAL_TRACE_METADATA_KEY] = trace.metadata(
+                    published_wall_ns=publish_wall_ns
+                )
+            except Exception:
+                message = data
+
+        started = _safe_perf_counter_ns()
+        try:
+            result = await super()._publish(message)
+        except asyncio.CancelledError:
+            _safe_record_terminal_trace(
+                trace,
+                stage="redis.publish",
+                result="cancelled",
+                publish_ms=_safe_elapsed_ms(started),
+                channel=self.channel,
+                manager=type(self).__name__,
+            )
+            raise
+        except Exception:
+            _safe_record_terminal_trace(
+                trace,
+                stage="redis.publish",
+                result="publish_failed",
+                publish_ms=_safe_elapsed_ms(started),
+                channel=self.channel,
+                manager=type(self).__name__,
+            )
+            raise
+
+        publish_result = (
+            "publish_failed"
+            if result is None
+            else "published_no_subscribers" if result == 0 else "published"
+        )
+        _safe_record_terminal_trace(
+            trace,
+            stage="redis.publish",
+            result=publish_result,
+            publish_ms=_safe_elapsed_ms(started),
+            subscribers=result,
+            channel=self.channel,
+            manager=type(self).__name__,
+        )
+        return result
+
+    async def _handle_emit(self, message: dict[str, Any]) -> Any:
+        try:
+            metadata_trace = TerminalTrace.from_metadata(
+                message.get(TERMINAL_TRACE_METADATA_KEY)
+            )
+        except Exception:
+            metadata_trace = None
+        trace = metadata_trace or current_terminal_trace()
+        if trace is None:
+            return await super()._handle_emit(message)
+
+        received_wall_ns = _safe_time_ns() if metadata_trace is not None else None
+        namespace = message.get("namespace") or "/"
+        room = message.get("room")
+        local_participant_count, participant_query_failed = _participant_count(
+            self, namespace, room
+        )
+        remote = metadata_trace is not None
+        started = _safe_perf_counter_ns()
+        try:
+            result = await super()._handle_emit(message)
+        except asyncio.CancelledError:
+            self._record_enqueue(
+                trace,
+                remote=remote,
+                namespace=namespace,
+                participant_count=local_participant_count,
+                started=started,
+                received_wall_ns=received_wall_ns,
+                result="cancelled",
+            )
+            raise
+        except Exception:
+            self._record_enqueue(
+                trace,
+                remote=remote,
+                namespace=namespace,
+                participant_count=local_participant_count,
+                started=started,
+                received_wall_ns=received_wall_ns,
+                result="enqueue_failed",
+            )
+            raise
+        self._record_enqueue(
+            trace,
+            remote=remote,
+            namespace=namespace,
+            participant_count=local_participant_count,
+            started=started,
+            received_wall_ns=received_wall_ns,
+            result="diagnostic_error" if participant_query_failed else "enqueued",
+        )
+        return result
+
+    def _record_enqueue(
+        self,
+        trace: TerminalTrace,
+        *,
+        remote: bool,
+        namespace: str,
+        participant_count: Optional[int],
+        started: Optional[int],
+        received_wall_ns: Optional[int],
+        result: str,
+    ) -> None:
+        try:
+            self._record_enqueue_fields(
+                trace,
+                remote=remote,
+                namespace=namespace,
+                participant_count=participant_count,
+                started=started,
+                received_wall_ns=received_wall_ns,
+                result=result,
+            )
+        except Exception:
+            pass
+
+    def _record_enqueue_fields(
+        self,
+        trace: TerminalTrace,
+        *,
+        remote: bool,
+        namespace: str,
+        participant_count: Optional[int],
+        started: Optional[int],
+        received_wall_ns: Optional[int],
+        result: str,
+    ) -> None:
+        if not participant_count and result == "enqueued":
+            return
+        diagnostic_error = result == "diagnostic_error"
+        fields: dict[str, object] = {
+            "target_namespace": namespace,
+            "target_location": (
+                "unknown"
+                if diagnostic_error
+                else "remote_or_absent" if remote or not participant_count else "local"
+            ),
+            "local_participant_count": participant_count,
+            "local_enqueue_ms": _safe_elapsed_ms(started),
+            "manager": type(self).__name__,
+        }
+        if diagnostic_error:
+            fields["reason_code"] = "participant_query_failed"
+        if (
+            remote
+            and trace.published_wall_ns is not None
+            and received_wall_ns is not None
+        ):
+            queue_ms = (received_wall_ns - trace.published_wall_ns) / 1_000_000
+            fields["approx_queue_ms"] = queue_ms
+            fields["clock_skew"] = queue_ms < 0
+            fields["target_pod"] = _current_pod()
+        _safe_record_terminal_trace(
+            trace,
+            stage="redis.consume_enqueue" if remote else "socketio.local_enqueue",
+            result=result,
+            **fields,
+        )
+
+
+def target_location(sio: socketio.AsyncServer, target: str, namespace: str) -> str:
+    """Classify a Socket.IO target without exposing its socket or room value."""
+    try:
+        manager = getattr(sio, "manager", None)
+        if manager is None:
+            return "unknown"
+        if manager.is_connected(target, namespace):
+            return "local"
+        if any(manager.get_participants(namespace, target)):
+            return "local"
+        return "remote_or_absent"
+    except Exception:
+        return "unknown"
+
+
+def _participant_count(
+    manager: socketio.AsyncManager, namespace: str, room: object
+) -> tuple[Optional[int], bool]:
+    try:
+        if room is None:
+            return None, False
+        return sum(1 for _ in manager.get_participants(namespace, room)), False
+    except Exception:
+        return None, True
+
+
+def _safe_perf_counter_ns() -> Optional[int]:
+    try:
+        return time.perf_counter_ns()
+    except Exception:
+        return None
+
+
+def _safe_time_ns() -> Optional[int]:
+    try:
+        return time.time_ns()
+    except Exception:
+        return None
+
+
+def _safe_elapsed_ms(started_ns: Optional[int]) -> Optional[float]:
+    if started_ns is None:
+        return None
+    try:
+        return (time.perf_counter_ns() - started_ns) / 1_000_000
+    except Exception:
+        return None
+
+
+def _current_pod() -> str:
+    return os.environ.get("HOSTNAME", "unknown")
+
+
+def _safe_record_terminal_trace(
+    trace: Optional[TerminalTrace], *, stage: str, result: str, **fields: object
+) -> None:
+    try:
+        record_terminal_trace(trace, stage=stage, result=result, **fields)
+    except Exception:
+        pass

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,10 @@ from app.models import *  # noqa: F401,F403
 from app.services.auth.internal_service_token import (
     require_internal_service_token_configured,
 )
+from app.services.device.terminal_diagnostics import (
+    start_event_loop_lag_sampler,
+    stop_event_loop_lag_sampler,
+)
 from app.services.jobs import start_background_jobs, stop_background_jobs
 from shared.telemetry.context.large_data import log_json_body
 
@@ -79,6 +83,15 @@ SENSITIVE_HTTP_BODY_PATHS = {
 setup_logging()
 log_registered_pool_configurations()
 _logger = logging.getLogger(__name__)
+
+
+def _start_terminal_diagnostics(app: FastAPI) -> None:
+    """Keep a strong reference to the optional process-owned sampler."""
+    app.state.terminal_diagnostics_task = start_event_loop_lag_sampler()
+
+
+async def _stop_terminal_diagnostics() -> None:
+    await stop_event_loop_lag_sampler()
 
 
 def _truncate_logged_header_value(value: str) -> str:
@@ -508,6 +521,10 @@ async def lifespan(app: FastAPI):
     await terminal_session_service.start()
     logger.info("✓ Terminal session invalidation listener started")
 
+    _start_terminal_diagnostics(app)
+    if app.state.terminal_diagnostics_task is not None:
+        logger.info("✓ Terminal backend diagnostic event-loop sampler started")
+
     logger.info("=" * 60)
     logger.info("Application startup completed successfully!")
     logger.info("=" * 60)
@@ -596,6 +613,9 @@ async def lifespan(app: FastAPI):
 
         await terminal_session_service.stop()
         logger.info("✓ Terminal session invalidation listener stopped")
+
+        await _stop_terminal_diagnostics()
+        logger.info("✓ Terminal backend diagnostic event-loop sampler stopped")
 
         from app.services.loop_items.external_provider import (
             external_loop_item_provider,

--- a/backend/app/services/device/terminal_diagnostics.py
+++ b/backend/app/services/device/terminal_diagnostics.py
@@ -1,0 +1,449 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in, privacy-safe timing diagnostics for the terminal relay."""
+
+import asyncio
+import hashlib
+import logging
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, replace
+from functools import lru_cache
+from typing import Any, Iterator, Mapping, Optional
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_TRACE_LOG_PREFIX = "[TerminalBackendTrace]"
+TERMINAL_TRACE_METADATA_KEY = "_wegent_terminal_trace"
+TERMINAL_TRACE_VERSION = 1
+ALWAYS_SAMPLED_EVENTS = {
+    "terminal:attach",
+    "terminal:input",
+    "terminal:resize",
+    "terminal:close",
+    "terminal:exit",
+}
+SAFE_LOG_FIELDS = {
+    "approx_queue_ms",
+    "authorization_ms",
+    "bytes",
+    "channel",
+    "clock_skew",
+    "current_pod",
+    "device_id",
+    "direction",
+    "event",
+    "event_loop_lag_age_ms",
+    "event_loop_lag_ms",
+    "local_enqueue_ms",
+    "local_participant_count",
+    "manager",
+    "parse_ms",
+    "pid",
+    "protocol_version",
+    "publish_ms",
+    "queue_bypassed",
+    "reason_code",
+    "relay_ms",
+    "result",
+    "sample_reason",
+    "sequence",
+    "session_hash",
+    "session_store_ms",
+    "source_pod",
+    "stage",
+    "subscribers",
+    "target_location",
+    "target_namespace",
+    "target_pod",
+    "total_ms",
+    "trace_id",
+    "version",
+    "call_total_ms",
+}
+SAFE_TEXT_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:/-"
+)
+
+
+def _current_pod() -> str:
+    return os.environ.get("HOSTNAME", "unknown")
+
+
+@lru_cache(maxsize=8)
+def _parse_target_device_ids(raw: str) -> frozenset[str]:
+    return frozenset(
+        item.strip() for item in raw.split(",") if item.strip() and item.strip() != "*"
+    )
+
+
+def _target_device_ids() -> frozenset[str]:
+    return _parse_target_device_ids(settings.TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS)
+
+
+def terminal_diagnostics_enabled() -> bool:
+    """Return whether this process has at least one exact target device."""
+    return bool(_target_device_ids())
+
+
+def is_target_device(device_id: object) -> bool:
+    """Match a device only by its complete ID."""
+    return isinstance(device_id, str) and device_id in _target_device_ids()
+
+
+def _hash_session_id(session_id: str) -> str:
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:12]
+
+
+def _deterministically_sample(trace_id: str) -> bool:
+    threshold = int(settings.TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE * (2**64))
+    value = int.from_bytes(hashlib.sha256(trace_id.encode()).digest()[:8], "big")
+    return value < threshold
+
+
+@dataclass(frozen=True)
+class TerminalTrace:
+    """Safe trace context propagated inside the Socket.IO Redis envelope."""
+
+    trace_id: str
+    session_hash: str
+    device_id: str
+    event: str
+    direction: str
+    sampled: bool
+    sample_reason: str
+    source_pod: str
+    created_wall_ns: int
+    protocol_version: Optional[int] = None
+    sequence: Optional[int] = None
+    byte_count: Optional[int] = None
+    published_wall_ns: Optional[int] = None
+
+    def metadata(self, *, published_wall_ns: Optional[int] = None) -> dict[str, Any]:
+        """Serialize only allowlisted, non-sensitive trace fields."""
+        return {
+            "version": TERMINAL_TRACE_VERSION,
+            "trace_id": self.trace_id,
+            "session_hash": self.session_hash,
+            "device_id": self.device_id,
+            "event": self.event,
+            "direction": self.direction,
+            "sampled": self.sampled,
+            "sample_reason": self.sample_reason,
+            "source_pod": self.source_pod,
+            "created_wall_ns": self.created_wall_ns,
+            "published_wall_ns": published_wall_ns or self.published_wall_ns,
+            "protocol_version": self.protocol_version,
+            "sequence": self.sequence,
+            "byte_count": self.byte_count,
+        }
+
+    @classmethod
+    def from_metadata(cls, value: object) -> Optional["TerminalTrace"]:
+        """Parse metadata defensively; malformed envelopes remain untraced."""
+        if not isinstance(value, Mapping) or value.get("version") != 1:
+            return None
+        try:
+            trace_id = str(value["trace_id"])
+            session_hash = str(value["session_hash"])
+            device_id = str(value["device_id"])
+            event = str(value["event"])
+            direction = str(value["direction"])
+            source_pod = str(value["source_pod"])
+            created_wall_ns = int(value["created_wall_ns"])
+            sampled = value["sampled"] is True
+            sample_reason = str(value["sample_reason"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if (
+            len(trace_id) != 32
+            or len(session_hash) != 12
+            or not is_target_device(device_id)
+        ):
+            return None
+        try:
+            published_wall_ns = (
+                int(value["published_wall_ns"])
+                if value.get("published_wall_ns") is not None
+                else None
+            )
+            protocol_version = (
+                int(value["protocol_version"])
+                if value.get("protocol_version") is not None
+                else None
+            )
+            sequence = (
+                int(value["sequence"]) if value.get("sequence") is not None else None
+            )
+            byte_count = (
+                int(value["byte_count"])
+                if value.get("byte_count") is not None
+                else None
+            )
+        except (TypeError, ValueError):
+            return None
+        return cls(
+            trace_id=trace_id,
+            session_hash=session_hash,
+            device_id=device_id,
+            event=event,
+            direction=direction,
+            sampled=sampled,
+            sample_reason=sample_reason,
+            source_pod=source_pod,
+            created_wall_ns=created_wall_ns,
+            protocol_version=protocol_version,
+            sequence=sequence,
+            byte_count=byte_count,
+            published_wall_ns=published_wall_ns,
+        )
+
+
+_current_terminal_trace: ContextVar[Optional[TerminalTrace]] = ContextVar(
+    "current_terminal_trace", default=None
+)
+_event_loop_lag_ms: Optional[float] = None
+_event_loop_lag_measured_ns: Optional[int] = None
+_event_loop_lag_task: Optional[asyncio.Task[None]] = None
+
+
+def create_terminal_trace(
+    *,
+    device_id: object,
+    session_id: object,
+    event: str,
+    direction: str,
+    protocol_version: Optional[int] = None,
+    sequence: Optional[int] = None,
+    byte_count: Optional[int] = None,
+) -> Optional[TerminalTrace]:
+    """Create trace metadata only for an explicitly targeted device."""
+    try:
+        return _create_terminal_trace(
+            device_id=device_id,
+            session_id=session_id,
+            event=event,
+            direction=direction,
+            protocol_version=protocol_version,
+            sequence=sequence,
+            byte_count=byte_count,
+        )
+    except Exception:
+        return None
+
+
+def _create_terminal_trace(
+    *,
+    device_id: object,
+    session_id: object,
+    event: str,
+    direction: str,
+    protocol_version: Optional[int],
+    sequence: Optional[int],
+    byte_count: Optional[int],
+) -> Optional[TerminalTrace]:
+    if (
+        not isinstance(device_id, str)
+        or not is_target_device(device_id)
+        or not isinstance(session_id, str)
+    ):
+        return None
+    trace_id = uuid.uuid4().hex
+    always_sampled = event in ALWAYS_SAMPLED_EVENTS
+    sampled = always_sampled or _deterministically_sample(trace_id)
+    return TerminalTrace(
+        trace_id=trace_id,
+        session_hash=_hash_session_id(session_id),
+        device_id=device_id,
+        event=event,
+        direction=direction,
+        sampled=sampled,
+        sample_reason=(
+            "input"
+            if event == "terminal:input"
+            else (
+                "lifecycle"
+                if always_sampled
+                else "sampled" if sampled else "not_sampled"
+            )
+        ),
+        source_pod=_current_pod(),
+        created_wall_ns=time.time_ns(),
+        protocol_version=protocol_version,
+        sequence=sequence,
+        byte_count=byte_count,
+    )
+
+
+def current_terminal_trace() -> Optional[TerminalTrace]:
+    return _current_terminal_trace.get()
+
+
+def with_terminal_trace_bytes(
+    trace: Optional[TerminalTrace], text: object
+) -> Optional[TerminalTrace]:
+    """Add payload size only when this event will normally be logged."""
+    if trace is None or not trace.sampled or not isinstance(text, str):
+        return trace
+    try:
+        return replace(trace, byte_count=len(text.encode("utf-8", errors="replace")))
+    except Exception:
+        return trace
+
+
+@contextmanager
+def bind_terminal_trace(trace: Optional[TerminalTrace]) -> Iterator[None]:
+    """Bind relay context without changing the called Socket.IO API."""
+    if trace is None:
+        yield
+        return
+    token: Token[Optional[TerminalTrace]] = _current_terminal_trace.set(trace)
+    try:
+        yield
+    finally:
+        _current_terminal_trace.reset(token)
+
+
+def _safe_text(value: object) -> str:
+    text = str(value)
+    cleaned = "".join(char if char in SAFE_TEXT_CHARS else "_" for char in text)
+    return cleaned[:160] or "unknown"
+
+
+def _lag_fields() -> dict[str, Any]:
+    if _event_loop_lag_ms is None or _event_loop_lag_measured_ns is None:
+        return {}
+    return {
+        "event_loop_lag_ms": round(_event_loop_lag_ms, 3),
+        "event_loop_lag_age_ms": round(
+            (time.perf_counter_ns() - _event_loop_lag_measured_ns) / 1_000_000, 3
+        ),
+    }
+
+
+def record_terminal_trace(
+    trace: Optional[TerminalTrace],
+    *,
+    stage: str,
+    result: str,
+    force: bool = False,
+    **fields: object,
+) -> None:
+    """Emit one safe diagnostic record. Diagnostics must never affect relay flow."""
+    try:
+        if trace is None:
+            return
+        numeric_values = [
+            float(value)
+            for key, value in fields.items()
+            if key.endswith("_ms") and isinstance(value, (int, float))
+        ]
+        slow = bool(numeric_values) and max(numeric_values) >= float(
+            settings.TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS
+        )
+        failed = result not in {
+            "enqueued",
+            "handler_accepted",
+            "published",
+            "published_no_subscribers",
+            "success",
+        }
+        if not (trace.sampled or force or slow or failed):
+            return
+        sample_reason = (
+            "error"
+            if failed
+            else "slow" if slow and not trace.sampled else trace.sample_reason
+        )
+        values: dict[str, object] = {
+            "version": TERMINAL_TRACE_VERSION,
+            "stage": stage,
+            "event": trace.event,
+            "direction": trace.direction,
+            "trace_id": trace.trace_id,
+            "session_hash": trace.session_hash,
+            "device_id": trace.device_id,
+            "current_pod": _current_pod(),
+            "pid": os.getpid(),
+            "result": result,
+            "sample_reason": sample_reason,
+            "source_pod": trace.source_pod,
+            "protocol_version": trace.protocol_version,
+            "sequence": trace.sequence,
+            "bytes": trace.byte_count,
+            **_lag_fields(),
+            **fields,
+        }
+        parts = []
+        for key in sorted(SAFE_LOG_FIELDS):
+            value = values.get(key)
+            if value is None:
+                continue
+            if isinstance(value, float):
+                rendered = str(round(value, 3))
+            elif isinstance(value, (int, bool)):
+                rendered = str(value).lower() if isinstance(value, bool) else str(value)
+            else:
+                rendered = _safe_text(value)
+            parts.append(f"{key}={rendered}")
+        logger.info("%s %s", TERMINAL_TRACE_LOG_PREFIX, " ".join(parts))
+    except Exception:
+        try:
+            logger.debug("Terminal diagnostic logging failed", exc_info=True)
+        except Exception:
+            pass
+
+
+async def _event_loop_lag_sampler() -> None:
+    global _event_loop_lag_measured_ns, _event_loop_lag_ms
+    interval = settings.TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS
+    expected = time.perf_counter() + interval
+    while True:
+        await asyncio.sleep(interval)
+        now = time.perf_counter()
+        _event_loop_lag_ms = max(0.0, (now - expected) * 1000)
+        _event_loop_lag_measured_ns = time.perf_counter_ns()
+        expected = now + interval
+
+
+def start_event_loop_lag_sampler() -> Optional[asyncio.Task[None]]:
+    """Start one process-owned sampler only while diagnostics are enabled."""
+    global _event_loop_lag_task
+    if not terminal_diagnostics_enabled():
+        return None
+    if _event_loop_lag_task is None or _event_loop_lag_task.done():
+        try:
+            loop = asyncio.get_running_loop()
+            _event_loop_lag_task = loop.create_task(
+                _event_loop_lag_sampler(), name="terminal-event-loop-lag"
+            )
+        except Exception:
+            _event_loop_lag_task = None
+    return _event_loop_lag_task
+
+
+async def stop_event_loop_lag_sampler() -> None:
+    """Cancel and await the process-owned sampler."""
+    global _event_loop_lag_task
+    task = _event_loop_lag_task
+    _event_loop_lag_task = None
+    if task is None:
+        return
+    if not task.done():
+        task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        try:
+            logger.debug("Terminal event-loop sampler failed", exc_info=True)
+        except Exception:
+            pass

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -107,7 +107,7 @@ dependencies = [
     # Pin litellm to safe version (crawl4ai dependency) - versions after 1.82.6 contain supply chain attack
     "litellm==1.82.6",
     # WebSocket support
-    "python-socketio>=5.10.0",
+    "python-socketio==5.15.1",
     # DingTalk Stream SDK for IM channel integration
     "dingtalk-stream>=0.24.0",
     # Telegram Bot SDK for IM channel integration

--- a/backend/tests/api/ws/test_device_capabilities_state.py
+++ b/backend/tests/api/ws/test_device_capabilities_state.py
@@ -12,6 +12,8 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 
 from app.api.ws import device_namespace, local_task_responses
+from app.core.config import settings
+from app.services.device import terminal_diagnostics
 from app.services.device.terminal_session_service import (
     TerminalSessionAuthorizationUnavailable,
     TerminalSessionRecord,
@@ -992,6 +994,61 @@ async def test_device_terminal_output_forwards_to_browser_terminal_room(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_device_terminal_output_binds_trace_for_actual_session_room(monkeypatch):
+    namespace = device_namespace.DeviceNamespace()
+    record = TerminalSessionRecord(
+        session_id="terminal-1",
+        user_id=7,
+        device_id="device-1",
+        socket_id="device-sid",
+        project_id=123,
+        path="/repo",
+        expires_at=future_terminal_expiry(),
+    )
+    service = SimpleNamespace(get=AsyncMock(return_value=record))
+    observed = []
+
+    async def capture_emit(_event, _payload, *, room, namespace):
+        observed.append(
+            (
+                room,
+                namespace,
+                terminal_diagnostics.current_terminal_trace(),
+            )
+        )
+
+    sio = SimpleNamespace(emit=AsyncMock(side_effect=capture_emit))
+    monkeypatch.setattr(
+        settings,
+        "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS",
+        "device-1",
+    )
+    monkeypatch.setattr(device_namespace, "terminal_session_service", service)
+    monkeypatch.setattr(device_namespace, "get_sio", lambda: sio, raising=False)
+    monkeypatch.setattr(
+        namespace,
+        "get_session",
+        AsyncMock(return_value={"user_id": 7, "device_id": "device-1"}),
+    )
+
+    result = await namespace.on_terminal_output(
+        "device-sid",
+        {
+            "session_id": "terminal-1",
+            "protocol_version": 2,
+            "consumer_id": "consumer-1",
+            "sequence": 8,
+            "data": "hello",
+        },
+    )
+
+    assert result == {"success": True}
+    assert observed[0][0:2] == ("terminal:terminal-1", "/terminal")
+    assert observed[0][2] is not None
+    assert observed[0][2].event == "terminal:output"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("sequence", [None, 0, -1, 1.0, "1", True])
 async def test_device_terminal_output_rejects_invalid_sequence(
     monkeypatch,
@@ -1056,6 +1113,36 @@ async def test_device_terminal_output_rejects_invalid_data_before_redis(
 
     assert result == {"error": "Invalid terminal output"}
     sio.emit.assert_not_awaited()
+    service.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_target_device_parse_error_is_traced_before_store_access(monkeypatch):
+    namespace = device_namespace.DeviceNamespace()
+    service = SimpleNamespace(get=AsyncMock())
+    records = Mock()
+    monkeypatch.setattr(settings, "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS", "device-1")
+    monkeypatch.setattr(device_namespace, "terminal_session_service", service)
+    monkeypatch.setattr(device_namespace, "record_terminal_trace", records)
+    monkeypatch.setattr(
+        namespace,
+        "get_session",
+        AsyncMock(return_value={"user_id": 7, "device_id": "device-1"}),
+    )
+
+    result = await namespace.on_terminal_output(
+        "device-sid",
+        {
+            "session_id": "terminal-1",
+            "protocol_version": 2,
+            "consumer_id": "consumer-1",
+            "sequence": 1,
+            "data": b"invalid",
+        },
+    )
+
+    assert result == {"error": "Invalid terminal output"}
+    assert records.call_args.kwargs["result"] == "parse_failed"
     service.get.assert_not_awaited()
 
 

--- a/backend/tests/api/ws/test_terminal_namespace.py
+++ b/backend/tests/api/ws/test_terminal_namespace.py
@@ -13,6 +13,8 @@ import pytest
 
 from app.api.ws import terminal_namespace
 from app.api.ws.terminal_namespace import TerminalNamespace
+from app.core.config import settings
+from app.services.device import terminal_diagnostics
 from app.services.device.terminal_session_service import (
     TerminalSessionAuthorizationUnavailable,
     TerminalSessionRecord,
@@ -566,6 +568,37 @@ async def test_terminal_input_relays_to_executor_socket(monkeypatch):
         namespace="/local-executor",
     )
     service.authorize.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_binds_safe_trace_during_relay(monkeypatch):
+    namespace = TerminalNamespace()
+    service = _service(authorize=AsyncMock(), is_revoked=Mock(return_value=False))
+    observed = []
+
+    async def capture_emit(*_args, **_kwargs):
+        observed.append(terminal_diagnostics.current_terminal_trace())
+
+    sio = SimpleNamespace(emit=AsyncMock(side_effect=capture_emit))
+    monkeypatch.setattr(
+        settings, "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS", "device-abc"
+    )
+    monkeypatch.setattr(terminal_namespace, "terminal_session_service", service)
+    monkeypatch.setattr(terminal_namespace, "get_sio", lambda: sio)
+    monkeypatch.setattr(
+        namespace, "get_session", AsyncMock(return_value=_attached_session())
+    )
+
+    result = await namespace.on_terminal_input(
+        "browser-sid", {"session_id": "terminal-1", "data": "你好\n"}
+    )
+
+    assert result == {"success": True}
+    assert observed[0] is not None
+    assert observed[0].event == "terminal:input"
+    assert observed[0].byte_count == len("你好\n".encode("utf-8"))
+    assert observed[0].session_hash != "terminal-1"
+    assert terminal_diagnostics.current_terminal_trace() is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -69,6 +69,25 @@ class TestSettings:
         assert s.DB_ASYNC_MAX_OVERFLOW == 20
         assert s.DB_POOL_TIMEOUT == 30
         assert s.DB_POOL_RECYCLE == 3600
+        assert s.TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS == ""
+        assert s.TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE == 0.01
+        assert s.TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS == 50
+        assert s.TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS == 1
+
+    @pytest.mark.parametrize(
+        ("setting_name", "invalid_value"),
+        [
+            ("TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE", -0.1),
+            ("TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE", 1.1),
+            ("TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS", -1),
+            ("TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS", 0.01),
+        ],
+    )
+    def test_terminal_diagnostic_settings_reject_invalid_values(
+        self, setting_name, invalid_value
+    ):
+        with pytest.raises(ValidationError):
+            build_settings(**{setting_name: invalid_value})
 
     @pytest.mark.parametrize(
         ("setting_name", "invalid_value"),

--- a/backend/tests/core/test_socketio.py
+++ b/backend/tests/core/test_socketio.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Socket.IO server configuration."""
+
+from app.core import socketio as socketio_config
+from app.core.config import settings
+from app.core.socketio import _safe_redis_endpoint
+from app.core.terminal_socketio_manager import TerminalDiagnosticAsyncRedisManager
+
+
+def test_socketio_server_uses_terminal_diagnostic_manager(monkeypatch):
+    monkeypatch.setattr(settings, "REDIS_URL", "redis://localhost:6379/0")
+
+    server = socketio_config.create_socketio_server()
+
+    assert isinstance(server.manager, TerminalDiagnosticAsyncRedisManager)
+
+
+def test_safe_redis_endpoint_removes_credentials_and_query():
+    endpoint = _safe_redis_endpoint(
+        "rediss://user:secret@redis.internal:6381/4?ssl_cert_reqs=required"
+    )
+
+    assert endpoint == "rediss://redis.internal:6381/4"
+    assert "user" not in endpoint
+    assert "secret" not in endpoint
+    assert "ssl_cert_reqs" not in endpoint
+
+
+def test_safe_redis_endpoint_does_not_echo_malformed_url():
+    assert _safe_redis_endpoint("redis://user:secret@host:not-a-port/0") == (
+        "unparseable"
+    )
+
+
+def test_safe_redis_endpoint_does_not_echo_non_database_path():
+    endpoint = _safe_redis_endpoint("redis://host/secret-path")
+
+    assert endpoint == "redis://host:6379/unknown"
+    assert "secret-path" not in endpoint

--- a/backend/tests/core/test_terminal_socketio_manager.py
+++ b/backend/tests/core/test_terminal_socketio_manager.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for terminal-aware Socket.IO Redis instrumentation."""
+
+import asyncio
+import importlib.metadata
+import inspect
+import time
+from unittest.mock import Mock
+
+import pytest
+import socketio
+
+from app.core import terminal_socketio_manager
+from app.core.config import settings
+from app.core.terminal_socketio_manager import TerminalDiagnosticAsyncRedisManager
+from app.services.device.terminal_diagnostics import (
+    TERMINAL_TRACE_METADATA_KEY,
+    TerminalTrace,
+    bind_terminal_trace,
+    create_terminal_trace,
+)
+
+
+@pytest.fixture
+def trace(monkeypatch) -> TerminalTrace:
+    monkeypatch.setattr(settings, "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS", "device-1")
+    monkeypatch.setattr(settings, "TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE", 1.0)
+    created = create_terminal_trace(
+        device_id="device-1",
+        session_id="terminal-secret",
+        event="terminal:output",
+        direction="device_to_browser",
+        byte_count=6,
+    )
+    assert created is not None
+    return created
+
+
+def test_python_socketio_private_contract_is_pinned():
+    assert importlib.metadata.version("python-socketio") == "5.15.1"
+    assert tuple(inspect.signature(socketio.AsyncRedisManager._publish).parameters) == (
+        "self",
+        "data",
+    )
+    assert tuple(
+        inspect.signature(socketio.AsyncRedisManager._handle_emit).parameters
+    ) == ("self", "message")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("publish_result", [3, 0, None])
+async def test_publish_preserves_result_and_adds_safe_metadata(
+    trace, monkeypatch, publish_result
+):
+    received = []
+
+    async def fake_publish(_manager, message):
+        received.append(message)
+        return publish_result
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_publish", fake_publish)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+    envelope = {
+        "method": "emit",
+        "event": "terminal:output",
+        "data": {"data": "secret-output"},
+        "namespace": "/terminal",
+        "room": "terminal:secret-session",
+    }
+
+    with bind_terminal_trace(trace):
+        result = await manager._publish(envelope)
+
+    assert result is publish_result or result == publish_result
+    assert received[0] is not envelope
+    metadata = received[0][TERMINAL_TRACE_METADATA_KEY]
+    assert metadata["session_hash"] == trace.session_hash
+    assert "secret-output" not in str(metadata)
+    assert "secret-session" not in str(metadata)
+
+
+@pytest.mark.asyncio
+async def test_publish_without_trace_passes_original_envelope(monkeypatch):
+    received = []
+
+    async def fake_publish(_manager, message):
+        received.append(message)
+        return 1
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_publish", fake_publish)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+    envelope = {"method": "emit", "event": "other", "data": {}}
+
+    assert await manager._publish(envelope) == 1
+    assert received == [envelope]
+    assert received[0] is envelope
+
+
+@pytest.mark.asyncio
+async def test_metadata_preparation_failure_is_fail_open(trace, monkeypatch):
+    received = []
+
+    async def fake_publish(_manager, message):
+        received.append(message)
+        return 1
+
+    def broken_metadata(*_args, **_kwargs):
+        raise RuntimeError("diagnostic failure")
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_publish", fake_publish)
+    monkeypatch.setattr(TerminalTrace, "metadata", broken_metadata)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+    envelope = {"method": "emit", "event": "terminal:output", "data": {}}
+
+    with bind_terminal_trace(trace):
+        result = await manager._publish(envelope)
+
+    assert result == 1
+    assert received[0] is envelope
+
+
+@pytest.mark.asyncio
+async def test_publish_preserves_cancellation(trace, monkeypatch):
+    async def cancelled(_manager, _message):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_publish", cancelled)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    with bind_terminal_trace(trace), pytest.raises(asyncio.CancelledError):
+        await manager._publish({"method": "emit", "event": "terminal:output"})
+
+
+@pytest.mark.asyncio
+async def test_publish_preserves_exception(trace, monkeypatch):
+    async def failed(_manager, _message):
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_publish", failed)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    with (
+        bind_terminal_trace(trace),
+        pytest.raises(RuntimeError, match="redis unavailable"),
+    ):
+        await manager._publish({"method": "emit", "event": "terminal:output"})
+
+
+@pytest.mark.asyncio
+async def test_source_local_enqueue_uses_context_before_publish(trace, monkeypatch):
+    handled = []
+    records = Mock()
+
+    expected = object()
+
+    async def fake_handle(_manager, message):
+        handled.append(message)
+        return expected
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", fake_handle)
+    monkeypatch.setattr(terminal_socketio_manager, "record_terminal_trace", records)
+    monkeypatch.setattr(
+        terminal_socketio_manager, "_participant_count", lambda *_args: (1, False)
+    )
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+    message = {
+        "method": "emit",
+        "event": "terminal:output",
+        "namespace": "/terminal",
+        "room": "terminal:secret-session",
+    }
+
+    with bind_terminal_trace(trace):
+        result = await manager._handle_emit(message)
+
+    assert result is expected
+    assert handled == [message]
+    assert records.call_args.kwargs["stage"] == "socketio.local_enqueue"
+    assert records.call_args.kwargs["target_namespace"] == "/terminal"
+
+
+@pytest.mark.asyncio
+async def test_remote_enqueue_uses_envelope_metadata_and_actual_room(
+    trace, monkeypatch
+):
+    records = Mock()
+
+    async def fake_handle(_manager, _message):
+        return None
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", fake_handle)
+    monkeypatch.setattr(terminal_socketio_manager, "record_terminal_trace", records)
+    monkeypatch.setattr(
+        terminal_socketio_manager, "_participant_count", lambda *_args: (1, False)
+    )
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+    message = {
+        "method": "emit",
+        "event": "terminal:output",
+        "namespace": "/terminal",
+        "room": "terminal:actual-session",
+        TERMINAL_TRACE_METADATA_KEY: trace.metadata(
+            published_wall_ns=time.time_ns() - 1_000_000
+        ),
+    }
+
+    await manager._handle_emit(message)
+
+    assert records.call_args.kwargs["stage"] == "redis.consume_enqueue"
+    assert records.call_args.kwargs["target_namespace"] == "/terminal"
+    assert records.call_args.kwargs["approx_queue_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_handle_emit_preserves_cancellation(trace, monkeypatch):
+    async def cancelled(_manager, _message):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", cancelled)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    with bind_terminal_trace(trace), pytest.raises(asyncio.CancelledError):
+        await manager._handle_emit(
+            {
+                "method": "emit",
+                "event": "terminal:output",
+                "namespace": "/terminal",
+                "room": "terminal:actual-session",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_handle_emit_preserves_exception(trace, monkeypatch):
+    calls = 0
+
+    async def failed(_manager, _message):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("local enqueue failed")
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", failed)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    with (
+        bind_terminal_trace(trace),
+        pytest.raises(RuntimeError, match="local enqueue failed"),
+    ):
+        await manager._handle_emit(
+            {
+                "method": "emit",
+                "event": "terminal:output",
+                "namespace": "/terminal",
+                "room": "terminal:actual-session",
+            }
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_remote_metadata_is_fail_open(monkeypatch):
+    handled = []
+
+    async def fake_handle(_manager, message):
+        handled.append(message)
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", fake_handle)
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+    message = {
+        "method": "emit",
+        "event": "terminal:output",
+        TERMINAL_TRACE_METADATA_KEY: {"version": 1, "trace_id": "invalid"},
+    }
+
+    await manager._handle_emit(message)
+
+    assert handled == [message]
+
+
+@pytest.mark.asyncio
+async def test_remote_manager_without_participant_does_not_log_normal_consume(
+    trace, monkeypatch
+):
+    records = Mock()
+
+    async def fake_handle(_manager, _message):
+        return None
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", fake_handle)
+    monkeypatch.setattr(terminal_socketio_manager, "record_terminal_trace", records)
+    monkeypatch.setattr(
+        terminal_socketio_manager, "_participant_count", lambda *_args: (0, False)
+    )
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    await manager._handle_emit(
+        {
+            "method": "emit",
+            "event": "terminal:output",
+            "namespace": "/terminal",
+            "room": "terminal:actual-session",
+            TERMINAL_TRACE_METADATA_KEY: trace.metadata(
+                published_wall_ns=time.time_ns()
+            ),
+        }
+    )
+
+    records.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_participant_query_failure_is_logged_and_emit_continues(
+    trace, monkeypatch
+):
+    handled = []
+    records = Mock()
+
+    async def fake_handle(_manager, message):
+        handled.append(message)
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", fake_handle)
+    monkeypatch.setattr(terminal_socketio_manager, "record_terminal_trace", records)
+    monkeypatch.setattr(
+        terminal_socketio_manager, "_participant_count", lambda *_args: (None, True)
+    )
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    with bind_terminal_trace(trace):
+        await manager._handle_emit(
+            {
+                "method": "emit",
+                "event": "terminal:output",
+                "namespace": "/terminal",
+                "room": "terminal:actual-session",
+            }
+        )
+
+    assert len(handled) == 1
+    assert records.call_args.kwargs["result"] == "diagnostic_error"
+    assert records.call_args.kwargs["target_location"] == "unknown"
+    assert records.call_args.kwargs["reason_code"] == "participant_query_failed"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_diagnostic_failure_does_not_change_emit(trace, monkeypatch):
+    handled = []
+
+    async def fake_handle(_manager, message):
+        handled.append(message)
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_handle_emit", fake_handle)
+    monkeypatch.setattr(
+        terminal_socketio_manager, "_participant_count", lambda *_args: (1, False)
+    )
+    monkeypatch.setattr(
+        terminal_socketio_manager,
+        "_safe_elapsed_ms",
+        Mock(side_effect=RuntimeError("timer failed")),
+    )
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    with bind_terminal_trace(trace):
+        result = await manager._handle_emit(
+            {
+                "method": "emit",
+                "event": "terminal:output",
+                "namespace": "/terminal",
+                "room": "terminal:actual-session",
+            }
+        )
+
+    assert result is None
+    assert len(handled) == 1
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_log_helper_failure_does_not_change_publish(
+    trace, monkeypatch
+):
+    calls = []
+
+    async def fake_publish(_manager, message):
+        calls.append(message)
+        return 2
+
+    monkeypatch.setattr(socketio.AsyncRedisManager, "_publish", fake_publish)
+    monkeypatch.setattr(
+        terminal_socketio_manager,
+        "record_terminal_trace",
+        Mock(side_effect=RuntimeError("logging failed")),
+    )
+    manager = TerminalDiagnosticAsyncRedisManager("redis://localhost:6379/0")
+
+    with bind_terminal_trace(trace):
+        result = await manager._publish(
+            {"method": "emit", "event": "terminal:output", "data": {}}
+        )
+
+    assert result == 2
+    assert len(calls) == 1

--- a/backend/tests/integration/test_terminal_socketio_diagnostics.py
+++ b/backend/tests/integration/test_terminal_socketio_diagnostics.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Two-Backend terminal diagnostics contracts over an isolated Redis."""
+
+import asyncio
+import logging
+import shutil
+import socket
+import subprocess
+import time
+from contextlib import suppress
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import pytest_asyncio
+import redis
+import socketio
+
+from app.api.ws import device_namespace, terminal_namespace
+from app.api.ws.device_namespace import DeviceNamespace
+from app.api.ws.terminal_namespace import TerminalNamespace
+from app.core.config import settings
+from app.core.terminal_socketio_manager import TerminalDiagnosticAsyncRedisManager
+from app.services.device.terminal_diagnostics import (
+    bind_terminal_trace,
+    create_terminal_trace,
+)
+from app.services.device.terminal_session_service import TerminalSessionRecord
+
+
+@pytest.fixture
+def isolated_redis_url(tmp_path):
+    executable = shutil.which("redis-server")
+    if executable is None:
+        pytest.fail("redis-server is required for terminal integration tests")
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    process = subprocess.Popen(
+        [
+            executable,
+            "--bind",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--save",
+            "",
+            "--appendonly",
+            "no",
+            "--dir",
+            str(tmp_path),
+            "--loglevel",
+            "warning",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    url = f"redis://127.0.0.1:{port}/0"
+    client = redis.Redis.from_url(url)
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            if client.ping():
+                break
+        except redis.RedisError:
+            time.sleep(0.02)
+    else:
+        process.terminate()
+        pytest.fail("isolated redis-server did not start")
+    try:
+        yield url
+    finally:
+        client.close()
+        process.terminate()
+        with suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=5)
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
+@pytest_asyncio.fixture
+async def backend_pair(isolated_redis_url, monkeypatch):
+    monkeypatch.setattr(settings, "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS", "device-1")
+    monkeypatch.setattr(settings, "TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE", 1.0)
+    manager_a = TerminalDiagnosticAsyncRedisManager(isolated_redis_url)
+    manager_b = TerminalDiagnosticAsyncRedisManager(isolated_redis_url)
+    server_a = socketio.AsyncServer(client_manager=manager_a)
+    server_b = socketio.AsyncServer(client_manager=manager_b)
+    server_a._send_eio_packet = AsyncMock()
+    server_b._send_eio_packet = AsyncMock()
+    manager_a.initialize()
+    manager_b.initialize()
+    await _wait_until(
+        lambda: bool(
+            getattr(manager_a, "pubsub", None)
+            and manager_a.pubsub.subscribed
+            and getattr(manager_b, "pubsub", None)
+            and manager_b.pubsub.subscribed
+        )
+    )
+    try:
+        yield SimpleNamespace(
+            manager_a=manager_a,
+            manager_b=manager_b,
+            server_a=server_a,
+            server_b=server_b,
+        )
+    finally:
+        for manager in (manager_a, manager_b):
+            manager.thread.cancel()
+        await asyncio.gather(
+            manager_a.thread,
+            manager_b.thread,
+            return_exceptions=True,
+        )
+        for manager in (manager_a, manager_b):
+            if getattr(manager, "pubsub", None) is not None:
+                await manager.pubsub.aclose()
+            if getattr(manager, "redis", None) is not None:
+                await manager.redis.aclose()
+
+
+@pytest.mark.asyncio
+async def test_terminal_relay_traces_both_directions_across_backends(
+    backend_pair, monkeypatch, caplog
+):
+    pair = backend_pair
+    caplog.set_level(
+        logging.INFO,
+        logger="app.services.device.terminal_diagnostics",
+    )
+    browser_sid = await pair.manager_a.connect("browser-eio", "/terminal")
+    await pair.manager_a.enter_room(
+        browser_sid,
+        "/terminal",
+        "terminal:terminal-1",
+    )
+    device_sid = await pair.manager_b.connect("device-eio", "/local-executor")
+    record = _record(device_sid)
+
+    browser_namespace = TerminalNamespace()
+    monkeypatch.setattr(
+        browser_namespace,
+        "get_session",
+        AsyncMock(return_value=_attached_session(record)),
+    )
+    monkeypatch.setattr(
+        terminal_namespace,
+        "terminal_session_service",
+        SimpleNamespace(
+            authorize=AsyncMock(),
+            is_authorization_current=Mock(return_value=True),
+            is_revoked=Mock(return_value=False),
+        ),
+    )
+    monkeypatch.setattr(terminal_namespace, "get_sio", lambda: pair.server_a)
+
+    input_result = await browser_namespace.on_terminal_input(
+        browser_sid,
+        {"session_id": "terminal-1", "data": "echo integration\n"},
+    )
+    await _wait_until(lambda: pair.server_b._send_eio_packet.await_count == 1)
+
+    executor_namespace = DeviceNamespace()
+    monkeypatch.setattr(
+        executor_namespace,
+        "get_session",
+        AsyncMock(return_value={"user_id": 7, "device_id": "device-1"}),
+    )
+    monkeypatch.setattr(
+        device_namespace,
+        "terminal_session_service",
+        SimpleNamespace(get=AsyncMock(return_value=record)),
+    )
+    monkeypatch.setattr(device_namespace, "get_sio", lambda: pair.server_b)
+
+    output_result = await executor_namespace.on_terminal_output(
+        device_sid,
+        {
+            "session_id": "terminal-1",
+            "protocol_version": 2,
+            "consumer_id": "consumer-1",
+            "sequence": 9,
+            "data": "ready\n",
+        },
+    )
+    await _wait_until(lambda: pair.server_a._send_eio_packet.await_count == 1)
+
+    assert input_result == {"success": True}
+    assert output_result == {"success": True}
+    _assert_cross_backend_stages(caplog.messages, "terminal:input")
+    _assert_cross_backend_stages(caplog.messages, "terminal:output")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event", "data"),
+    [
+        ("terminal:attach", {"session_id": "terminal-1"}),
+        ("terminal:ack", {"session_id": "terminal-1", "sequence": 1}),
+        ("terminal:close", {"session_id": "terminal-1"}),
+    ],
+)
+async def test_socketio_call_callback_crosses_redis_without_fake_callback_stage(
+    backend_pair, event, data, caplog
+):
+    pair = backend_pair
+    caplog.set_level(
+        logging.INFO,
+        logger="app.services.device.terminal_diagnostics",
+    )
+    device_sid = await pair.manager_b.connect("device-eio", "/local-executor")
+
+    async def acknowledge(eio_sid, packet):
+        await pair.server_b._handle_ack(
+            eio_sid,
+            packet.namespace,
+            packet.id,
+            [{"success": True}],
+        )
+
+    pair.server_b._send_packet = acknowledge
+    trace = create_terminal_trace(
+        device_id="device-1",
+        session_id="terminal-1",
+        event=event,
+        direction="browser_to_device",
+    )
+    assert trace is not None
+
+    with bind_terminal_trace(trace):
+        result = await pair.server_a.call(
+            event,
+            data,
+            to=device_sid,
+            namespace="/local-executor",
+            timeout=3,
+        )
+    await _wait_until(
+        lambda: any(
+            f"trace_id={trace.trace_id}" in message
+            and "stage=redis.consume_enqueue" in message
+            for message in caplog.messages
+        )
+    )
+
+    traced_messages = [
+        message
+        for message in caplog.messages
+        if f"trace_id={trace.trace_id}" in message
+    ]
+    assert result == {"success": True}
+    assert any("stage=redis.publish" in message for message in traced_messages)
+    assert any("stage=redis.consume_enqueue" in message for message in traced_messages)
+    assert not any("callback" in message for message in traced_messages)
+
+
+def _record(socket_id: str) -> TerminalSessionRecord:
+    return TerminalSessionRecord(
+        session_id="terminal-1",
+        user_id=7,
+        device_id="device-1",
+        socket_id=socket_id,
+        project_id=123,
+        path="/repo",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+
+
+def _attached_session(record: TerminalSessionRecord) -> dict:
+    return {
+        "user_id": 7,
+        "token_exp": 9999999999,
+        "terminal_session_id": record.session_id,
+        "terminal_consumer_id": "consumer-1",
+        "terminal_protocol_version": 2,
+        "terminal_authorization": record,
+    }
+
+
+async def _wait_until(predicate, timeout: float = 5) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition was not met before timeout")
+
+
+def _assert_cross_backend_stages(messages: list[str], event: str) -> None:
+    event_messages = [message for message in messages if f"event={event}" in message]
+    trace_ids = {
+        field.split("=", maxsplit=1)[1]
+        for message in event_messages
+        for field in message.split()
+        if field.startswith("trace_id=")
+    }
+    assert len(trace_ids) == 1
+    assert any("stage=namespace.relay" in message for message in event_messages)
+    assert any("stage=redis.publish" in message for message in event_messages)
+    assert any("stage=redis.consume_enqueue" in message for message in event_messages)

--- a/backend/tests/services/device/test_terminal_diagnostics.py
+++ b/backend/tests/services/device/test_terminal_diagnostics.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for opt-in terminal backend diagnostics."""
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from app.core.config import settings
+from app.services.device import terminal_diagnostics
+
+
+@pytest.fixture
+def targeted_device(monkeypatch):
+    monkeypatch.setattr(
+        settings, "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS", "device-1, device-2"
+    )
+    monkeypatch.setattr(settings, "TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE", 0.0)
+    monkeypatch.setattr(
+        settings, "TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS", 50.0
+    )
+
+
+def test_device_filter_is_exact_and_does_not_support_wildcard(monkeypatch):
+    monkeypatch.setattr(
+        settings,
+        "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS",
+        "device-1,*,device-2",
+    )
+
+    assert terminal_diagnostics.is_target_device("device-1") is True
+    assert terminal_diagnostics.is_target_device("device-10") is False
+    assert terminal_diagnostics.is_target_device("*") is False
+
+
+def test_control_event_is_sampled_and_session_is_hashed(targeted_device):
+    trace = terminal_diagnostics.create_terminal_trace(
+        device_id="device-1",
+        session_id="terminal-secret-session",
+        event="terminal:input",
+        direction="browser_to_device",
+        byte_count=9,
+    )
+
+    assert trace is not None
+    assert trace.sampled is True
+    assert trace.sample_reason == "input"
+    assert trace.session_hash != "terminal-secret-session"
+    assert len(trace.session_hash) == 12
+    assert "terminal-secret-session" not in str(trace.metadata())
+
+
+def test_unsampled_output_still_has_propagation_metadata(targeted_device):
+    trace = terminal_diagnostics.create_terminal_trace(
+        device_id="device-1",
+        session_id="terminal-1",
+        event="terminal:output",
+        direction="device_to_browser",
+    )
+
+    assert trace is not None
+    assert trace.sampled is False
+    assert trace.sample_reason == "not_sampled"
+    assert terminal_diagnostics.TerminalTrace.from_metadata(trace.metadata()) == trace
+
+
+def test_unsampled_output_does_not_encode_payload(targeted_device):
+    class EncodingMustNotRun(str):
+        def encode(self, *_args, **_kwargs):
+            raise AssertionError("unsampled output must not be encoded")
+
+    trace = terminal_diagnostics.create_terminal_trace(
+        device_id="device-1",
+        session_id="terminal-1",
+        event="terminal:output",
+        direction="device_to_browser",
+    )
+
+    assert trace is not None
+    assert trace.sampled is False
+    assert (
+        terminal_diagnostics.with_terminal_trace_bytes(
+            trace, EncodingMustNotRun("secret output")
+        )
+        is trace
+    )
+
+
+def test_unsampled_fast_stage_is_quiet_but_slow_stage_is_logged(
+    targeted_device, monkeypatch
+):
+    trace = terminal_diagnostics.create_terminal_trace(
+        device_id="device-1",
+        session_id="terminal-1",
+        event="terminal:output",
+        direction="device_to_browser",
+    )
+    log = Mock()
+    monkeypatch.setattr(terminal_diagnostics.logger, "info", log)
+
+    terminal_diagnostics.record_terminal_trace(
+        trace, stage="namespace.relay", result="success", relay_ms=1.0
+    )
+    log.assert_not_called()
+
+    terminal_diagnostics.record_terminal_trace(
+        trace,
+        stage="namespace.relay",
+        result="success",
+        relay_ms=51.0,
+        reason_code="safe_reason",
+        data="secret-output",
+        sid="secret-sid",
+        token="secret-token",
+    )
+
+    logged_fields = log.call_args.args[2]
+    assert "sample_reason=slow" in logged_fields
+    assert "relay_ms=51.0" in logged_fields
+    assert "terminal-1" not in logged_fields
+    assert "secret-output" not in logged_fields
+    assert "secret-sid" not in logged_fields
+    assert "secret-token" not in logged_fields
+
+
+def test_logging_failure_never_escapes(targeted_device, monkeypatch):
+    trace = terminal_diagnostics.create_terminal_trace(
+        device_id="device-1",
+        session_id="terminal-1",
+        event="terminal:input",
+        direction="browser_to_device",
+    )
+    monkeypatch.setattr(
+        terminal_diagnostics.logger, "info", Mock(side_effect=RuntimeError("boom"))
+    )
+    monkeypatch.setattr(
+        terminal_diagnostics.logger, "debug", Mock(side_effect=RuntimeError("boom"))
+    )
+
+    terminal_diagnostics.record_terminal_trace(
+        trace, stage="namespace.relay", result="success", relay_ms=1.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_loop_sampler_is_owned_and_stopped(targeted_device, monkeypatch):
+    monkeypatch.setattr(
+        settings, "TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS", 0.1
+    )
+
+    task = terminal_diagnostics.start_event_loop_lag_sampler()
+
+    assert isinstance(task, asyncio.Task)
+    assert task.get_name() == "terminal-event-loop-lag"
+    await terminal_diagnostics.stop_event_loop_lag_sampler()
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_event_loop_sampler_stays_off_without_targets(monkeypatch):
+    monkeypatch.setattr(settings, "TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS", "")
+
+    assert terminal_diagnostics.start_event_loop_lag_sampler() is None
+    await terminal_diagnostics.stop_event_loop_lag_sampler()

--- a/backend/tests/test_main_terminal_diagnostics.py
+++ b/backend/tests/test_main_terminal_diagnostics.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Backend ownership of the terminal diagnostic sampler."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app import main
+
+
+def test_main_keeps_strong_reference_to_terminal_diagnostic_task(monkeypatch):
+    task = object()
+    app = SimpleNamespace(state=SimpleNamespace())
+    start = Mock(return_value=task)
+    monkeypatch.setattr(main, "start_event_loop_lag_sampler", start)
+
+    main._start_terminal_diagnostics(app)
+
+    start.assert_called_once_with()
+    assert app.state.terminal_diagnostics_task is task
+
+
+@pytest.mark.asyncio
+async def test_main_awaits_terminal_diagnostic_shutdown(monkeypatch):
+    stop = AsyncMock()
+    monkeypatch.setattr(main, "stop_event_loop_lag_sampler", stop)
+
+    await main._stop_terminal_diagnostics()
+
+    stop.assert_awaited_once_with()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6081,7 +6081,7 @@ requires-dist = [
     { name = "python-magic-bin", marker = "sys_platform == 'win32'", specifier = ">=0.4.14" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "python-pptx", specifier = ">=0.6.23" },
-    { name = "python-socketio", specifier = ">=5.10.0" },
+    { name = "python-socketio", specifier = "==5.15.1" },
     { name = "python-telegram-bot", specifier = ">=21.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "redis", specifier = ">=5.0.1" },

--- a/docs/en/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/en/wework/developer-guide/wework-performance-diagnostics.md
@@ -171,6 +171,33 @@ Acceptance targets, not measured local-script performance claims:
 - Executor `/metrics`: `terminal_output_batches_total`, `terminal_output_bytes_total`, `terminal_replayed_batches_total`, `terminal_replay_bytes`, `terminal_ack_lag_bytes`, and `terminal_backpressured_sessions`.
 - Wework performance events: `remote-terminal-write` and `remote-terminal-replay-request`. Metrics, traces, and diagnostic logs must not record raw terminal content or credentials. Use Redis `INFO commandstats`, never `SCAN`, `KEYS`, or `MONITOR`, for observation.
 
+### Backend-only Segmented Latency Diagnostics
+
+To separate Backend handler time, local Socket.IO delivery, and cross-Pod Redis relay time in production, configure an exact device allowlist on Backend only:
+
+```text
+TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS=device-id-1,device-id-2
+TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE=0.01
+TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS=50
+TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS=1
+```
+
+Device IDs use complete-string matching; wildcards, prefixes, and regular expressions are unsupported. An empty allowlist disables the feature: no trace is created, no Socket.IO envelope is changed, and no event-loop lag sampler starts. `attach`, `input`, `resize`, `close`, and `exit` are always recorded. High-frequency `output` and `ack` events are sampled deterministically by trace ID. An unsampled target event still carries minimal safe trace metadata so a later slow stage can record itself; it cannot backfill complete logs for earlier stages.
+
+Logs use the `[TerminalBackendTrace]` prefix and can be grouped by `trace_id`, `session_hash`, and `device_id`. Important stages are:
+
+- `namespace.relay`: parsing, authorization, target lookup, and total `emit` or `call` time. A normal return uses `result=handler_accepted` and only means that Backend completed the handler. `call_total_ms` includes the Executor or Browser callback round trip and is not one-way network latency.
+- `socketio.local_enqueue`: time for Engine.IO send coroutines to enqueue when the target is on the current Pod. It does not mean the Browser or Executor has received the event.
+- `redis.publish`: Redis publish time and subscriber count. `published_no_subscribers` is distinct from a publish failure.
+- `redis.consume_enqueue`: time for another Pod to consume the envelope and complete local enqueue; a normal return uses `result=enqueued`. `approx_queue_ms` is calculated when the target Pod starts handling the envelope and is a wall-clock approximation across hosts; negative values are preserved with `clock_skew=true`.
+- `namespace.forced_exit`: confirmation of a terminal end to the original Browser SID after a rejected event. `queue_bypassed=true` means same-Pod direct delivery.
+
+Records contain only the first 12 characters of the session SHA-256, byte counts, protocol versions, sequences, Pods, PIDs, durations, and internal reason codes. They never contain terminal content, user tokens, complete session IDs, Socket.IO SIDs, paths, or environment-variable values. The Socket.IO Redis initialization log also removes usernames, passwords, and query parameters.
+
+Start by correlating `namespace.relay → socketio.local_enqueue` or `namespace.relay → redis.publish → redis.consume_enqueue` with the same `trace_id`. Compare `event_loop_lag_ms` as well: slow handlers with low lag point toward authorization or Redis; slow publish or cross-Pod queue stages point toward Redis or Pod networking; fast enqueue with poor user experience requires follow-up in the Executor PTY, network RTT, and Wework `remote-terminal-write`. These logs cannot measure WebSocket arrival or xterm render completion and do not replace an end-to-end probe.
+
+Enable one affected device first and observe log volume before widening the allowlist. To roll back, clear `TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS` and roll Backend; no Wework, Executor, protocol, or Redis data change is required.
+
 ## Local Codex Streaming Logs
 
 The local executor keeps Codex delta details enabled by default so developers can diagnose streaming order, phase classification, and final-content overwrite issues. By default, it records raw Codex delta events and run-state classification summaries.

--- a/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
+++ b/docs/zh/wework/developer-guide/wework-performance-diagnostics.md
@@ -171,6 +171,33 @@ pnpm --filter wework e2e:desktop -- --cloud-only --segment core-task-flow
 - Executor `/metrics`：`terminal_output_batches_total`、`terminal_output_bytes_total`、`terminal_replayed_batches_total`、`terminal_replay_bytes`、`terminal_ack_lag_bytes`、`terminal_backpressured_sessions`。
 - Wework 性能事件：`remote-terminal-write`、`remote-terminal-replay-request`。指标、trace 和诊断日志不记录终端原始内容或凭据；Redis 观测使用 `INFO commandstats`，禁止 `SCAN`、`KEYS`、`MONITOR`。
 
+### Backend-only 分段延迟诊断
+
+生产现场需要区分 Backend handler、Socket.IO 本地投递和 Redis 跨 Pod 转发耗时时，可只在 Backend 配置精确设备白名单：
+
+```text
+TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS=device-id-1,device-id-2
+TERMINAL_BACKEND_DIAGNOSTICS_SAMPLE_RATE=0.01
+TERMINAL_BACKEND_DIAGNOSTICS_SLOW_THRESHOLD_MS=50
+TERMINAL_BACKEND_DIAGNOSTICS_LOOP_LAG_INTERVAL_SECONDS=1
+```
+
+设备 ID 只做完整字符串匹配，不支持 `*`、前缀或正则。空白名单为关闭状态，此时不创建 trace、不修改 Socket.IO envelope，也不启动事件循环 lag 采样器。`attach`、`input`、`resize`、`close`、`exit` 全量记录；高频 `output`、`ack` 按 trace ID 确定性采样。未抽中的目标事件仍携带最小的安全 trace 元数据，使后续慢阶段能单独留证；它不能补写更早阶段的完整日志。
+
+日志前缀为 `[TerminalBackendTrace]`，可按 `trace_id`、`session_hash` 和 `device_id` 聚合。常用阶段：
+
+- `namespace.relay`：解析、授权、目标查询、`emit` 或 `call` 总耗时。正常返回使用 `result=handler_accepted`，只表示 Backend 已完成 handler；`call_total_ms` 包含 Executor/Browser 回调往返，不代表单向网络耗时。
+- `socketio.local_enqueue`：目标位于当前 Pod 时，等待 Engine.IO 发送协程入队完成的耗时；不代表浏览器或 Executor 已收到。
+- `redis.publish`：Redis publish 调用耗时和订阅者数量。`published_no_subscribers` 与 publish 失败分开记录。
+- `redis.consume_enqueue`：另一 Pod 消费 envelope 并完成本地入队的耗时，正常返回使用 `result=enqueued`。`approx_queue_ms` 从目标 Pod 开始处理 envelope 的时刻计算，使用两台机器的墙钟近似；负值保留并标记 `clock_skew=true`。
+- `namespace.forced_exit`：拒绝事件后向原 Browser SID 确认 terminal end。`queue_bypassed=true` 表示本 Pod 直投。
+
+记录只包含 session 的 SHA-256 前 12 位、字节数、协议版本、序号、Pod、PID、耗时和内部原因码；不会写终端内容、用户 Token、完整 session ID、Socket.IO SID、路径或环境变量值。Socket.IO Redis 连接日志也会去除用户名、密码和查询参数。
+
+建议先按 `trace_id` 查看 `namespace.relay → socketio.local_enqueue` 或 `namespace.relay → redis.publish → redis.consume_enqueue`。同时对比 `event_loop_lag_ms`：handler 慢而 lag 低时检查授权/Redis；publish 或跨 Pod queue 慢时检查 Redis 与 Pod 网络；入队快但用户仍感觉慢时继续查看 Executor PTY、网络 RTT 和 Wework `remote-terminal-write`。这套日志不能测量 WebSocket 到达或 xterm 渲染完成时间，也不能代替端到端探针。
+
+先在单个问题设备上启用并观察日志量，再扩大白名单。回滚只需清空 `TERMINAL_BACKEND_DIAGNOSTICS_DEVICE_IDS` 并滚动 Backend；不需要修改 Wework、Executor、协议或 Redis 数据。
+
 ## 本地 Codex 流式日志
 
 本地 executor 的 Codex 调试日志默认保留 delta 详情，便于定位流式输出顺序、阶段识别和最终内容覆盖问题。默认会记录 Codex 原始 delta 与运行态分类摘要。


### PR DESCRIPTION
## Summary

- add opt-in, exact-device Terminal Backend trace context with safe sampling and event-loop lag context
- segment Browser/Device namespace, local Socket.IO enqueue, Redis publish, and target-Pod consume/enqueue latency without changing Terminal payloads or ACK behavior
- pin python-socketio 5.15.1, cover private manager contracts and two-Backend real-Redis relays, and document rollout/query/rollback steps in Chinese and English
- install redis-server in Backend CI so the isolated integration tests cannot silently skip

## Verification

- `uv lock --check`
- `uv run black --check app/`
- `uv run isort --check-only --diff app/`
- focused diagnostics, namespace, lifecycle, and real-Redis integration suites: 148 passed
- full Backend suite: 7,383 passed, 1 skipped, 3 existing macOS-only failures
  - all three failures are in `tests/docker/test_device_executor_home_contract.py` because macOS `/bin/bash` 3.2 cannot evaluate the existing `${value,,}` expression in `docker/device/Dockerfile`; neither file is changed by this PR
  - GitHub Test Backend runs on Ubuntu and covers the complete suite with Redis explicitly installed

## Safety boundaries

- diagnostics are disabled when the exact device allowlist is empty
- logs exclude Terminal content, credentials, full session IDs, Socket.IO SIDs, paths, and Redis authentication data
- diagnostic failures fail open and preserve the original Socket.IO return, exception, cancellation, and callback behavior