### PR TITLE
fix(wework): paginate Codex transcript items

### DIFF
--- a/executor/src/runtime_work/codex_transcript_page.rs
+++ b/executor/src/runtime_work/codex_transcript_page.rs
@@ -5,7 +5,8 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use futures_util::{stream, TryStreamExt};
+use futures_util::{stream, StreamExt, TryStreamExt};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::agents::CodexAppServerClient;
@@ -14,7 +15,9 @@ use super::util::string_field;
 
 const CODEX_ITEM_PAGE_SIZE: usize = 100;
 const CODEX_ITEM_LOAD_CONCURRENCY: usize = 5;
+const CODEX_INITIAL_ITEM_TURN_LIMIT: usize = 5;
 const CODEX_FULL_TRANSCRIPT_MAX_TURNS: usize = 500;
+const CODEX_INCREMENTAL_CURSOR_PREFIX: &str = "wework-codex-items:";
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub(crate) enum CodexTranscriptDirection {
@@ -44,6 +47,22 @@ pub(crate) struct CodexTranscriptPage {
     pub thread: Value,
     pub before_cursor: Option<String>,
     pub after_cursor: Option<String>,
+    pub prepend_item_turn_ids: HashSet<String>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexIncrementalCursor {
+    turn_cursor: Option<String>,
+    pending_turns: Vec<CodexTurnItemCursor>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexTurnItemCursor {
+    turn: Value,
+    cursor: Option<String>,
+    started: bool,
 }
 
 pub(crate) async fn load_codex_transcript(
@@ -69,9 +88,31 @@ pub(crate) async fn load_codex_transcript(
         }
     }
     let paginated_history = thread_uses_paginated_history(&thread);
-    let mut cursor = request.cursor.map(ToOwned::to_owned);
+    let incremental_cursor = if paginated_history
+        && !request.full_content
+        && request.direction == CodexTranscriptDirection::Descending
+    {
+        request
+            .cursor
+            .map(parse_incremental_cursor)
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    if let Some(cursor) = incremental_cursor
+        .as_ref()
+        .filter(|cursor| !cursor.pending_turns.is_empty())
+    {
+        return load_incremental_item_page(client, thread, request.thread_id, cursor).await;
+    }
+    let mut cursor = incremental_cursor
+        .as_ref()
+        .and_then(|cursor| cursor.turn_cursor.clone())
+        .or_else(|| request.cursor.map(ToOwned::to_owned));
     let mut turns = Vec::new();
     let mut backwards_cursor = None;
+    let mut pending_turns = Vec::new();
     let mut seen_cursors = HashSet::new();
     if let Some(cursor) = cursor.as_ref() {
         seen_cursors.insert(cursor.clone());
@@ -85,6 +126,7 @@ pub(crate) async fn load_codex_transcript(
             request.limit,
             request.direction,
             paginated_history,
+            request.full_content,
         )
         .await?;
         if backwards_cursor.is_none() {
@@ -95,8 +137,14 @@ pub(crate) async fn load_codex_transcript(
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
-        if paginated_history {
+        if paginated_history && request.full_content {
             page_turns = load_full_turn_items(client, request.thread_id, page_turns).await?;
+        } else if paginated_history {
+            let hydrated =
+                load_initial_turn_items(client, request.thread_id, page_turns, request.direction)
+                    .await?;
+            page_turns = hydrated.turns;
+            pending_turns.extend(hydrated.pending_turns);
         }
         turns.extend(page_turns);
 
@@ -122,10 +170,16 @@ pub(crate) async fn load_codex_transcript(
                 } else {
                     (backwards_cursor, next_cursor)
                 };
+            let before_cursor = if request.full_content {
+                before_cursor
+            } else {
+                incremental_before_cursor(before_cursor, pending_turns)?
+            };
             return Ok(CodexTranscriptPage {
                 thread,
                 before_cursor,
                 after_cursor,
+                prepend_item_turn_ids: HashSet::new(),
             });
         }
         let next_cursor = next_cursor.expect("checked above");
@@ -172,6 +226,7 @@ async fn load_rollout_transcript_page(
             thread,
             before_cursor: None,
             after_cursor: None,
+            prepend_item_turn_ids: HashSet::new(),
         }));
     }
 
@@ -200,6 +255,7 @@ async fn load_rollout_transcript_page(
         thread,
         before_cursor,
         after_cursor,
+        prepend_item_turn_ids: HashSet::new(),
     }))
 }
 
@@ -303,6 +359,7 @@ async fn load_turn_page(
     limit: usize,
     direction: CodexTranscriptDirection,
     paginated_history: bool,
+    full_content: bool,
 ) -> Result<Value, String> {
     client
         .request(
@@ -312,7 +369,7 @@ async fn load_turn_page(
                 "cursor": cursor,
                 "limit": limit,
                 "sortDirection": direction.as_str(),
-                "itemsView": turn_items_view(paginated_history),
+                "itemsView": turn_items_view(paginated_history, full_content),
             }),
         )
         .await
@@ -322,12 +379,244 @@ fn thread_uses_paginated_history(thread: &Value) -> bool {
     string_field(thread, "historyMode").as_deref() == Some("paginated")
 }
 
-fn turn_items_view(paginated_history: bool) -> &'static str {
-    if paginated_history {
+fn turn_items_view(paginated_history: bool, full_content: bool) -> &'static str {
+    if paginated_history && full_content {
         "notLoaded"
+    } else if paginated_history {
+        "summary"
     } else {
         "full"
     }
+}
+
+struct InitialTurnItems {
+    turns: Vec<Value>,
+    pending_turns: Vec<CodexTurnItemCursor>,
+}
+
+async fn load_initial_turn_items(
+    client: &CodexAppServerClient,
+    thread_id: &str,
+    turns: Vec<Value>,
+    direction: CodexTranscriptDirection,
+) -> Result<InitialTurnItems, String> {
+    let hydrated = stream::iter(turns.into_iter().enumerate().map(|(index, turn)| {
+        let client = client.clone();
+        async move {
+            let metadata = turn_metadata(&turn);
+            if index >= CODEX_INITIAL_ITEM_TURN_LIMIT {
+                return Ok::<_, String>((
+                    turn,
+                    Some(CodexTurnItemCursor {
+                        turn: metadata,
+                        cursor: None,
+                        started: false,
+                    }),
+                ));
+            }
+            let turn_id = string_field(&turn, "id")
+                .ok_or_else(|| "thread/turns/list returned a turn without id".to_owned())?;
+            let page = load_turn_item_page(&client, thread_id, &turn_id, None).await?;
+            let next_cursor = string_field(&page, "nextCursor");
+            let items = turn_items_from_page(&page, &turn_id)?;
+            let mut turn = turn;
+            turn["items"] = Value::Array(merge_summary_and_recent_items(&turn, items));
+            turn["itemsView"] = Value::String(
+                if next_cursor.is_some() {
+                    "summary"
+                } else {
+                    "full"
+                }
+                .to_owned(),
+            );
+            let pending = next_cursor.map(|cursor| CodexTurnItemCursor {
+                turn: metadata,
+                cursor: Some(cursor),
+                started: true,
+            });
+            Ok((turn, pending))
+        }
+    }))
+    .buffered(CODEX_ITEM_LOAD_CONCURRENCY)
+    .try_collect::<Vec<_>>()
+    .await?;
+    let mut page_turns = Vec::with_capacity(hydrated.len());
+    let mut pending_turns = Vec::new();
+    for (turn, pending) in hydrated {
+        page_turns.push(turn);
+        if let Some(pending) = pending {
+            pending_turns.push(pending);
+        }
+    }
+    if direction == CodexTranscriptDirection::Descending {
+        pending_turns.reverse();
+    }
+    Ok(InitialTurnItems {
+        turns: page_turns,
+        pending_turns,
+    })
+}
+
+async fn load_incremental_item_page(
+    client: &CodexAppServerClient,
+    mut thread: Value,
+    thread_id: &str,
+    cursor: &CodexIncrementalCursor,
+) -> Result<CodexTranscriptPage, String> {
+    let mut pending_turns = cursor.pending_turns.clone();
+    let mut pending = pending_turns.remove(0);
+    let turn_id = string_field(&pending.turn, "id")
+        .ok_or_else(|| "Codex item cursor contains a turn without id".to_owned())?;
+    let page = load_turn_item_page(client, thread_id, &turn_id, pending.cursor.as_deref()).await?;
+    let next_cursor = string_field(&page, "nextCursor");
+    if pending.started && next_cursor == pending.cursor {
+        return Err(format!(
+            "thread/items/list returned an unchanged cursor for turn {turn_id}"
+        ));
+    }
+    let items = turn_items_from_page(&page, &turn_id)?;
+    let mut turn = pending.turn.clone();
+    turn["items"] = Value::Array(items);
+    turn["itemsView"] = Value::String(
+        if next_cursor.is_some() {
+            "summary"
+        } else {
+            "full"
+        }
+        .to_owned(),
+    );
+    if let Some(next_cursor) = next_cursor {
+        pending.cursor = Some(next_cursor);
+        pending.started = true;
+        pending_turns.insert(0, pending);
+    }
+    thread["turns"] = Value::Array(vec![turn]);
+    let before_cursor = incremental_before_cursor(cursor.turn_cursor.clone(), pending_turns)?;
+    Ok(CodexTranscriptPage {
+        thread,
+        before_cursor,
+        after_cursor: None,
+        prepend_item_turn_ids: HashSet::from([turn_id]),
+    })
+}
+
+fn turn_metadata(turn: &Value) -> Value {
+    let mut metadata = turn.clone();
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert("items".to_owned(), Value::Array(Vec::new()));
+        object.insert(
+            "itemsView".to_owned(),
+            Value::String("notLoaded".to_owned()),
+        );
+    }
+    metadata
+}
+
+fn merge_summary_and_recent_items(turn: &Value, recent_items: Vec<Value>) -> Vec<Value> {
+    let summary_items = turn
+        .get("items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let recent_ids = recent_items
+        .iter()
+        .filter_map(|item| string_field(item, "id"))
+        .collect::<HashSet<_>>();
+    let mut merged = summary_items
+        .iter()
+        .filter(|item| item_is_user_message(item))
+        .filter(|item| {
+            string_field(item, "id").map_or(true, |item_id| !recent_ids.contains(&item_id))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    merged.extend(recent_items);
+    let merged_ids = merged
+        .iter()
+        .filter_map(|item| string_field(item, "id"))
+        .collect::<HashSet<_>>();
+    merged.extend(
+        summary_items
+            .into_iter()
+            .filter(|item| !item_is_user_message(item))
+            .filter(|item| {
+                string_field(item, "id").map_or(true, |item_id| !merged_ids.contains(&item_id))
+            }),
+    );
+    merged
+}
+
+fn item_is_user_message(item: &Value) -> bool {
+    string_field(item, "type")
+        .is_some_and(|item_type| item_type.eq_ignore_ascii_case("userMessage"))
+}
+
+async fn load_turn_item_page(
+    client: &CodexAppServerClient,
+    thread_id: &str,
+    turn_id: &str,
+    cursor: Option<&str>,
+) -> Result<Value, String> {
+    client
+        .request(
+            "thread/items/list",
+            json!({
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "cursor": cursor,
+                "limit": CODEX_ITEM_PAGE_SIZE,
+                "sortDirection": "desc",
+            }),
+        )
+        .await
+}
+
+fn turn_items_from_page(page: &Value, turn_id: &str) -> Result<Vec<Value>, String> {
+    let mut items = Vec::new();
+    for entry in page
+        .get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if string_field(entry, "turnId").as_deref() != Some(turn_id) {
+            return Err(format!(
+                "thread/items/list returned an item for a different turn than {turn_id}"
+            ));
+        }
+        let item = entry
+            .get("item")
+            .cloned()
+            .ok_or_else(|| "thread/items/list returned an entry without item".to_owned())?;
+        items.push(item);
+    }
+    items.reverse();
+    Ok(items)
+}
+
+fn incremental_before_cursor(
+    turn_cursor: Option<String>,
+    pending_turns: Vec<CodexTurnItemCursor>,
+) -> Result<Option<String>, String> {
+    if pending_turns.is_empty() {
+        return Ok(turn_cursor);
+    }
+    let state = CodexIncrementalCursor {
+        turn_cursor,
+        pending_turns,
+    };
+    serde_json::to_string(&state)
+        .map(|encoded| Some(format!("{CODEX_INCREMENTAL_CURSOR_PREFIX}{encoded}")))
+        .map_err(|error| format!("failed to encode Codex transcript cursor: {error}"))
+}
+
+fn parse_incremental_cursor(cursor: &str) -> Result<Option<CodexIncrementalCursor>, String> {
+    let Some(encoded) = cursor.strip_prefix(CODEX_INCREMENTAL_CURSOR_PREFIX) else {
+        return Ok(None);
+    };
+    serde_json::from_str(encoded)
+        .map(Some)
+        .map_err(|error| format!("invalid Codex transcript item cursor: {error}"))
 }
 
 async fn load_full_turn_items(
@@ -427,9 +716,11 @@ mod tests {
     }
 
     #[test]
-    fn requests_items_only_for_paginated_thread_history() {
-        assert_eq!(turn_items_view(true), "notLoaded");
-        assert_eq!(turn_items_view(false), "full");
+    fn requests_summary_items_for_incremental_paginated_history() {
+        assert_eq!(turn_items_view(true, false), "summary");
+        assert_eq!(turn_items_view(true, true), "notLoaded");
+        assert_eq!(turn_items_view(false, false), "full");
+        assert_eq!(turn_items_view(false, true), "full");
     }
 
     #[test]

--- a/executor/src/runtime_work/codex_transcript_page.rs
+++ b/executor/src/runtime_work/codex_transcript_page.rs
@@ -15,7 +15,7 @@ use super::util::string_field;
 
 const CODEX_ITEM_PAGE_SIZE: usize = 100;
 const CODEX_ITEM_LOAD_CONCURRENCY: usize = 5;
-const CODEX_INITIAL_ITEM_BUDGET_PAGES: usize = 5;
+const CODEX_INITIAL_ITEM_BUDGET_TURN_CAP: usize = 5;
 const CODEX_FULL_TRANSCRIPT_MAX_TURNS: usize = 500;
 const CODEX_INCREMENTAL_CURSOR_PREFIX: &str = "wework-codex-items:";
 
@@ -397,7 +397,7 @@ async fn load_initial_turn_items(
     turn_limit: usize,
 ) -> Result<InitialTurnItems, String> {
     let mut remaining_items = turn_limit
-        .min(CODEX_INITIAL_ITEM_BUDGET_PAGES)
+        .min(CODEX_INITIAL_ITEM_BUDGET_TURN_CAP)
         .saturating_mul(CODEX_ITEM_PAGE_SIZE);
     let mut page_turns = Vec::with_capacity(turns.len());
     let mut pending_turns = Vec::new();

--- a/executor/src/runtime_work/codex_transcript_page.rs
+++ b/executor/src/runtime_work/codex_transcript_page.rs
@@ -5,7 +5,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use futures_util::{stream, StreamExt, TryStreamExt};
+use futures_util::{stream, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -15,7 +15,7 @@ use super::util::string_field;
 
 const CODEX_ITEM_PAGE_SIZE: usize = 100;
 const CODEX_ITEM_LOAD_CONCURRENCY: usize = 5;
-const CODEX_INITIAL_ITEM_TURN_LIMIT: usize = 5;
+const CODEX_INITIAL_ITEM_BUDGET_PAGES: usize = 5;
 const CODEX_FULL_TRANSCRIPT_MAX_TURNS: usize = 500;
 const CODEX_INCREMENTAL_CURSOR_PREFIX: &str = "wework-codex-items:";
 
@@ -126,7 +126,6 @@ pub(crate) async fn load_codex_transcript(
             request.limit,
             request.direction,
             paginated_history,
-            request.full_content,
         )
         .await?;
         if backwards_cursor.is_none() {
@@ -141,7 +140,7 @@ pub(crate) async fn load_codex_transcript(
             page_turns = load_full_turn_items(client, request.thread_id, page_turns).await?;
         } else if paginated_history {
             let hydrated =
-                load_initial_turn_items(client, request.thread_id, page_turns, request.direction)
+                load_initial_turn_items(client, request.thread_id, page_turns, request.limit)
                     .await?;
             page_turns = hydrated.turns;
             pending_turns.extend(hydrated.pending_turns);
@@ -359,7 +358,6 @@ async fn load_turn_page(
     limit: usize,
     direction: CodexTranscriptDirection,
     paginated_history: bool,
-    full_content: bool,
 ) -> Result<Value, String> {
     client
         .request(
@@ -369,7 +367,7 @@ async fn load_turn_page(
                 "cursor": cursor,
                 "limit": limit,
                 "sortDirection": direction.as_str(),
-                "itemsView": turn_items_view(paginated_history, full_content),
+                "itemsView": turn_items_view(paginated_history),
             }),
         )
         .await
@@ -379,11 +377,9 @@ fn thread_uses_paginated_history(thread: &Value) -> bool {
     string_field(thread, "historyMode").as_deref() == Some("paginated")
 }
 
-fn turn_items_view(paginated_history: bool, full_content: bool) -> &'static str {
-    if paginated_history && full_content {
+fn turn_items_view(paginated_history: bool) -> &'static str {
+    if paginated_history {
         "notLoaded"
-    } else if paginated_history {
-        "summary"
     } else {
         "full"
     }
@@ -398,58 +394,77 @@ async fn load_initial_turn_items(
     client: &CodexAppServerClient,
     thread_id: &str,
     turns: Vec<Value>,
-    direction: CodexTranscriptDirection,
+    turn_limit: usize,
 ) -> Result<InitialTurnItems, String> {
-    let hydrated = stream::iter(turns.into_iter().enumerate().map(|(index, turn)| {
-        let client = client.clone();
-        async move {
-            let metadata = turn_metadata(&turn);
-            if index >= CODEX_INITIAL_ITEM_TURN_LIMIT {
-                return Ok::<_, String>((
-                    turn,
-                    Some(CodexTurnItemCursor {
-                        turn: metadata,
-                        cursor: None,
-                        started: false,
-                    }),
+    let mut remaining_items = turn_limit
+        .min(CODEX_INITIAL_ITEM_BUDGET_PAGES)
+        .saturating_mul(CODEX_ITEM_PAGE_SIZE);
+    let mut page_turns = Vec::with_capacity(turns.len());
+    let mut pending_turns = Vec::new();
+    for turn in turns {
+        let metadata = turn_metadata(&turn);
+        let turn_id = string_field(&turn, "id")
+            .ok_or_else(|| "thread/turns/list returned a turn without id".to_owned())?;
+        let mut items = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut started = false;
+        let mut seen_cursors = HashSet::new();
+        let mut seen_item_ids = HashSet::new();
+        while (!started || cursor.is_some()) && remaining_items > 0 {
+            if let Some(cursor) = cursor.as_ref() {
+                if !seen_cursors.insert(cursor.clone()) {
+                    return Err(format!(
+                        "thread/items/list returned a repeated cursor for turn {turn_id}"
+                    ));
+                }
+            }
+            started = true;
+            let page = load_turn_item_page(
+                client,
+                thread_id,
+                &turn_id,
+                cursor.as_deref(),
+                remaining_items.min(CODEX_ITEM_PAGE_SIZE),
+            )
+            .await?;
+            let page_items = turn_items_from_page(&page, &turn_id)?
+                .into_iter()
+                .filter(|item| {
+                    string_field(item, "id")
+                        .map(|item_id| seen_item_ids.insert(item_id))
+                        .unwrap_or(true)
+                })
+                .collect::<Vec<_>>();
+            remaining_items = remaining_items.saturating_sub(page_items.len());
+            items.splice(0..0, page_items);
+            let next_cursor = string_field(&page, "nextCursor");
+            if next_cursor.is_some() && next_cursor == cursor {
+                return Err(format!(
+                    "thread/items/list returned an unchanged cursor for turn {turn_id}"
                 ));
             }
-            let turn_id = string_field(&turn, "id")
-                .ok_or_else(|| "thread/turns/list returned a turn without id".to_owned())?;
-            let page = load_turn_item_page(&client, thread_id, &turn_id, None).await?;
-            let next_cursor = string_field(&page, "nextCursor");
-            let items = turn_items_from_page(&page, &turn_id)?;
-            let mut turn = turn;
-            turn["items"] = Value::Array(merge_summary_and_recent_items(&turn, items));
-            turn["itemsView"] = Value::String(
-                if next_cursor.is_some() {
-                    "summary"
-                } else {
-                    "full"
-                }
-                .to_owned(),
-            );
-            let pending = next_cursor.map(|cursor| CodexTurnItemCursor {
-                turn: metadata,
-                cursor: Some(cursor),
-                started: true,
-            });
-            Ok((turn, pending))
+            cursor = next_cursor;
         }
-    }))
-    .buffered(CODEX_ITEM_LOAD_CONCURRENCY)
-    .try_collect::<Vec<_>>()
-    .await?;
-    let mut page_turns = Vec::with_capacity(hydrated.len());
-    let mut pending_turns = Vec::new();
-    for (turn, pending) in hydrated {
+
+        let mut turn = turn;
+        turn["items"] = Value::Array(items);
+        turn["itemsView"] = Value::String(
+            if started && cursor.is_none() {
+                "full"
+            } else {
+                "summary"
+            }
+            .to_owned(),
+        );
+        let pending = (!started || cursor.is_some()).then_some(CodexTurnItemCursor {
+            turn: metadata,
+            cursor,
+            started,
+        });
         page_turns.push(turn);
         if let Some(pending) = pending {
             pending_turns.push(pending);
         }
-    }
-    if direction == CodexTranscriptDirection::Descending {
-        pending_turns.reverse();
     }
     Ok(InitialTurnItems {
         turns: page_turns,
@@ -467,7 +482,14 @@ async fn load_incremental_item_page(
     let mut pending = pending_turns.remove(0);
     let turn_id = string_field(&pending.turn, "id")
         .ok_or_else(|| "Codex item cursor contains a turn without id".to_owned())?;
-    let page = load_turn_item_page(client, thread_id, &turn_id, pending.cursor.as_deref()).await?;
+    let page = load_turn_item_page(
+        client,
+        thread_id,
+        &turn_id,
+        pending.cursor.as_deref(),
+        CODEX_ITEM_PAGE_SIZE,
+    )
+    .await?;
     let next_cursor = string_field(&page, "nextCursor");
     if pending.started && next_cursor == pending.cursor {
         return Err(format!(
@@ -512,50 +534,12 @@ fn turn_metadata(turn: &Value) -> Value {
     metadata
 }
 
-fn merge_summary_and_recent_items(turn: &Value, recent_items: Vec<Value>) -> Vec<Value> {
-    let summary_items = turn
-        .get("items")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    let recent_ids = recent_items
-        .iter()
-        .filter_map(|item| string_field(item, "id"))
-        .collect::<HashSet<_>>();
-    let mut merged = summary_items
-        .iter()
-        .filter(|item| item_is_user_message(item))
-        .filter(|item| {
-            string_field(item, "id").map_or(true, |item_id| !recent_ids.contains(&item_id))
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    merged.extend(recent_items);
-    let merged_ids = merged
-        .iter()
-        .filter_map(|item| string_field(item, "id"))
-        .collect::<HashSet<_>>();
-    merged.extend(
-        summary_items
-            .into_iter()
-            .filter(|item| !item_is_user_message(item))
-            .filter(|item| {
-                string_field(item, "id").map_or(true, |item_id| !merged_ids.contains(&item_id))
-            }),
-    );
-    merged
-}
-
-fn item_is_user_message(item: &Value) -> bool {
-    string_field(item, "type")
-        .is_some_and(|item_type| item_type.eq_ignore_ascii_case("userMessage"))
-}
-
 async fn load_turn_item_page(
     client: &CodexAppServerClient,
     thread_id: &str,
     turn_id: &str,
     cursor: Option<&str>,
+    limit: usize,
 ) -> Result<Value, String> {
     client
         .request(
@@ -564,7 +548,7 @@ async fn load_turn_item_page(
                 "threadId": thread_id,
                 "turnId": turn_id,
                 "cursor": cursor,
-                "limit": CODEX_ITEM_PAGE_SIZE,
+                "limit": limit,
                 "sortDirection": "desc",
             }),
         )
@@ -716,11 +700,9 @@ mod tests {
     }
 
     #[test]
-    fn requests_summary_items_for_incremental_paginated_history() {
-        assert_eq!(turn_items_view(true, false), "summary");
-        assert_eq!(turn_items_view(true, true), "notLoaded");
-        assert_eq!(turn_items_view(false, false), "full");
-        assert_eq!(turn_items_view(false, true), "full");
+    fn requests_unloaded_items_for_paginated_history() {
+        assert_eq!(turn_items_view(true), "notLoaded");
+        assert_eq!(turn_items_view(false), "full");
     }
 
     #[test]

--- a/executor/src/runtime_work/handler/queries.rs
+++ b/executor/src/runtime_work/handler/queries.rs
@@ -367,6 +367,7 @@ impl RuntimeWorkRpcHandler {
             mut thread,
             before_cursor: page_before_cursor,
             after_cursor: page_after_cursor,
+            prepend_item_turn_ids,
         } = load_codex_transcript(
             &self.codex_app_server,
             CodexTranscriptRequest {
@@ -489,7 +490,7 @@ impl RuntimeWorkRpcHandler {
             running,
         });
 
-        Ok(transcript_response(TranscriptResponseInput {
+        let mut response = transcript_response(TranscriptResponseInput {
             local_task_id,
             workspace_path,
             runtime: "codex".to_owned(),
@@ -510,6 +511,27 @@ impl RuntimeWorkRpcHandler {
             },
             full_content: include_full_content,
             turn_item_source: TranscriptTurnItemSource::CodexItems,
-        }))
+        });
+        mark_prepend_item_turns(&mut response, &prepend_item_turn_ids);
+        Ok(response)
+    }
+}
+
+fn mark_prepend_item_turns(response: &mut Value, turn_ids: &HashSet<String>) {
+    if turn_ids.is_empty() {
+        return;
+    }
+    for turn in response
+        .get_mut("turns")
+        .and_then(Value::as_array_mut)
+        .into_iter()
+        .flatten()
+    {
+        let Some(turn_id) = string_field(turn, "id") else {
+            continue;
+        };
+        if turn_ids.contains(&turn_id) {
+            turn["itemMerge"] = Value::String("prepend".to_owned());
+        }
     }
 }

--- a/executor/tests/app_runtime_work_contract.rs
+++ b/executor/tests/app_runtime_work_contract.rs
@@ -401,7 +401,7 @@ async fn app_runtime_pages_codex_thread_transcript_from_provider() {
     assert_eq!(turns_list_count, 3);
     assert_eq!(items_list_count, 3);
     assert!(calls.iter().all(|call| {
-        call["method"] != "thread/turns/list" || call["params"]["itemsView"] == "notLoaded"
+        call["method"] != "thread/turns/list" || call["params"]["itemsView"] == "summary"
     }));
     assert!(calls.iter().any(|call| {
         call["method"] == "thread/turns/list"
@@ -412,6 +412,90 @@ async fn app_runtime_pages_codex_thread_transcript_from_provider() {
         call["method"] == "thread/turns/list"
             && call["params"]["cursor"].is_null()
             && call["params"]["limit"] == 40
+            && call["params"]["sortDirection"] == "desc"
+    }));
+}
+
+#[tokio::test]
+async fn app_runtime_pages_codex_turn_items_before_older_turns() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("wegent-app-runtime-item-page-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let _codex_home = set_temp_codex_home("wegent-app-runtime-item-page-codex-home");
+    let log_path = temp_path("wegent-app-runtime-item-page-log", "jsonl");
+    let fake_codex = write_fake_incremental_items_codex(&log_path);
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let latest = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "taskId": "thread-1",
+                "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-1"},
+                "limit": 1
+            }
+        }))
+        .await
+        .expect("latest transcript page should succeed");
+    let item_cursor = latest["beforeCursor"]
+        .as_str()
+        .expect("partial turn should return an item cursor");
+    assert!(item_cursor.starts_with("wework-codex-items:"));
+    assert_eq!(latest["messages"][0]["content"], "new prompt");
+    assert_eq!(
+        latest["turns"][0]["items"]
+            .as_array()
+            .expect("latest turn items")
+            .len(),
+        3
+    );
+
+    let older_items = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "taskId": "thread-1",
+                "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-1"},
+                "limit": 1,
+                "beforeCursor": item_cursor
+            }
+        }))
+        .await
+        .expect("older item page should succeed");
+
+    assert_eq!(older_items["beforeCursor"], "older-turns");
+    assert_eq!(older_items["turns"][0]["itemMerge"], "prepend");
+    assert_eq!(older_items["turns"][0]["items"][0]["type"], "user_message");
+    assert_eq!(older_items["turns"][0]["items"][1]["type"], "block");
+    assert_eq!(
+        older_items["turns"][0]["items"][1]["block"]["tool_input"]["command"],
+        "older-tool"
+    );
+
+    let calls = read_json_lines(&log_path);
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call["method"] == "thread/turns/list")
+            .count(),
+        1
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call["method"] == "thread/items/list")
+            .count(),
+        2
+    );
+    assert!(calls.iter().any(|call| {
+        call["method"] == "thread/items/list"
+            && call["params"]["cursor"] == "older-items"
             && call["params"]["sortDirection"] == "desc"
     }));
 }
@@ -961,6 +1045,9 @@ while IFS= read -r line; do
     *'"method":"thread/turns/list"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"id":"turn-1","createdAt":1780000000,"itemsView":"notLoaded","items":[]}}],"nextCursor":null,"backwardsCursor":null}}}}'
       ;;
+    *'"method":"thread/items/list"'*'"sortDirection":"desc"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-1","item":{{"id":"agent-1","type":"agentMessage","text":"done","phase":"final_answer"}}}},{{"turnId":"turn-1","item":{{"id":"cmd-1","type":"commandExecution","command":"cargo test","cwd":"/tmp/project","status":"completed","aggregatedOutput":"test result: ok\n","exitCode":0}}}},{{"turnId":"turn-1","item":{{"id":"reason-1","type":"reasoning","summary":["inspect failure"]}}}},{{"turnId":"turn-1","item":{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"please fix ci"}},{{"type":"localImage","path":"/tmp/codex-clipboard/screenshot.png"}}]}}}}],"nextCursor":null,"backwardsCursor":null}}}}'
+      ;;
     *'"method":"thread/items/list"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-1","item":{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"please fix ci"}},{{"type":"localImage","path":"/tmp/codex-clipboard/screenshot.png"}}]}}}},{{"turnId":"turn-1","item":{{"id":"reason-1","type":"reasoning","summary":["inspect failure"]}}}},{{"turnId":"turn-1","item":{{"id":"cmd-1","type":"commandExecution","command":"cargo test","cwd":"/tmp/project","status":"completed","aggregatedOutput":"test result: ok\n","exitCode":0}}}},{{"turnId":"turn-1","item":{{"id":"agent-1","type":"agentMessage","text":"done","phase":"final_answer"}}}}],"nextCursor":null,"backwardsCursor":null}}}}'
       ;;
@@ -1119,11 +1206,59 @@ while IFS= read -r line; do
     *'"method":"thread/turns/list"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"id":"turn-new","startedAt":1780000100,"completedAt":1780000101,"status":"completed","itemsView":"notLoaded","items":[]}}],"nextCursor":"older-turns","backwardsCursor":null}}}}'
       ;;
+    *'"method":"thread/items/list"'*'"sortDirection":"desc"'*'"turnId":"turn-old"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-old","item":{{"id":"agent-old","type":"agentMessage","text":"old answer","phase":"final_answer"}}}},{{"turnId":"turn-old","item":{{"id":"user-old","type":"userMessage","content":[{{"type":"text","text":"old prompt"}}]}}}}],"nextCursor":null,"backwardsCursor":"old-items-head"}}}}'
+      ;;
     *'"method":"thread/items/list"'*'"turnId":"turn-old"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-old","item":{{"id":"user-old","type":"userMessage","content":[{{"type":"text","text":"old prompt"}}]}}}},{{"turnId":"turn-old","item":{{"id":"agent-old","type":"agentMessage","text":"old answer","phase":"final_answer"}}}}],"nextCursor":null,"backwardsCursor":"old-items-head"}}}}'
       ;;
+    *'"method":"thread/items/list"'*'"sortDirection":"desc"'*'"turnId":"turn-new"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-new","item":{{"id":"agent-new","type":"agentMessage","text":"new answer","phase":"final_answer"}}}},{{"turnId":"turn-new","item":{{"id":"user-new","type":"userMessage","content":[{{"type":"text","text":"new prompt"}}]}}}}],"nextCursor":null,"backwardsCursor":"new-items-head"}}}}'
+      ;;
     *'"method":"thread/items/list"'*'"turnId":"turn-new"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-new","item":{{"id":"user-new","type":"userMessage","content":[{{"type":"text","text":"new prompt"}}]}}}},{{"turnId":"turn-new","item":{{"id":"agent-new","type":"agentMessage","text":"new answer","phase":"final_answer"}}}}],"nextCursor":null,"backwardsCursor":"new-items-head"}}}}'
+      ;;
+  esac
+done
+"#,
+        log_path.display()
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
+fn write_fake_incremental_items_codex(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-app-runtime-item-pagination", "sh");
+    let _ = fs::remove_file(log_path);
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  request_id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/read"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","path":"/tmp/codex/thread-1.jsonl","historyMode":"paginated","turns":[]}}}}}}'
+      ;;
+    *'"method":"thread/turns/list"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"id":"turn-new","startedAt":1780000100,"completedAt":1780000101,"status":"completed","itemsView":"summary","items":[{{"id":"user-new","type":"userMessage","content":[{{"type":"text","text":"new prompt"}}]}},{{"id":"agent-new","type":"agentMessage","text":"new answer","phase":"final_answer"}}]}}],"nextCursor":"older-turns","backwardsCursor":null}}}}'
+      ;;
+    *'"method":"thread/items/list"'*'"cursor":"older-items"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-new","item":{{"id":"tool-old","type":"commandExecution","command":"older-tool","status":"completed","aggregatedOutput":"old"}}}},{{"turnId":"turn-new","item":{{"id":"user-new","type":"userMessage","content":[{{"type":"text","text":"new prompt"}}]}}}}],"nextCursor":null,"backwardsCursor":"newer-items"}}}}'
+      ;;
+    *'"method":"thread/items/list"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-new","item":{{"id":"agent-new","type":"agentMessage","text":"new answer","phase":"final_answer"}}}},{{"turnId":"turn-new","item":{{"id":"tool-new","type":"commandExecution","command":"newer-tool","status":"completed","aggregatedOutput":"new"}}}}],"nextCursor":"older-items","backwardsCursor":null}}}}'
       ;;
   esac
 done

--- a/executor/tests/app_runtime_work_contract.rs
+++ b/executor/tests/app_runtime_work_contract.rs
@@ -401,7 +401,7 @@ async fn app_runtime_pages_codex_thread_transcript_from_provider() {
     assert_eq!(turns_list_count, 3);
     assert_eq!(items_list_count, 3);
     assert!(calls.iter().all(|call| {
-        call["method"] != "thread/turns/list" || call["params"]["itemsView"] == "summary"
+        call["method"] != "thread/turns/list" || call["params"]["itemsView"] == "notLoaded"
     }));
     assert!(calls.iter().any(|call| {
         call["method"] == "thread/turns/list"
@@ -446,13 +446,13 @@ async fn app_runtime_pages_codex_turn_items_before_older_turns() {
         .as_str()
         .expect("partial turn should return an item cursor");
     assert!(item_cursor.starts_with("wework-codex-items:"));
-    assert_eq!(latest["messages"][0]["content"], "new prompt");
+    assert_eq!(latest["messages"][0]["content"], "new answer");
     assert_eq!(
         latest["turns"][0]["items"]
             .as_array()
             .expect("latest turn items")
             .len(),
-        3
+        100
     );
 
     let older_items = handler
@@ -1236,6 +1236,28 @@ done
 fn write_fake_incremental_items_codex(log_path: &Path) -> PathBuf {
     let path = temp_path("fake-codex-app-runtime-item-pagination", "sh");
     let _ = fs::remove_file(log_path);
+    let mut recent_entries = vec![json!({
+        "turnId": "turn-new",
+        "item": {
+            "id": "agent-new",
+            "type": "agentMessage",
+            "text": "new answer",
+            "phase": "final_answer",
+        },
+    })];
+    recent_entries.extend((0..99).map(|index| {
+        json!({
+            "turnId": "turn-new",
+            "item": {
+                "id": format!("tool-new-{index}"),
+                "type": "commandExecution",
+                "command": format!("newer-tool-{index}"),
+                "status": "completed",
+                "aggregatedOutput": "new",
+            },
+        })
+    }));
+    let recent_entries = serde_json::to_string(&recent_entries).unwrap();
     let content = format!(
         r#"#!/bin/sh
 LOG_PATH='{}'
@@ -1252,18 +1274,19 @@ while IFS= read -r line; do
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","path":"/tmp/codex/thread-1.jsonl","historyMode":"paginated","turns":[]}}}}}}'
       ;;
     *'"method":"thread/turns/list"'*)
-      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"id":"turn-new","startedAt":1780000100,"completedAt":1780000101,"status":"completed","itemsView":"summary","items":[{{"id":"user-new","type":"userMessage","content":[{{"type":"text","text":"new prompt"}}]}},{{"id":"agent-new","type":"agentMessage","text":"new answer","phase":"final_answer"}}]}}],"nextCursor":"older-turns","backwardsCursor":null}}}}'
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"id":"turn-new","startedAt":1780000100,"completedAt":1780000101,"status":"completed","itemsView":"notLoaded","items":[]}}],"nextCursor":"older-turns","backwardsCursor":null}}}}'
       ;;
     *'"method":"thread/items/list"'*'"cursor":"older-items"'*)
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-new","item":{{"id":"tool-old","type":"commandExecution","command":"older-tool","status":"completed","aggregatedOutput":"old"}}}},{{"turnId":"turn-new","item":{{"id":"user-new","type":"userMessage","content":[{{"type":"text","text":"new prompt"}}]}}}}],"nextCursor":null,"backwardsCursor":"newer-items"}}}}'
       ;;
     *'"method":"thread/items/list"'*)
-      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"turnId":"turn-new","item":{{"id":"agent-new","type":"agentMessage","text":"new answer","phase":"final_answer"}}}},{{"turnId":"turn-new","item":{{"id":"tool-new","type":"commandExecution","command":"newer-tool","status":"completed","aggregatedOutput":"new"}}}}],"nextCursor":"older-items","backwardsCursor":null}}}}'
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":{recent_entries},"nextCursor":"older-items","backwardsCursor":null}}}}'
       ;;
   esac
 done
 "#,
-        log_path.display()
+        log_path.display(),
+        recent_entries = recent_entries,
     );
     fs::write(&path, content).unwrap();
     #[cfg(unix)]

--- a/executor/tests/app_runtime_work_file_changes_contract.rs
+++ b/executor/tests/app_runtime_work_file_changes_contract.rs
@@ -973,16 +973,28 @@ fn fake_item_response_case(turn: &mut Value) -> String {
         .iter()
         .map(|item| json!({"turnId": turn_id, "item": item}))
         .collect::<Vec<_>>();
-    let response = json!({
+    let ascending_response = json!({
         "id": "__REQUEST_ID__",
         "result": {"data": data, "nextCursor": null},
     });
+    let descending_response = json!({
+        "id": "__REQUEST_ID__",
+        "result": {
+            "data": data.into_iter().rev().collect::<Vec<_>>(),
+            "nextCursor": null,
+        },
+    });
     format!(
-        r#"        *'"turnId":"{}"'*)
+        r#"        *'"sortDirection":"desc"'*'"turnId":"{}"'*)
+          printf '%s\n' {} | sed 's/"__REQUEST_ID__"/'"$request_id"'/'
+          ;;
+        *'"turnId":"{}"'*)
           printf '%s\n' {} | sed 's/"__REQUEST_ID__"/'"$request_id"'/'
           ;;"#,
         turn_id,
-        shell_single_quote(&response.to_string()),
+        shell_single_quote(&descending_response.to_string()),
+        turn_id,
+        shell_single_quote(&ascending_response.to_string()),
     )
 }
 

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -615,6 +615,12 @@ describe('runtimeConversationTurns', () => {
               createdAt: 100,
             },
           },
+          {
+            id: 'assistant-older-same-text',
+            type: 'assistant_text',
+            content: 'Done',
+            createdAt: '2026-08-25T07:20:36.000Z',
+          },
         ],
         status: 'done',
       },
@@ -625,6 +631,7 @@ describe('runtimeConversationTurns', () => {
     expect(merged[0]?.items.map(item => item.id)).toEqual([
       'user-1',
       'tool-older',
+      'assistant-older-same-text',
       'tool-newer',
       'assistant-1',
     ])

--- a/wework/src/features/workbench/runtimeConversationTurns.test.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.test.ts
@@ -561,6 +561,76 @@ describe('runtimeConversationTurns', () => {
     ])
   })
 
+  test('prepends an older provider item page after the leading user message', () => {
+    const local: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        items: [
+          {
+            id: 'user-1',
+            type: 'user_message',
+            message: userMessage('user-1', 'Prompt'),
+          },
+          {
+            id: 'tool-newer',
+            type: 'block',
+            block: {
+              id: 'tool-newer',
+              subtaskId: 'turn-1',
+              type: 'tool',
+              toolName: 'exec_command',
+              status: 'done',
+              createdAt: 200,
+            },
+          },
+          {
+            id: 'assistant-1',
+            type: 'assistant_text',
+            content: 'Done',
+            createdAt: '2026-08-25T07:20:37.000Z',
+          },
+        ],
+        status: 'done',
+      },
+    ]
+    const olderPage: RuntimeConversationTurn[] = [
+      {
+        id: 'turn-1',
+        itemMerge: 'prepend',
+        items: [
+          {
+            id: 'user-1',
+            type: 'user_message',
+            message: userMessage('user-1', 'Prompt'),
+          },
+          {
+            id: 'tool-older',
+            type: 'block',
+            block: {
+              id: 'tool-older',
+              subtaskId: 'turn-1',
+              type: 'tool',
+              toolName: 'exec_command',
+              status: 'done',
+              createdAt: 100,
+            },
+          },
+        ],
+        status: 'done',
+      },
+    ]
+
+    const merged = mergeRuntimeConversationTurns(local, olderPage)
+
+    expect(merged[0]?.items.map(item => item.id)).toEqual([
+      'user-1',
+      'tool-older',
+      'tool-newer',
+      'assistant-1',
+    ])
+    expect(merged[0]?.itemMerge).toBeUndefined()
+  })
+
   test('does not synthesize a Codex turn from a terminal event', () => {
     const turns = reduceRuntimeConversationTurns(
       [

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -329,7 +329,10 @@ function mergeRuntimeConversationTurn(
 ): RuntimeConversationTurn {
   const preserveLocalTerminal =
     isTerminalTurnStatus(local.status) && isUnsettledTurnStatus(snapshot.status)
-  const items = mergeRuntimeConversationItems(local.items, snapshot.items, preserveLocalTerminal)
+  const items =
+    snapshot.itemMerge === 'prepend'
+      ? prependRuntimeConversationItems(local.items, snapshot.items, preserveLocalTerminal)
+      : mergeRuntimeConversationItems(local.items, snapshot.items, preserveLocalTerminal)
   const preserveLocalFailure = local.status === 'failed' && Boolean(local.error) && !snapshot.error
   const preserveStreamingThinking =
     snapshot.status === 'streaming' &&
@@ -339,6 +342,7 @@ function mergeRuntimeConversationTurn(
     ...snapshot,
     clientUserMessageId: snapshot.clientUserMessageId ?? local.clientUserMessageId,
     runtimeMessageIndex: earliestRuntimeMessageIndex(local, snapshot),
+    itemMerge: undefined,
     items,
     status: preserveLocalTerminal || preserveLocalFailure ? local.status : snapshot.status,
     completedAt:
@@ -352,6 +356,33 @@ function mergeRuntimeConversationTurn(
         ? getLatestThinkingContent(processingBlocks(items))
         : snapshot.streamingThinkingContent,
   }
+}
+
+function prependRuntimeConversationItems(
+  localItems: RuntimeConversationItem[],
+  snapshotItems: RuntimeConversationItem[],
+  preserveLocalTerminal: boolean
+): RuntimeConversationItem[] {
+  const matchedLocalIndexes = new Set<number>()
+  const mergedSnapshotItems = snapshotItems.map(snapshotItem => {
+    const localIndex = localItems.findIndex(
+      (localItem, index) =>
+        !matchedLocalIndexes.has(index) &&
+        (localItem.id === snapshotItem.id ||
+          isEquivalentAssistantTextRepresentation(localItem, snapshotItem))
+    )
+    if (localIndex < 0) return snapshotItem
+    matchedLocalIndexes.add(localIndex)
+    return mergeRuntimeConversationItem(localItems[localIndex], snapshotItem, preserveLocalTerminal)
+  })
+  const remainingLocalItems = localItems.filter((_, index) => !matchedLocalIndexes.has(index))
+  const leadingUserCount = remainingLocalItems.findIndex(item => item.type !== 'user_message')
+  const insertionIndex = leadingUserCount < 0 ? remainingLocalItems.length : leadingUserCount
+  return [
+    ...remainingLocalItems.slice(0, insertionIndex),
+    ...mergedSnapshotItems,
+    ...remainingLocalItems.slice(insertionIndex),
+  ]
 }
 
 function isTerminalTurnStatus(status: RuntimeConversationTurn['status']): boolean {

--- a/wework/src/features/workbench/runtimeConversationTurns.ts
+++ b/wework/src/features/workbench/runtimeConversationTurns.ts
@@ -366,10 +366,7 @@ function prependRuntimeConversationItems(
   const matchedLocalIndexes = new Set<number>()
   const mergedSnapshotItems = snapshotItems.map(snapshotItem => {
     const localIndex = localItems.findIndex(
-      (localItem, index) =>
-        !matchedLocalIndexes.has(index) &&
-        (localItem.id === snapshotItem.id ||
-          isEquivalentAssistantTextRepresentation(localItem, snapshotItem))
+      (localItem, index) => !matchedLocalIndexes.has(index) && localItem.id === snapshotItem.id
     )
     if (localIndex < 0) return snapshotItem
     matchedLocalIndexes.add(localIndex)

--- a/wework/src/features/workbench/runtimePaneMessages.test.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.test.ts
@@ -131,6 +131,19 @@ describe('runtime transcript status', () => {
     expect(turn.runtimeMessageIndex).toBe(42)
   })
 
+  test('preserves the item prepend merge mode for an older item page', () => {
+    const [turn] = runtimeTranscriptTurnsToConversationTurns([
+      {
+        id: 'turn-1',
+        itemMerge: 'prepend',
+        items: [],
+        status: 'done',
+      },
+    ])
+
+    expect(turn.itemMerge).toBe('prepend')
+  })
+
   test('keeps valid canonical items when a transcript turn contains a malformed item', () => {
     const [turn] = runtimeTranscriptTurnsToConversationTurns([
       {

--- a/wework/src/features/workbench/runtimePaneMessages.ts
+++ b/wework/src/features/workbench/runtimePaneMessages.ts
@@ -672,6 +672,7 @@ export function runtimeTranscriptTurnsToConversationTurns(
         id: turn.id,
         clientUserMessageId: items.find(item => item.type === 'user_message')?.message.id,
         runtimeMessageIndex: typeof turn.messageIndex === 'number' ? turn.messageIndex : undefined,
+        itemMerge: turn.itemMerge,
         items,
         status,
         completedAt: turn.completedAt,

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -646,6 +646,7 @@ export interface RuntimeTranscriptResponse {
 export interface RuntimeTranscriptTurn {
   id: string
   items: RuntimeTranscriptTurnItem[]
+  itemMerge?: 'prepend'
   messageIndex?: number | null
   status?: string
   runtimeStatus?: string | null

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -157,6 +157,7 @@ export interface RuntimeConversationTurn {
   id: string | null
   clientUserMessageId?: string
   runtimeMessageIndex?: number
+  itemMerge?: 'prepend'
   items: RuntimeConversationItem[]
   status: RuntimeWorkbenchMessageStatus
   completedAt?: string | number | null


### PR DESCRIPTION
## Summary

- page paginated Codex transcript items through `thread/items/list` instead of exhausting every turn before rendering
- mirror ChatGPT/Codex’s bounded tail hydration: `itemsView: notLoaded` plus a shared `min(turnLimit, 5) * 100` item budget
- carry unfinished per-turn item cursors through the existing transcript cursor, then prepend older items before requesting older turns
- keep the existing “load older messages” interaction; no new “load full output” control

## Verification

- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_contract` (17 passed)
- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_file_changes_contract` (7 passed)
- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_send_contract` (44 passed)
- `cargo clippy --manifest-path executor/Cargo.toml --lib --tests -- -D warnings`
- focused Wework transcript tests (132 passed after rebasing latest `main`)
- Wework ESLint/Prettier, `cargo fmt --check`, and `git diff --check`
- isolated real Electron startup with local Executor and Codex app-server connected
- real 276 MB Codex thread with Codex 0.153.3: 20 turns, 500 bounded items, 5 item requests, ~1.36 MB response data, 46 ms direct app-server hydration; the previous exhaustive Wework path timed out at 30 s
- full CI run after the behavioral fix: 65 checks passed, including the previously failing `Wework Desktop E2E (Cloud / shard 6)` window-lifecycle pagination flow

## Review follow-up

- prepend-page reconciliation uses exact item IDs, preserving equal-text assistant items with distinct IDs
- the item budget intentionally counts returned unique items, matching the current ChatGPT implementation; cursor repetition and unchanged cursors fail explicitly
